### PR TITLE
feat(truncation): add global MCP response tokens threshold

### DIFF
--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -42,6 +42,10 @@ custom_instructions_file_name = "INSTRUCTIONS.md"
 # Warn when MCP tool responses exceed this token count (0 = disable warnings)
 mcp_response_warning_threshold = 10000
 
+# Global token limit for ALL MCP tool responses (0 = unlimited)
+# When exceeded, responses are automatically truncated with notice
+mcp_response_tokens_threshold = 0
+
 # Maximum tokens per session before truncation kicks in (0 = disabled, >0 = enabled)
 max_session_tokens_threshold = 0
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -138,6 +138,7 @@ pub struct Config {
 
 	// System-wide configuration settings (not role-specific)
 	pub mcp_response_warning_threshold: usize,
+	pub mcp_response_tokens_threshold: usize,
 	pub max_session_tokens_threshold: usize,
 	pub cache_tokens_threshold: u64,
 	pub cache_timeout_seconds: u64,

--- a/src/mcp/agent/functions.rs
+++ b/src/mcp/agent/functions.rs
@@ -44,7 +44,20 @@ pub fn get_all_functions(config: &crate::config::Config) -> Vec<McpFunction> {
 	// Add call_llm function
 	functions.push(McpFunction {
 		name: "call_llm".to_string(),
-		description: "Make a direct LLM call with runtime parameters, bypassing agent configuration".to_string(),
+		description: "Make a direct LLM call with runtime parameters, bypassing agent configuration.
+
+		Parameters:
+		- `prompt`: The input/prompt to process
+		- `model`: Model in 'provider:model' format (e.g., 'openai:gpt-4o', 'openrouter:anthropic/claude-3.5-sonnet')
+		- `system`: System prompt for the LLM
+		- `temperature`: Temperature for randomness (0.0-2.0, default: 0.7)
+
+		Note: Response size is controlled by global mcp_response_tokens_threshold setting.
+		Use more specific prompts to reduce output size if responses are truncated.
+
+		Examples:
+		- Basic call: `{\"prompt\": \"Explain quantum computing\", \"model\": \"openai:gpt-4o\", \"system\": \"You are a helpful assistant\"}`
+		- With temperature: `{\"prompt\": \"Write a poem\", \"model\": \"openrouter:anthropic/claude-3.5-sonnet\", \"system\": \"You are a creative writer\", \"temperature\": 1.2}`".to_string(),
 		parameters: json!({
 			"type": "object",
 			"properties": {
@@ -66,11 +79,7 @@ pub fn get_all_functions(config: &crate::config::Config) -> Vec<McpFunction> {
 					"minimum": 0.0,
 					"maximum": 2.0
 				},
-				"max_tokens": {
-					"type": "integer",
-					"description": "Maximum output tokens (default: 4096)",
-					"minimum": 1
-				}
+
 			},
 			"required": ["prompt", "model", "system"]
 		}),

--- a/src/mcp/dev/ast_grep.rs
+++ b/src/mcp/dev/ast_grep.rs
@@ -81,8 +81,10 @@ Parameters:
 - `rewrite`: Optional rewrite pattern to apply for refactoring transformations
 - `json_output`: Optional boolean to get output in JSON format (default: false)
 - `context`: Optional number of lines of context to show around matches (default: 0)
-- `max_lines`: Maximum lines to return (default: 20, set to 0 for unlimited)
 - `update_all`: Optional boolean to apply rewrites to all matches without confirmation (default: false)
+
+Note: Response size is controlled by global mcp_response_tokens_threshold setting.
+Use more specific patterns to reduce output size if responses are truncated.
 
 Pattern Syntax:
 - Use metavariables like $NAME, $ARGS, $BODY for flexible matching
@@ -175,11 +177,6 @@ Usage Examples:
 					"type": "boolean",
 					"default": false,
 					"description": "Optional boolean to apply rewrites to all matches without confirmation (default: false)"
-				},
-				"max_lines": {
-					"type": "integer",
-					"default": 20,
-					"description": "Maximum lines to return (default: 20, set to 0 for unlimited)"
 				}
 			}
 		}),
@@ -258,12 +255,6 @@ pub async fn execute_ast_grep_command(call: &McpToolCall) -> Result<McpToolResul
 		.get("update_all")
 		.and_then(|v| v.as_bool())
 		.unwrap_or(false);
-
-	let max_lines = call
-		.parameters
-		.get("max_lines")
-		.and_then(|v| v.as_i64())
-		.unwrap_or(20) as usize;
 
 	// Build the ast-grep command using proper argument passing
 	let mut cmd = TokioCommand::new("sg");
@@ -401,18 +392,16 @@ pub async fn execute_ast_grep_command(call: &McpToolCall) -> Result<McpToolResul
 			// Group FIRST to preserve file-based organization
 			let grouped_output = group_ast_grep_output(&stdout);
 
-			// Then apply truncation to the grouped output
-			let output_lines: Vec<String> = grouped_output.lines().map(|s| s.to_string()).collect();
-			let (truncated_lines, truncation_info) =
-				crate::mcp::shared_utils::apply_head_truncation(&output_lines, max_lines);
+			// Global truncation will be applied by MCP response handler
+			let final_output = grouped_output;
 
 			// Format the final output
 			let combined = if stderr.is_empty() {
-				truncated_lines.join("\n")
-			} else if truncated_lines.is_empty() {
+				final_output
+			} else if final_output.is_empty() {
 				stderr
 			} else {
-				format!("{}\n\nError: {}", truncated_lines.join("\n"), stderr)
+				format!("{}\n\nError: {}", final_output, stderr)
 			};
 
 			// Add detailed execution results including status code
@@ -426,7 +415,7 @@ pub async fn execute_ast_grep_command(call: &McpToolCall) -> Result<McpToolResul
 				"search"
 			};
 
-			let mut result = json!({
+			let result = json!({
 				"success": success,
 				"output": combined,
 				"code": status_code,
@@ -438,8 +427,7 @@ pub async fn execute_ast_grep_command(call: &McpToolCall) -> Result<McpToolResul
 					"rewrite": rewrite,
 					"json_output": json_output,
 					"context": context,
-					"update_all": update_all,
-					"max_lines": max_lines
+					"update_all": update_all
 				},
 				"message": if success {
 					format!("AST-grep {operation_type} executed successfully with exit code {status_code}")
@@ -447,11 +435,6 @@ pub async fn execute_ast_grep_command(call: &McpToolCall) -> Result<McpToolResul
 					format!("AST-grep {operation_type} failed with exit code {status_code}")
 				}
 			});
-
-			// Add truncation info if present
-			if let Some(info) = truncation_info {
-				result["truncation_info"] = json!(info);
-			}
 
 			result
 		}
@@ -467,8 +450,7 @@ pub async fn execute_ast_grep_command(call: &McpToolCall) -> Result<McpToolResul
 				"rewrite": rewrite,
 				"json_output": json_output,
 				"context": context,
-				"update_all": update_all,
-				"max_lines": max_lines
+				"update_all": update_all
 			},
 			"message": format!("Failed to execute ast-grep command: {}", e)
 		}),

--- a/src/mcp/dev/dev_tests.rs
+++ b/src/mcp/dev/dev_tests.rs
@@ -465,8 +465,8 @@ fn private_func() {
 	}
 
 	#[tokio::test]
-	async fn test_ast_grep_truncation() {
-		// Test that ast_grep supports smart truncation like list_files
+	async fn test_ast_grep_basic_functionality() {
+		// Test that ast_grep works correctly without tool-level truncation
 		// Create a temporary Rust file with many functions
 		let temp_content = r#"
 fn function1() { println!("1"); }
@@ -486,15 +486,14 @@ fn function14() { println!("14"); }
 fn function15() { println!("15"); }
 "#;
 
-		let temp_file = "test_ast_grep_truncation.rs";
+		let temp_file = "test_ast_grep_basic.rs";
 		std::fs::write(temp_file, temp_content).unwrap();
 
-		// Test with max_lines = 5 (should truncate)
+		// Test basic ast_grep functionality (no max_lines parameter)
 		let params = json!({
 			"pattern": "fn $NAME() { $$$ }",
 			"language": "rust",
-			"paths": [temp_file],
-			"max_lines": 5
+			"paths": [temp_file]
 		});
 
 		let call = McpToolCall {
@@ -513,40 +512,46 @@ fn function15() { println!("15"); }
 		let result = result.unwrap();
 		let output = result.result.as_object().unwrap();
 
-		// Check that parameters include max_lines
+		// Check basic result structure (no max_lines parameter)
 		let params = &output["parameters"];
-		assert_eq!(params["max_lines"], 5);
+		assert!(params.get("max_lines").is_none()); // max_lines should not be present
+		assert_eq!(params["pattern"], "fn $NAME() { $$$ }");
+		assert_eq!(params["language"], "rust");
 
-		// If ast-grep finds matches and we have more than 5 lines, should have truncation info
+		// Should have successful execution
+		assert_eq!(output["success"], true);
+		assert_eq!(output["operation"], "search");
+
+		// Should have output with function matches
 		let output_text = output["output"].as_str().unwrap_or("");
-		println!("ast_grep truncation test output:\n{}", output_text);
+		println!("ast_grep basic test output:\n{}", output_text);
 
-		// Test with max_lines = 0 (unlimited)
-		let params_unlimited = json!({
+		// Test with context parameter
+		let params_with_context = json!({
 			"pattern": "fn $NAME() { $$$ }",
 			"language": "rust",
 			"paths": [temp_file],
-			"max_lines": 0
+			"context": 1
 		});
-
-		let call_unlimited = McpToolCall {
-			tool_name: "ast_grep".to_string(),
-			parameters: params_unlimited,
-			tool_id: "test-call-id".to_string(),
-		};
 
 		// Recreate the file for the second test
 		std::fs::write(temp_file, temp_content).unwrap();
-		let result_unlimited = execute_ast_grep_command(&call_unlimited).await;
+
+		let call_with_context = McpToolCall {
+			tool_name: "ast_grep".to_string(),
+			parameters: params_with_context,
+			tool_id: "test-call-id".to_string(),
+		};
+
+		let result_with_context = execute_ast_grep_command(&call_with_context).await;
 		let _ = std::fs::remove_file(temp_file);
 
-		assert!(result_unlimited.is_ok());
-		let result_unlimited = result_unlimited.unwrap();
-		let output_unlimited = result_unlimited.result.as_object().unwrap();
+		assert!(result_with_context.is_ok());
+		let result_with_context = result_with_context.unwrap();
+		let output_with_context = result_with_context.result.as_object().unwrap();
 
-		// Should not have truncation with max_lines = 0
-		assert!(!output_unlimited.contains_key("truncation_info"));
-		assert_eq!(output_unlimited["parameters"]["max_lines"], 0);
+		// Should have context parameter
+		assert_eq!(output_with_context["parameters"]["context"], 1);
 	}
 
 	#[tokio::test]

--- a/src/mcp/dev/shell.rs
+++ b/src/mcp/dev/shell.rs
@@ -15,7 +15,6 @@
 // Shell execution functionality for the Developer MCP provider
 
 use super::super::{McpFunction, McpToolCall, McpToolResult};
-use crate::utils::truncation::truncate_content_smart;
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 use std::fs::OpenOptions;
@@ -78,11 +77,6 @@ fn add_to_shell_history(command: &str) -> Result<()> {
 	Ok(())
 }
 
-// Truncate shell output if it exceeds token limit
-fn truncate_shell_output(output: &str, max_tokens: usize) -> String {
-	truncate_content_smart(output, max_tokens)
-}
-
 // Define the shell function for the MCP protocol with enhanced description
 pub fn get_shell_function() -> McpFunction {
 	McpFunction {
@@ -96,7 +90,6 @@ of if the command succeeded or failed.
 Parameters:
 - `command`: The shell command to execute (required)
 - `background`: Run command in background and return PID instead of waiting for completion (default: false)
-- `max_tokens`: Maximum tokens allowed in output before truncation (default: 2000)
 
 **Working Directory:**
 All commands execute from the current working directory.
@@ -104,9 +97,9 @@ NO `cd` command is required when you working with current project files.
 REMEMBER that each command you run has NO knowledge of previous runs, other context, or variables that were set BEFORE in another command.
 
 **Output Truncation:**
-To prevent huge outputs from consuming excessive tokens, output is automatically truncated
-if it exceeds max_tokens. Avoid commands that produce large outputs (like `cat large_file`
-or `find /` without filters). When large output is needed, increase max_tokens parameter.
+Output size is controlled by global mcp_response_tokens_threshold setting.
+Avoid commands that produce large outputs (like `cat large_file` or `find /` without filters).
+Use more specific commands to reduce output size if responses are truncated.
 
 **Background Execution:**
 When `background` is true, the command runs in the background and returns immediately with the process PID.
@@ -126,7 +119,6 @@ may show ignored or hidden files. For example *do not* use `find` or `ls -r`
 Examples:
 - Foreground: `{\"command\": \"ls -la\"}`
 - Background: `{\"command\": \"python -m http.server 8000\", \"background\": true}`
-- Large output: `{\"command\": \"cat large_file.txt\", \"max_tokens\": 5000}`
 - Kill background: `{\"command\": \"kill 12345\"}` (where 12345 is the returned PID)
 ".to_string(),
 		parameters: json!({
@@ -140,12 +132,6 @@ Examples:
 					"type": "boolean",
 					"default": false,
 					"description": "Run command in background and return PID instead of waiting for completion (no need to append '&')"
-				},
-				"max_tokens": {
-					"type": "integer",
-					"default": 2000,
-					"minimum": 100,
-					"description": "Maximum tokens allowed in output before truncation (default: 2000)"
 				}
 			},
 			"required": ["command"]
@@ -191,14 +177,6 @@ pub async fn execute_shell_command(call: &McpToolCall) -> Result<McpToolResult> 
 		.get("background")
 		.and_then(|v| v.as_bool())
 		.unwrap_or(false);
-
-	// Extract max_tokens parameter
-	let max_tokens = call
-		.parameters
-		.get("max_tokens")
-		.and_then(|v| v.as_u64())
-		.map(|n| n as usize)
-		.unwrap_or(2000);
 
 	// Add command to shell history before execution
 	let _ = add_to_shell_history(&command);
@@ -275,8 +253,8 @@ pub async fn execute_shell_command(call: &McpToolCall) -> Result<McpToolResult> 
 				format!("{stdout}\n\nError: {stderr}")
 			};
 
-			// Apply token-based truncation to prevent huge outputs
-			let truncated_output = truncate_shell_output(&combined, max_tokens);
+			// Apply global truncation (handled by global MCP response truncation)
+			let final_output = combined;
 
 			// Add detailed execution results including status code
 			let status_code = output.status.code().unwrap_or(-1);
@@ -288,7 +266,7 @@ pub async fn execute_shell_command(call: &McpToolCall) -> Result<McpToolResult> 
 				Ok(McpToolResult::success(
 					"shell".to_string(),
 					call.tool_id.clone(),
-					truncated_output,
+					final_output,
 				))
 			} else {
 				// Command failed - use error format per MCP protocol
@@ -296,7 +274,7 @@ pub async fn execute_shell_command(call: &McpToolCall) -> Result<McpToolResult> 
 					"shell".to_string(),
 					call.tool_id.clone(),
 					format!(
-						"Command failed with exit code {status_code}\nCommand: {command}\n\nOutput:\n{truncated_output}"
+						"Command failed with exit code {status_code}\nCommand: {command}\n\nOutput:\n{final_output}"
 					),
 				))
 			}

--- a/src/mcp/fs/directory.rs
+++ b/src/mcp/fs/directory.rs
@@ -275,12 +275,6 @@ pub async fn execute_list_files(call: &McpToolCall) -> Result<McpToolResult> {
 		.and_then(|v| v.as_bool())
 		.unwrap_or(false);
 
-	let max_lines = call
-		.parameters
-		.get("max_lines")
-		.and_then(|v| v.as_i64())
-		.unwrap_or(20) as usize;
-
 	let line_numbers = call
 		.parameters
 		.get("line_numbers")
@@ -359,25 +353,22 @@ pub async fn execute_list_files(call: &McpToolCall) -> Result<McpToolResult> {
 					// Group FIRST to preserve match + context relationships
 					let grouped_output = group_ripgrep_output(&lines);
 
-					// Then apply truncation to the grouped output
-					let output_lines: Vec<String> =
-						grouped_output.lines().map(|s| s.to_string()).collect();
-					let (truncated_lines, truncation_info) =
-						crate::mcp::shared_utils::apply_head_truncation(&output_lines, max_lines);
+					// Global truncation will be applied by MCP response handler
+					let final_output = grouped_output;
 
 					let output_str = if stdout.is_empty() && !stderr.is_empty() {
 						stderr
 					} else {
-						truncated_lines.join("\n")
+						final_output
 					};
 
 					// For content search, we return the formatted output with matches
-					let mut result = json!({
+					let result = json!({
 							"success": output.status.success(),
 							"output": output_str,
-							"lines": truncated_lines,
+							"lines": lines,
 							"total_lines": lines.len(),
-							"displayed_lines": truncated_lines.len(),
+							"displayed_lines": lines.len(),
 							"type": output_type,
 							"parameters": {
 							"directory": directory,
@@ -385,16 +376,11 @@ pub async fn execute_list_files(call: &McpToolCall) -> Result<McpToolResult> {
 							"content": content,
 							"max_depth": max_depth,
 							"include_hidden": include_hidden,
-							"max_lines": max_lines,
+
 							"line_numbers": line_numbers,
 							"context": context_lines
 						}
 					});
-
-					// Add truncation info if present
-					if let Some(info) = truncation_info {
-						result["truncation_info"] = json!(info);
-					}
 
 					result
 				} else {
@@ -408,23 +394,22 @@ pub async fn execute_list_files(call: &McpToolCall) -> Result<McpToolResult> {
 							files.retain(|file| regex.is_match(file));
 						}
 					}
-
-					// Apply head truncation for consistent behavior
-					let (truncated_files, truncation_info) =
-						crate::mcp::shared_utils::apply_head_truncation(&files, max_lines);
+					// Global truncation will be applied by MCP response handler
+					let files_count = files.len();
+					let final_files = files;
 
 					let output_str = if stdout.is_empty() && !stderr.is_empty() {
 						stderr
 					} else {
-						truncated_files.join("\n")
+						final_files.join("\n")
 					};
 
-					let mut result = json!({
+					let result = json!({
 							"success": output.status.success(),
 							"output": output_str,
-							"files": truncated_files,
-							"count": files.len(),
-							"displayed_count": truncated_files.len(),
+							"files": final_files,
+							"count": files_count,
+							"displayed_count": final_files.len(),
 							"type": output_type,
 							"parameters": {
 							"directory": directory,
@@ -432,16 +417,11 @@ pub async fn execute_list_files(call: &McpToolCall) -> Result<McpToolResult> {
 							"content": content,
 							"max_depth": max_depth,
 							"include_hidden": include_hidden,
-							"max_lines": max_lines,
+
 							"line_numbers": line_numbers,
 							"context": context_lines
 						}
 					});
-
-					// Add truncation info if present
-					if let Some(info) = truncation_info {
-						result["truncation_info"] = json!(info);
-					}
 
 					result
 				}
@@ -458,7 +438,6 @@ pub async fn execute_list_files(call: &McpToolCall) -> Result<McpToolResult> {
 					"content": content,
 					"max_depth": max_depth,
 					"include_hidden": include_hidden,
-					"max_lines": max_lines,
 					"line_numbers": line_numbers,
 					"context": context_lines
 				}

--- a/src/mcp/fs/fs_tests.rs
+++ b/src/mcp/fs/fs_tests.rs
@@ -689,7 +689,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_list_files_truncation() {
+	async fn test_list_files_basic_functionality() {
 		use crate::mcp::fs::directory::execute_list_files;
 		use std::fs;
 		use tempfile::TempDir;
@@ -704,7 +704,7 @@ mod tests {
 			fs::write(&file_path, format!("Content of file {}", i)).unwrap();
 		}
 
-		// Test with default max_lines (20) - should truncate
+		// Test basic file listing functionality
 		let call = McpToolCall {
 			tool_name: "list_files".to_string(),
 			parameters: json!({
@@ -717,55 +717,40 @@ mod tests {
 		let result = execute_list_files(&call).await.unwrap();
 		let output = result.result.as_object().unwrap();
 
-		// Should have truncation info
-		assert!(output.contains_key("truncation_info"));
+		// Should have basic file listing info (no tool-level truncation)
 		assert_eq!(output["count"], 30); // Total count
-		assert_eq!(output["displayed_count"], 20); // 19 files + 1 truncation marker (max_lines=20)
+		assert_eq!(output["displayed_count"], 30); // All files displayed (global truncation handles limits)
+		assert_eq!(output["success"], true);
+		assert_eq!(output["type"], "file listing");
 
-		// Test with max_lines = 0 (unlimited) - should not truncate
-		let call_unlimited = McpToolCall {
+		// Should have files array
+		assert!(output.contains_key("files"));
+		let files = output["files"].as_array().unwrap();
+		assert_eq!(files.len(), 30);
+
+		// Test with different pattern
+		let call_limited = McpToolCall {
 			tool_name: "list_files".to_string(),
 			parameters: json!({
 				"directory": temp_path.to_str().unwrap(),
-				"pattern": "*.txt",
-				"max_lines": 0
+				"pattern": "*_01.txt"
 			}),
 			tool_id: "test-call-id".to_string(),
 		};
 
-		let result_unlimited = execute_list_files(&call_unlimited).await.unwrap();
-		let output_unlimited = result_unlimited.result.as_object().unwrap();
+		let result_limited = execute_list_files(&call_limited).await.unwrap();
+		let output_limited = result_limited.result.as_object().unwrap();
 
-		// Should not have truncation info
-		assert!(!output_unlimited.contains_key("truncation_info"));
-		assert_eq!(output_unlimited["count"], 30);
-		assert_eq!(output_unlimited["displayed_count"], 30);
+		// Should find only one file matching the pattern
+		assert_eq!(output_limited["count"], 1);
+		assert_eq!(output_limited["displayed_count"], 1);
 
-		// Test with max_lines = 5 - should truncate more aggressively
-		let call_small = McpToolCall {
-			tool_name: "list_files".to_string(),
-			parameters: json!({
-				"directory": temp_path.to_str().unwrap(),
-				"pattern": "*.txt",
-				"max_lines": 5
-			}),
-			tool_id: "test-call-id".to_string(),
-		};
-
-		let result_small = execute_list_files(&call_small).await.unwrap();
-		let output_small = result_small.result.as_object().unwrap();
-
-		// Should have truncation info
-		assert!(output_small.contains_key("truncation_info"));
-		assert_eq!(output_small["count"], 30);
-		assert_eq!(output_small["displayed_count"], 5); // 4 files + 1 truncation marker (max_lines=5)
-
-		// Check that truncation marker is present in the files array
-		let files = output_small["files"].as_array().unwrap();
-		let has_truncation_marker = files
-			.iter()
-			.any(|f| f.as_str().unwrap_or("").contains("lines truncated"));
-		assert!(has_truncation_marker);
+		let files_limited = output_limited["files"].as_array().unwrap();
+		assert_eq!(files_limited.len(), 1);
+		assert!(files_limited[0]
+			.as_str()
+			.unwrap()
+			.contains("test_file_01.txt"));
 	}
 
 	#[tokio::test]

--- a/src/mcp/fs/functions.rs
+++ b/src/mcp/fs/functions.rs
@@ -34,9 +34,11 @@ pub fn get_list_files_function() -> McpFunction {
 			- `content`: Optional content search within files
 			- `max_depth`: Optional depth limit for directory traversal
 			- `include_hidden`: Include hidden files/directories starting with '.' (default: false)
-			- `max_lines`: Maximum lines to return (default: 20, set to 0 for unlimited)
 			- `line_numbers`: Show line numbers for content search (default: true)
 			- `context`: Number of context lines to show around matches (default: 0)
+
+			Note: Response size is controlled by global mcp_response_tokens_threshold setting.
+			Use specific patterns and filters to reduce output size if responses are truncated.
 
 			Best Practices:
 			- Always use specific patterns - avoid listing entire large directories
@@ -83,11 +85,6 @@ pub fn get_list_files_function() -> McpFunction {
 					"type": "boolean",
 					"default": false,
 					"description": "Include hidden files and directories starting with '.' (default: false)"
-				},
-				"max_lines": {
-					"type": "integer",
-					"default": 20,
-					"description": "Maximum lines to return (default: 20, set to 0 for unlimited)"
 				},
 				"line_numbers": {
 					"type": "boolean",

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -213,16 +213,27 @@ pub struct ToolResponseMessage {
 	pub content: String,
 }
 
-// Convert tool results to proper messages
-pub fn tool_results_to_messages(results: &[McpToolResult]) -> Vec<ToolResponseMessage> {
+// Convert tool results to proper messages with global truncation
+pub fn tool_results_to_messages(
+	results: &[McpToolResult],
+	config: &crate::config::Config,
+) -> Vec<ToolResponseMessage> {
 	let mut messages = Vec::new();
 
 	for result in results {
+		let content_str = serde_json::to_string(&result.result).unwrap_or_default();
+
+		// Apply global MCP response truncation
+		let final_content = crate::utils::truncation::truncate_mcp_response_global(
+			&content_str,
+			config.mcp_response_tokens_threshold,
+		);
+
 		messages.push(ToolResponseMessage {
 			role: "tool".to_string(),
 			tool_call_id: result.tool_id.clone(),
 			name: result.tool_name.clone(),
-			content: serde_json::to_string(&result.result).unwrap_or_default(),
+			content: final_content,
 		});
 	}
 

--- a/src/utils/truncation.rs
+++ b/src/utils/truncation.rs
@@ -252,3 +252,54 @@ pub fn truncate_tool_output_smart(content: &str, max_lines: usize, max_chars: us
 		format!("{}...", truncated)
 	}
 }
+
+/// Global MCP response truncation - simple and effective
+///
+/// Applies consistent truncation across ALL MCP tools when responses exceed threshold.
+/// Uses 0 = unlimited, otherwise applies smart truncation with MCP-specific notice.
+pub fn truncate_mcp_response_global(content: &str, max_tokens: usize) -> String {
+	if max_tokens == 0 {
+		return content.to_string();
+	}
+
+	let token_count = estimate_tokens(content);
+	if token_count <= max_tokens {
+		return content.to_string();
+	}
+
+	// Use existing smart truncation
+	let truncated = truncate_content_smart(content, max_tokens);
+
+	// Replace the truncation message with MCP-specific one
+	truncated.replace(
+		"[Content truncated -",
+		"⚠️ **MCP RESPONSE TRUNCATED** - Original:",
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_mcp_truncation_unlimited() {
+		let content = "This is a test content";
+		let result = truncate_mcp_response_global(content, 0);
+		assert_eq!(result, content);
+	}
+
+	#[test]
+	fn test_mcp_truncation_under_limit() {
+		let content = "Short content";
+		let result = truncate_mcp_response_global(content, 1000);
+		assert_eq!(result, content);
+	}
+
+	#[test]
+	fn test_mcp_truncation_over_limit() {
+		let content = "This is a very long content that should be truncated when it exceeds the token limit. ".repeat(100);
+		let result = truncate_mcp_response_global(&content, 50);
+		assert!(result.contains("⚠️ **MCP RESPONSE TRUNCATED**"));
+		assert!(result.len() < content.len());
+	}
+}


### PR DESCRIPTION
- Introduce mcp_response_tokens_threshold to limit output size globally
- Remove per-command and per-function max_tokens/max_lines parameters
- Update config and docs to reflect unified truncation policy
- Simplify shell tool and MCP commands by removing local truncation logic