### PR TITLE
feat(sandbox): restrict writes to cwd and safe temp paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e8937ef8c3fa38978b79354462bd10152014a1101d00ed6d26b120e9f4655"
+checksum = "9c56a59cf6315e99f874d2c1f96c69d2da5ffe0087d211297fc4a41f849770a2"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f833f2ec0d0ac6d68cbd0c1e2e02642876291048f45fb9772ff617ac5c34ef3"
+checksum = "e0497b9a95a404e35799904835c57c6f8c69b9d08ccfd3cb5b7d746425cd6789"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -475,13 +475,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
@@ -801,6 +800,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -1606,6 +1625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy-regex"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,6 +1971,7 @@ dependencies = [
  "image",
  "indicatif",
  "keyring",
+ "landlock",
  "lazy_static",
  "nu-ansi-term",
  "oauth2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ tracing = { version = "0.1", default-features = false }
 agent-client-protocol = "0.10.0"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4"
+
 [dev-dependencies]
 tempfile = "3.24.0"
 serial_test = "3.3.1"

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -15,8 +15,8 @@ CLI / WebSocket
       ├── Workflows   ← src/session/workflows/       (multi-step orchestrated task runners)
       │
       └── MCP servers ← src/mcp/
-            ├── dev/      shell, ast_grep, plan
-            ├── fs/       text_editor, list_files, batch_edit, extract_lines
+            ├── core/     plan, ask
+            ├── fs/       view, text_editor, batch_edit, extract_lines, shell, workdir, ast_grep
             └── agent/    agent_* tools → route tasks to configured layers
 ```
 

--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -39,6 +39,13 @@ custom_instructions_file_name = "INSTRUCTIONS.md"
 # Set to empty string to disable: custom_constraints_file_name = ""
 custom_constraints_file_name = "CONSTRAINTS.md"
 
+# Sandbox mode: restrict all filesystem writes to the current working directory
+# When enabled, the process and all child processes (shell, MCP servers) cannot
+# write outside the directory where octomind was launched.
+# Supported on Linux (Landlock, kernel 5.13+) and macOS (Seatbelt).
+# Can also be enabled at runtime with --sandbox CLI flag.
+sandbox = false
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # PERFORMANCE & LIMITS
 # Configure thresholds and performance-related settings

--- a/doc/02-overview.md
+++ b/doc/02-overview.md
@@ -39,8 +39,10 @@ graph TB
     F --> Q[Context Management<br/>Conversation compression]
     F --> R[Cost Tracking<br/>Real-time monitoring]
     F --> S[Caching System<br/>Automatic optimization]
+```
 
 ## Core Components
+
 
 ### 1. Session-First Design
 
@@ -68,14 +70,10 @@ graph TB
 - `workdir(path="...", reset=false)` - Get or set working directory for parallel execution isolation
 - `ast_grep(pattern="...", language="...", rewrite="...", ...)` - Search and refactor code using AST patterns
 
-**External Server Support**:
-- HTTP MCP servers with OAuth 2.1 + PKCE authentication
-- Command-based (stdin) MCP servers
-- Health monitoring and automatic recovery
-- Server registry for centralized configuration
+**Agent Server** (`src/mcp/agent/`):
+- `agent_*()` tools - Delegate tasks to configured ACP sub-agents (each spawns an ACP subprocess via the configured `command`)
 
 ### 3. Multi-Provider AI Support
-
 **Unified Interface** across 7 AI providers with consistent `provider:model` format:
 
 | Provider | Format | Key Features |
@@ -90,11 +88,11 @@ graph TB
 
 ### 4. Role-Based Configuration
 
-**Developer Role** (`config-templates/default.toml` lines 156-337):
+**Developer Role** (`config-templates/default.toml` lines 119-301):
 - Full access to all MCP tools
 - Optimized system prompts for development tasks
 - Layer processing enabled for complex workflows
-- Server references: developer, filesystem, web, agent
+- Server references: core, filesystem, octocode, agent
 
 **Assistant Role** (lines 340-355):
 - Chat-only mode with limited tool access

--- a/doc/03-configuration.md
+++ b/doc/03-configuration.md
@@ -129,7 +129,7 @@ system = """You are an Octomind – top notch fully autonomous AI developer...""
 
 # MCP configuration for developer role
 [developer.mcp]
-server_refs = ["developer", "filesystem", "web", "octocode"]
+server_refs = ["core", "filesystem", "octocode", "agent"]
 allowed_tools = []
 
 # Assistant role - optimized for general assistance
@@ -152,7 +152,14 @@ allowed_tools = []
 
 # Built-in MCP servers
 [[mcp.servers]]
-name = "developer"
+name = "core"
+type = "builtin"
+timeout_seconds = 30
+args = []
+tools = []
+
+[[mcp.servers]]
+name = "agent"
 type = "builtin"
 timeout_seconds = 30
 args = []
@@ -380,7 +387,7 @@ enabled = true
 
 [[mcp.servers]]
 enabled = true
-name = "developer"
+name = "core"
 type = "builtin"
 
 [[mcp.servers]]
@@ -429,7 +436,7 @@ enabled = true
 
 [[code-reviewer.mcp.servers]]
 enabled = true
-name = "developer"
+name = "core"
 type = "builtin"
 tools = ["text_editor", "shell"]  # Limited tool set
 ```
@@ -524,8 +531,7 @@ output_mode = "append"  # Adds research findings to session
 
 [layers.mcp]
 server_refs = ["filesystem", "octocode"]
-allowed_tools = ["list_files"]
-```
+allowed_tools = ["view"]
 
 ### Custom Layer Configuration
 
@@ -542,8 +548,7 @@ output_mode = "append"
 
 [layers.mcp]
 server_refs = ["filesystem"]
-allowed_tools = ["text_editor", "list_files"]
-
+allowed_tools = ["text_editor", "view"]
 [[layers]]
 name = "code_optimizer"
 description = "Optimizes code for performance and maintainability"
@@ -553,7 +558,7 @@ input_mode = "all"
 output_mode = "append"
 
 [layers.mcp]
-server_refs = ["developer", "filesystem"]
+server_refs = ["core", "filesystem"]
 allowed_tools = ["text_editor", "shell"]
 ```
 
@@ -621,7 +626,7 @@ allowed_tools = []
 
 # Built-in servers (always available)
 [[mcp.servers]]
-name = "developer"
+name = "core"
 type = "builtin"
 timeout_seconds = 30
 args = []
@@ -655,24 +660,23 @@ tools = []
 # Role configurations reference servers by name
 [developer.mcp]
 enabled = true
-server_refs = ["developer", "filesystem"]  # Reference servers by name
+server_refs = ["core", "filesystem"]  # Reference servers by name
 allowed_tools = []  # Empty means all tools from referenced servers
 
 # Role-specific override with limited servers
 [assistant.mcp]
 enabled = true
 server_refs = ["filesystem"]  # Only filesystem tools
-allowed_tools = ["text_editor", "list_files"]  # Limit to specific tools
-
+allowed_tools = ["text_editor", "view"]  # Limit to specific tools
 # Global MCP fallback
 [mcp]
 enabled = true
-server_refs = ["developer", "filesystem"]  # Default servers
+server_refs = ["core", "filesystem"]  # Default servers
 ```
 
 ### Server Types
 
-- **developer**: Built-in developer tools (shell, code search, file operations)
+- **core**: Built-in developer tools (shell, code search, file operations)
 - **filesystem**: Built-in filesystem tools (file reading, writing, listing)
 - **web**: Built-in web tools (web search, HTML conversion)
 - **external**: External MCP servers (HTTP or command-based)
@@ -695,7 +699,7 @@ enabled = true
 
 [[mcp.servers]]
 enabled = true
-name = "developer"
+name = "core"
 type = "builtin"
 
 [[mcp.servers]]
@@ -708,7 +712,7 @@ type = "builtin"
 ```toml
 # Define servers in main MCP section
 [[mcp.servers]]
-name = "developer"
+name = "core"
 type = "builtin"
 timeout_seconds = 30
 args = []
@@ -731,7 +735,7 @@ tools = []
 # Reference from roles
 [developer.mcp]
 enabled = true
-server_refs = ["developer", "filesystem", "web"]
+server_refs = ["core", "filesystem", "web"]
 ```
 
 **Migration benefits:**
@@ -1026,7 +1030,7 @@ temperature = 0.1
 input_mode = "all"  # Gets full conversation context
 
 [developer.commands.review.mcp]
-server_refs = ["developer", "filesystem"]  # Access to development tools
+server_refs = ["core", "filesystem"]  # Access to development tools
 allowed_tools = ["text_editor", "shell"]  # Limit to specific tools
 ```
 
@@ -1098,7 +1102,7 @@ enabled = true
 
 [[developer.mcp.servers]]
 enabled = true
-name = "developer"
+name = "core"
 type = "builtin"
 
 [developer.config]
@@ -1127,7 +1131,7 @@ Octomind automatically migrates legacy configurations on load, but it's recommen
 
 3. **Tool execution failures**
   ```
-  Tool execution failed: Unknown tool 'list_files'
+  Tool execution failed: Unknown tool 'view'
   Solution: Check MCP server configuration and tool routing
   ```
 

--- a/doc/05-sessions.md
+++ b/doc/05-sessions.md
@@ -69,7 +69,7 @@ system = "You are an Octomind AI developer assistant with full access to develop
 
 # MCP configuration using current server structure
 [developer.mcp]
-server_refs = ["developer", "filesystem", "octocode"]
+server_refs = ["core", "filesystem", "octocode"]
 allowed_tools = []  # Empty means all tools from referenced servers
 
 # Server definitions in main MCP section
@@ -77,7 +77,7 @@ allowed_tools = []  # Empty means all tools from referenced servers
 allowed_tools = []
 
 [[mcp.servers]]
-name = "developer"
+name = "core"
 type = "builtin"
 timeout_seconds = 30
 args = []
@@ -121,10 +121,11 @@ octomind session --role=assistant -n quick_chat
 [assistant.mcp]
 enabled = true  # Can enable tools if needed
 server_refs = ["filesystem"]  # Specific servers only
-allowed_tools = ["text_editor", "list_files"]  # Limited tools
+allowed_tools = ["text_editor", "view"]  # Limited tools
 ```
 
 ### Assistant Role Configuration
+
 
 ```toml
 [assistant]
@@ -160,10 +161,13 @@ system = "You are a code review expert focused on security and best practices."
 
 [code-reviewer.mcp]
 enabled = true
-server_refs = ["developer", "filesystem"]
-allowed_tools = ["text_editor", "list_files"]
+server_refs = ["core", "filesystem"]
+allowed_tools = ["text_editor", "view"]
+```
 
+```toml
 # Security analyst role
+
 [security-analyst]
 model = "openrouter:anthropic/claude-sonnet-4"
 enable_layers = true
@@ -171,10 +175,13 @@ system = "You are a security expert focused on finding vulnerabilities and secur
 
 [security-analyst.mcp]
 enabled = true
-server_refs = ["developer"]
+server_refs = ["core"]
 allowed_tools = ["shell"]  # Limited to analysis tools
+```
 
 # Documentation writer role
+
+```toml
 [documentation-writer]
 model = "openrouter:openai/gpt-4o"
 enable_layers = false
@@ -183,10 +190,11 @@ system = "You are a technical writer focused on creating clear, comprehensive do
 [documentation-writer.mcp]
 enabled = true
 server_refs = ["filesystem"]
-allowed_tools = ["text_editor", "list_files"]  # Only file operations
+allowed_tools = ["text_editor", "view"]  # Only file operations
 ```
 
 ### Role Inheritance
+
 
 Custom roles follow this inheritance pattern:
 1. **Start with assistant role** as the base configuration
@@ -720,10 +728,12 @@ output_mode = "replace"  # Replaces input with context
 builtin = true
 
 [layers.mcp]
-server_refs = ["developer", "filesystem", "web"]
-allowed_tools = ["list_files"]
+server_refs = ["core", "filesystem", "web"]
+allowed_tools = ["view"]
+```
 
 [[layers]]
+
 name = "reducer"
 model = "openrouter:openai/o4-mini"
 temperature = 0.2
@@ -747,11 +757,12 @@ output_mode = "append"  # Add analysis to session
 builtin = false
 
 [layers.mcp]
-server_refs = ["developer", "filesystem"]
-allowed_tools = ["text_editor", "list_files"]
+server_refs = ["core", "filesystem"]
+allowed_tools = ["text_editor", "view"]
 ```
 
 ### Input and Output Modes
+
 
 #### Input Modes
 Layers can process input in different modes:

--- a/doc/06-advanced.md
+++ b/doc/06-advanced.md
@@ -398,7 +398,7 @@ allowed_tools = []
 
 # Built-in server definitions
 [[mcp.servers]]
-name = "developer"
+name = "core"
 type = "builtin"
 timeout_seconds = 30
 args = []
@@ -444,17 +444,16 @@ Roles reference servers from the main MCP configuration and can limit tool acces
 ```toml
 # Developer role with full access
 [developer.mcp]
-server_refs = ["developer", "filesystem", "web"]
+server_refs = ["core", "filesystem", "web"]
 allowed_tools = []  # Empty means all tools from referenced servers
 
 # Assistant role with limited access
 [assistant.mcp]
 server_refs = ["filesystem"]
-allowed_tools = ["text_editor", "list_files"]  # Only specific tools
-
+allowed_tools = ["text_editor", "view"]  # Only specific tools
 # Custom role with external tools
 [code-reviewer.mcp]
-server_refs = ["developer", "external_tools"]
+server_refs = ["core", "external_tools"]
 allowed_tools = ["text_editor", "shell"]
 
 ### Server Types
@@ -573,9 +572,8 @@ output_mode = "replace"  # Replaces input with processed context
 builtin = true
 
 [layers.mcp]
-server_refs = ["developer", "filesystem", "octocode"]
-allowed_tools = ["list_files"]
-
+server_refs = ["core", "filesystem", "octocode"]
+allowed_tools = ["view"]
 [[layers]]
 name = "reducer"
 model = "openrouter:openai/o4-mini"
@@ -604,12 +602,12 @@ output_mode = "append"  # Add review results to session
 builtin = false
 
 [layers.mcp]
-server_refs = ["developer", "filesystem"]
-allowed_tools = ["text_editor", "list_files"]
+server_refs = ["core", "filesystem"]
+allowed_tools = ["text_editor", "view"]
 ```
-allowed_tools = ["core", "text_editor"]
-input_mode = "last"
 
+
+```toml
 [[layers]]
 name = "developer"
 enabled = true
@@ -1005,7 +1003,7 @@ enable_layers = true
 
 [security-reviewer.mcp]
 enabled = true
-server_refs = ["developer", "filesystem"]
+server_refs = ["core", "filesystem"]
 allowed_tools = ["text_editor", "shell"]  # Limited tools for security focus
 
 # Documentation role
@@ -1025,7 +1023,7 @@ model = "openrouter:anthropic/claude-sonnet-4"
 
 [web-dev.mcp]
 enabled = true
-server_refs = ["developer", "filesystem", "web_tools"]
+server_refs = ["core", "filesystem", "web_tools"]
 
 # Add web-specific MCP server
 [[mcp.servers]]
@@ -1234,14 +1232,14 @@ providers = ["core"]
 **Current format:**
 ```toml
 [[mcp.servers]]
-name = "developer"
+name = "core"
 type = "builtin"
 timeout_seconds = 30
 args = []
 tools = []
 
 [developer.mcp]
-server_refs = ["developer"]
+server_refs = ["core"]
 allowed_tools = []
 ```
 

--- a/doc/07-command-layers.md
+++ b/doc/07-command-layers.md
@@ -90,7 +90,7 @@ output_mode = "none"  # none, append, replace, last, restart
 system_prompt = "Layer-specific system prompt"
 
 [layers.layer_name.mcp]
-server_refs = ["filesystem", "developer"]
+server_refs = ["filesystem", "core"]
 allowed_tools = ["text_editor", "shell"]
 ```
 
@@ -152,7 +152,7 @@ Commands can have their own tool configurations using the new server registry sy
 
 ```toml
 [developer.commands.review.mcp]
-server_refs = ["developer", "filesystem"]  # Reference servers by name
+server_refs = ["core", "filesystem"]  # Reference servers by name
 allowed_tools = ["text_editor", "shell"]   # Limit to specific tools
 ```
 
@@ -200,11 +200,12 @@ temperature = 0.1
 input_mode = "all"  # Gets full conversation context
 
 [developer.commands.review.mcp]
-server_refs = ["developer", "filesystem"]  # Access to code files and shell
-allowed_tools = ["text_editor", "list_files", "shell"]
+server_refs = ["core", "filesystem"]  # Access to code files and shell
+allowed_tools = ["text_editor", "view", "shell"]
 ```
 
 Usage: `/run review`
+
 
 ### 3. Quick Summary
 
@@ -286,7 +287,7 @@ Command 'estimate' not found in configuration
 
 ### Tool Execution Errors
 ```
-Tool execution failed: Unknown tool 'list_files'. Available tools: text_editor, batch_edit, list_files, extract_lines
+Tool execution failed: Unknown tool 'view'. Available tools: text_editor, batch_edit, view, extract_lines
 ```
 - **Tool routing issue**: The tool is being sent to the wrong server
 - **Solution**: Check your MCP server configuration and ensure proper server references

--- a/doc/08-mcp-server-development.md
+++ b/doc/08-mcp-server-development.md
@@ -125,7 +125,7 @@ Add your server to the `from_name` method:
 ```rust
 pub fn from_name(name: &str) -> Self {
     let connection_type = match name {
-        "developer" => McpConnectionType::Builtin,
+        "core" => McpConnectionType::Builtin,
         "filesystem" => McpConnectionType::Builtin,
         "agent" => McpConnectionType::Builtin,
         "database" => McpConnectionType::Builtin,  // <- Add here
@@ -292,7 +292,6 @@ pub mod fs;
 ### 5. Update MCP Function Discovery
 
 **File: `src/mcp/mod.rs`**
-
 Add your server to the `get_available_functions` method:
 
 ```rust
@@ -301,7 +300,7 @@ for server in enabled_servers {
         crate::config::McpConnectionType::Builtin => {
             // Handle builtin servers by name
             match server.name.as_str() {
-                "developer" => {
+                "core" => {
                     // existing code...
                 }
                 "database" => {
@@ -313,41 +312,24 @@ for server in enabled_servers {
         // existing code...
     }
 }
-        crate::config::McpServerType::Filesystem => {
-            // existing code...
-        }
-        crate::config::McpServerType::Agent => {
-            // existing code...
-        }
-        crate::config::McpServerType::Database => {  // <- Add this
-            let server_functions =
-                get_cached_internal_functions("database", &server.tools, || {
-                    database::get_all_functions()
-                });
-            functions.extend(server_functions);
-        }
-        // ...
-    }
+```
+
+### 6. Add Server Type Enum (if needed)
+
+If your server needs a dedicated enum variant (rare for builtin servers):
+
+```rust
+// In src/config/mcp.rs
+pub enum McpServerType {
+    Core,
+    Filesystem,
+    Agent,
+    Database,  // <- Add this
+    Http,
 }
 ```
 
-Add to the `build_tool_server_map` function:
-
-```rust
-let server_functions = match server.connection_type {
-    crate::config::McpConnectionType::Builtin => {
-        // Handle builtin servers by name
-        match server.name.as_str() {
-            "database" => {
-                get_cached_internal_functions("database", &server.tools, || {
-            database::get_all_functions()
-        })
-    }
-    // ...
-};
-```
-
-### 6. Update Tool Execution
+### 7. Update Tool Execution
 
 **File: `src/mcp/mod.rs`**
 
@@ -359,36 +341,40 @@ match target_server.connection_type {
         // Handle builtin servers by name
         match target_server.name.as_str() {
             "database" => match call.tool_name.as_str() {
-        "db_query" | "db_schema" => {
-            crate::log_debug!(
-                "Executing database command via database server '{}'",
-                target_server.name
-            );
-            let mut result = match database::execute_database_command(call, config, cancellation_token.clone()).await {
-                Ok(res) => res,
-                Err(e) => {
+                "db_query" | "db_schema" => {
+                    crate::log_debug!(
+                        "Executing database command via database server '{}'",
+                        target_server.name
+                    );
+                    let mut result = match database::execute_database_command(call, config, cancellation_token.clone()).await {
+                        Ok(res) => res,
+                        Err(e) => {
+                            return Ok(McpToolResult::error(
+                                call.tool_name.clone(),
+                                call.tool_id.clone(),
+                                format!("Database execution failed: {}", e),
+                            ));
+                        }
+                    };
+                    result.tool_id = call.tool_id.clone();
+                    return Ok(result);
+                }
+                _ => {
                     return Ok(McpToolResult::error(
                         call.tool_name.clone(),
                         call.tool_id.clone(),
-                        format!("Database execution failed: {}", e),
+                        format!("Tool '{}' not implemented in database server", call.tool_name),
                     ));
                 }
-            };
-            result.tool_id = call.tool_id.clone();
-            return Ok(result);
+            },
+            // ... other servers
         }
-        _ => {
-            return Err(anyhow::anyhow!(
-                "Tool '{}' not implemented in database server",
-                call.tool_name
-            ));
-        }
-    },
-    // ...
+    }
+    // ... other connection types
 }
 ```
 
-### 7. Update Server Health Monitoring
+### 8. Update Server Health Monitoring
 
 **File: `src/mcp/server.rs`**
 
@@ -398,15 +384,12 @@ Add your server type to the builtin server check:
 match server.connection_type {
     crate::config::McpConnectionType::Builtin => {
         // All builtin servers are always available
-    | crate::config::McpServerType::Database => {  // <- Add here
-        // Internal servers are always considered running
-        // ...
     }
     // ...
 }
 ```
 
-### 8. Update Session Commands
+### 9. Update Session Commands
 
 **File: `src/session/chat/session/commands.rs`**
 
@@ -416,15 +399,12 @@ Add to server health status checks (2 locations):
 let (health, restart_info) = match server.connection_type {
     crate::config::McpConnectionType::Builtin => {
         // All builtin servers are always healthy
-    | crate::config::McpServerType::Database => {  // <- Add here
-        // Internal servers are always running
-        // ...
     }
     // ...
 };
 ```
 
-### 9. Update Response Processing
+### 10. Update Response Processing
 
 **File: `src/session/chat/response.rs`**
 
@@ -437,14 +417,17 @@ let server_functions = match server.connection_type {
         match server.name.as_str() {
             "database" => {
                 crate::mcp::get_cached_internal_functions("database", &server.tools, || {
-            crate::mcp::database::get_all_functions()
-        })
+                    crate::mcp::database::get_all_functions()
+                })
+            }
+            // ...
+        }
     }
     // ...
 };
 ```
 
-### 10. Update Config Commands
+### 11. Update Config Commands
 
 **File: `src/commands/config.rs`**
 
@@ -452,7 +435,7 @@ Add to server type detection (2 locations):
 
 ```rust
 let effective_type = match name.as_str() {
-    "developer" => McpServerType::Developer,
+    "core" => McpServerType::Core,
     "filesystem" => McpServerType::Filesystem,
     "agent" => McpServerType::Agent,
     "database" => McpServerType::Database,  // <- Add here
@@ -498,7 +481,7 @@ Add to role configurations where appropriate:
 
 ```toml
 # Developer role - add database server
-mcp = { server_refs = ["developer", "filesystem", "agent", "database"], allowed_tools = [] }
+mcp = { server_refs = ["core", "filesystem", "agent", "database"], allowed_tools = [] }
 ```
 
 ### 12. Update Documentation

--- a/doc/09-websocket-server.md
+++ b/doc/09-websocket-server.md
@@ -143,9 +143,8 @@ All server messages are JSON objects tagged by `"type"`. Each variant carries on
 ```json
 { "type": "assistant",   "content": "I'll help you fix that...", "session_id": "my-feature-x" }
 { "type": "thinking",    "content": "Let me reason through this...", "session_id": "my-feature-x" }
-{ "type": "tool_use",    "tool": "list_files", "tool_id": "call_abc", "server": "filesystem", "params": {"directory": "src"}, "session_id": "my-feature-x" }
-{ "type": "tool_result", "tool": "list_files", "tool_id": "call_abc", "server": "filesystem", "content": "src/main.rs\nsrc/lib.rs", "success": true, "session_id": "my-feature-x" }
-{ "type": "cost",        "session_tokens": 1234, "session_cost": 0.0025, "input_tokens": 1000, "output_tokens": 200, "cache_read_tokens": 30, "cache_write_tokens": 4, "reasoning_tokens": 0, "session_id": "my-feature-x" }
+{ "type": "tool_use",    "tool": "view", "tool_id": "call_abc", "server": "filesystem", "params": {"path": "src"}, "session_id": "my-feature-x" }
+{ "type": "tool_result", "tool": "view", "tool_id": "call_abc", "server": "filesystem", "content": "src/main.rs\nsrc/lib.rs", "success": true, "session_id": "my-feature-x" }
 { "type": "status",      "message": "Session created: my-feature-x", "session_id": "my-feature-x" }
 { "type": "status",      "message": "Command '/info' executed successfully", "session_id": "my-feature-x", "data": { ... } }
 { "type": "error",         "message": "Session not found: nonexistent." }
@@ -193,9 +192,8 @@ or if it already existed on disk:
 
 **Server responds (multiple messages):**
 ```json
-{ "type": "tool_use",    "tool": "list_files", "tool_id": "call_abc", "server": "filesystem", "params": {"directory": "src"}, "session_id": "my-feature-x" }
-{ "type": "tool_result", "tool": "list_files", "tool_id": "call_abc", "server": "filesystem", "content": "src/main.rs\nsrc/lib.rs\n...", "success": true, "session_id": "my-feature-x" }
-{ "type": "assistant",   "content": "The src directory contains...", "session_id": "my-feature-x" }
+{ "type": "tool_use",    "tool": "view", "tool_id": "call_abc", "server": "filesystem", "params": {"path": "src"}, "session_id": "my-feature-x" }
+{ "type": "tool_result", "tool": "view", "tool_id": "call_abc", "server": "filesystem", "content": "src/main.rs\nsrc/lib.rs\n...", "success": true, "session_id": "my-feature-x" }
 { "type": "cost",        "session_tokens": 1234, "session_cost": 0.0025, "input_tokens": 1000, "output_tokens": 200, "cache_read_tokens": 30, "cache_write_tokens": 4, "reasoning_tokens": 0, "session_id": "my-feature-x" }
 ```
 
@@ -250,7 +248,7 @@ The AI calls the `ask` tool mid-execution. The server halts tool processing and 
 
 **Server continues** (execution resumes, AI receives the answer as the tool result):
 ```json
-{ "type": "tool_result", "tool": "ask", "tool_id": "call_xyz", "server": "developer", "content": "Use sqlx — we want async-native.", "success": true, "session_id": "my-feature-x" }
+{ "type": "tool_result", "tool": "ask", "tool_id": "call_xyz", "server": "core", "content": "Use sqlx — we want async-native.", "success": true, "session_id": "my-feature-x" }
 { "type": "assistant", "content": "Got it — I'll use sqlx for the database layer.", "session_id": "my-feature-x" }
 ```
 

--- a/doc/10-workflows.md
+++ b/doc/10-workflows.md
@@ -309,8 +309,8 @@ workflow = "map_development"  # Use MAP workflow
 system = "You are an elite developer using brain-inspired planning."
 
 [roles.developer.mcp]
-server_refs = ["developer", "filesystem"]
-allowed_tools = ["developer:*", "filesystem:*"]
+server_refs = ["core", "filesystem"]
+allowed_tools = ["core:*", "filesystem:*"]
 ```
 
 ### Layer Configuration
@@ -337,10 +337,11 @@ Success Criteria: <verification>"""
 
 [layers.task_decomposer.mcp]
 server_refs = ["filesystem"]
-allowed_tools = ["list_files"]
+allowed_tools = ["view"]
 ```
 
 ## Usage
+
 
 ### Starting a Session with Workflow
 

--- a/src/commands/acp.rs
+++ b/src/commands/acp.rs
@@ -19,6 +19,10 @@ pub struct AcpArgs {
 	/// Session role: developer (default with layers and tools) or assistant (simple chat without tools)
 	#[arg(long, default_value = "developer")]
 	pub role: String,
+
+	/// Restrict all filesystem writes to the current working directory
+	#[arg(long)]
+	pub sandbox: bool,
 }
 
 /// Execute the acp command — runs Octomind as an ACP agent over stdio

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -68,6 +68,10 @@ pub struct RunArgs {
 	/// Path to JSON schema file for structured output (runtime only)
 	#[arg(long)]
 	pub schema: Option<String>,
+
+	/// Restrict all filesystem writes to the current working directory
+	#[arg(long)]
+	pub sandbox: bool,
 }
 
 impl RunArgs {
@@ -86,6 +90,7 @@ impl RunArgs {
 			system: self.system.clone(),
 			instructions: self.instructions.clone(),
 			schema: self.schema.clone(),
+			sandbox: self.sandbox,
 		}
 	}
 

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -27,6 +27,10 @@ pub struct ServerArgs {
 	/// Session role: developer (default with layers and tools) or assistant (simple chat without tools)
 	#[arg(long, default_value = "developer")]
 	pub role: String,
+
+	/// Restrict all filesystem writes to the current working directory
+	#[arg(long)]
+	pub sandbox: bool,
 }
 
 /// Execute the server command

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -63,6 +63,10 @@ pub struct SessionArgs {
 	/// Path to JSON schema file for structured output (runtime only)
 	#[arg(long)]
 	pub schema: Option<String>,
+
+	/// Restrict all filesystem writes to the current working directory
+	#[arg(long)]
+	pub sandbox: bool,
 }
 
 // No execute function here since it's handled directly by the session::chat module

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -258,6 +258,10 @@ pub struct Config {
 	#[serde(skip)]
 	pub working_directory: Option<PathBuf>,
 
+	// Sandbox mode: restrict all filesystem writes to the current working directory
+	// Can also be enabled at runtime with --sandbox CLI flag
+	pub sandbox: bool,
+
 	#[serde(skip)]
 	config_path: Option<PathBuf>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub mod directories;
 pub mod logging;
 pub mod mcp;
 pub mod providers;
+pub mod sandbox;
 pub mod session;
 pub mod state;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,7 @@ async fn initialize_mcp_for_role_with_progress(
 	}
 }
 
+async fn run_with_cleanup(args: CliArgs, config: Config) -> Result<(), anyhow::Error> {
 	// Initialize tracing based on the command being run.
 	// ACP initializes its own tracing in acp/mod.rs (must happen before LocalSet).
 	// Server initializes in commands/server.rs (needs WebSocket mode).

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,6 @@ async fn initialize_mcp_for_role_with_progress(
 	}
 }
 
-async fn run_with_cleanup(args: CliArgs, config: Config) -> Result<(), anyhow::Error> {
 	// Initialize tracing based on the command being run.
 	// ACP initializes its own tracing in acp/mod.rs (must happen before LocalSet).
 	// Server initializes in commands/server.rs (needs WebSocket mode).
@@ -159,6 +158,20 @@ async fn run_with_cleanup(args: CliArgs, config: Config) -> Result<(), anyhow::E
 			}
 		}
 		_ => {}
+	}
+
+	// Apply filesystem sandbox before anything else (including MCP server spawning)
+	// so the restriction is inherited by all child processes.
+	let sandbox_enabled = match &args.command {
+		Commands::Session(a) => config.sandbox || a.sandbox,
+		Commands::Run(a) => config.sandbox || a.sandbox,
+		Commands::Server(a) => config.sandbox || a.sandbox,
+		Commands::Acp(a) => config.sandbox || a.sandbox,
+		_ => false,
+	};
+	if sandbox_enabled {
+		let cwd = std::env::current_dir()?;
+		octomind::sandbox::apply(&cwd)?;
 	}
 
 	// Initialize MCP servers and tool map once at startup for commands that need them

--- a/src/mcp/fs/text_editing.rs
+++ b/src/mcp/fs/text_editing.rs
@@ -315,12 +315,12 @@ pub async fn line_replace_spec(
 
 	let (start_line, end_line) = lines;
 
-	// Validate content for escaped characters
-	if content.starts_with("\\t") && content.contains("\\n") {
+	// Validate content for escaped characters — catch both \t and \n independently
+	if content.contains("\\t") || content.contains("\\n") {
 		return Ok(McpToolResult::error(
 			call.tool_name.clone(),
 			call.tool_id.clone(),
-			"content should CONTAIN RAW content not escaped characters".to_string(),
+			"content must be RAW text — do not escape whitespace (use real tabs/newlines, not \\t or \\n)".to_string(),
 		));
 	}
 
@@ -387,30 +387,40 @@ pub async fn line_replace_spec(
 		.map(|&line| line.to_string())
 		.collect();
 
-	// DUPLICATE DETECTION: Check if replacement content duplicates adjacent lines
-	let mut duplicate_warnings = Vec::new();
+	// DUPLICATE DETECTION: block writes where content duplicates an adjacent line —
+	// this is the #1 cause of AI-introduced line duplication.
 	let content_lines: Vec<&str> = content.lines().collect();
 
 	if !content_lines.is_empty() {
-		// Check if first line of content matches line BEFORE replacement range
+		// First line of new content matches the line immediately before the range → AI included a surrounding line it shouldn't have
 		if start_line > 1 {
 			let line_before = lines[start_line - 2];
 			if content_lines[0].trim() == line_before.trim() && !line_before.trim().is_empty() {
-				duplicate_warnings.push(format!(
-					"⚠️  Line {} (before replacement range) matches first line of your content. Did you mean to include it in your range?",
-					start_line - 1
+				return Ok(McpToolResult::error(
+					call.tool_name.clone(),
+					call.tool_id.clone(),
+					format!(
+						"Duplicate line detected: your content's first line matches line {} (just before the replacement range). \
+						Do NOT include surrounding unchanged lines in content — only provide the lines that replace [{}-{}].",
+						start_line - 1, start_line, end_line
+					),
 				));
 			}
 		}
 
-		// Check if last line of content matches line AFTER replacement range
+		// Last line of new content matches the line immediately after the range → same problem on the other side
 		if end_line < lines.len() {
 			let line_after = lines[end_line];
 			let last_content_line = content_lines[content_lines.len() - 1];
 			if last_content_line.trim() == line_after.trim() && !line_after.trim().is_empty() {
-				duplicate_warnings.push(format!(
-					"⚠️  Line {} (after replacement range) matches last line of your content. Did you mean to include it in your range?",
-					end_line + 1
+				return Ok(McpToolResult::error(
+					call.tool_name.clone(),
+					call.tool_id.clone(),
+					format!(
+						"Duplicate line detected: your content's last line matches line {} (just after the replacement range). \
+						Do NOT include surrounding unchanged lines in content — only provide the lines that replace [{}-{}].",
+						end_line + 1, start_line, end_line
+					),
 				));
 			}
 		}
@@ -458,70 +468,56 @@ pub async fn line_replace_spec(
 		.await
 		.map_err(|e| anyhow!("Permission denied. Cannot write to file: {}", e))?;
 
-	// Create a snippet showing the replaced lines with smart highlighting
-	let replaced_snippet = if original_lines.is_empty() {
-		"(empty range)".to_string()
-	} else if original_lines.len() == 1 {
-		// For single line replacement, show exactly what was replaced
-		format!("{}: {}", start_line, original_lines[0])
-	} else if original_lines.len() <= 3 {
-		// For 2-3 lines, show all lines with line numbers
-		original_lines
-			.iter()
-			.enumerate()
-			.map(|(i, line)| format!("{}: {}", start_line + i, line))
-			.collect::<Vec<_>>()
-			.join("\n")
-	} else {
-		// For more than 3 lines, show first and last with summary
-		format!(
-			"{}: {}\n... [{} more lines]\n{}: {}",
-			start_line,
-			original_lines[0],
-			original_lines.len() - 2,
-			start_line + original_lines.len() - 1,
-			original_lines[original_lines.len() - 1]
-		)
-	};
+	// Build an annotated diff view so the AI can verify the edit landed correctly.
+	// Format:
+	//   context lines:  "  NNN: <line>"
+	//   removed lines:  "- NNN: <line>"
+	//   added lines:    "+ NNN: <line>"  (NNN = new line number after edit)
+	//   skipped gap:    "  ..."
+	const CONTEXT: usize = 3;
 
-	let lines_replaced_count = end_line - start_line + 1;
-	let new_lines_count = content.lines().count();
+	let new_lines: Vec<&str> = final_content.lines().collect();
+	let new_lines_count = content_lines.len();
 
-	let mut content_message = if lines_replaced_count == 1 && new_lines_count == 1 {
-		format!("Successfully replaced line {} with new content", start_line)
-	} else if lines_replaced_count == 1 {
-		format!(
-			"Successfully replaced line {} with {} lines",
-			start_line, new_lines_count
-		)
-	} else if new_lines_count == 1 {
-		format!(
-			"Successfully replaced {} lines ({}-{}) with 1 line",
-			lines_replaced_count, start_line, end_line
-		)
-	} else {
-		format!(
-			"Successfully replaced {} lines ({}-{}) with {} lines",
-			lines_replaced_count, start_line, end_line, new_lines_count
-		)
-	};
+	let mut diff: Vec<String> = Vec::new();
 
-	// Append duplicate warnings if any
-	if !duplicate_warnings.is_empty() {
-		content_message.push_str("\n\n");
-		content_message.push_str(&duplicate_warnings.join("\n"));
+	// --- context before ---
+	let ctx_before_start = start_line.saturating_sub(CONTEXT); // 1-indexed, inclusive
+	if ctx_before_start > 1 {
+		diff.push("...".to_string());
 	}
+	for i in ctx_before_start..start_line {
+		diff.push(format!("{}: {}", i, lines[i - 1]));
+	}
+
+	// --- removed lines (what was there before) ---
+	for (i, old_line) in original_lines.iter().enumerate() {
+		diff.push(format!("-{}: {}", start_line + i, old_line));
+	}
+
+	// --- added lines (what is there now) ---
+	// New line numbers start at start_line in the post-edit file
+	for (i, new_line) in content_lines.iter().enumerate() {
+		diff.push(format!("+{}: {}", start_line + i, new_line));
+	}
+
+	// --- context after ---
+	// In the new file, lines after the edit start at: start_line + new_lines_count
+	let new_after_start = start_line + new_lines_count; // 1-indexed in new file
+	let new_after_end = (new_after_start + CONTEXT - 1).min(new_lines.len());
+	for new_i in new_after_start..=new_after_end {
+		diff.push(format!("{}: {}", new_i, new_lines[new_i - 1]));
+	}
+	if new_after_end < new_lines.len() {
+		diff.push("...".to_string());
+	}
+	diff.push(format!("[{} lines total]", new_lines.len()));
 
 	Ok(McpToolResult {
 		tool_name: "text_editor".to_string(),
 		tool_id: call.tool_id.clone(),
 		result: json!({
-			"content": content_message,
-			"path": path.to_string_lossy(),
-			"lines_replaced": lines_replaced_count,
-			"new_lines": new_lines_count,
-			"replaced_snippet": replaced_snippet,
-			"range": format!("{}-{}", start_line, end_line)
+			"diff": diff.join("\n"),
 		}),
 	})
 }

--- a/src/mcp/fs/text_editing.rs
+++ b/src/mcp/fs/text_editing.rs
@@ -482,7 +482,7 @@ pub async fn line_replace_spec(
 	let mut diff: Vec<String> = Vec::new();
 
 	// --- context before ---
-	let ctx_before_start = start_line.saturating_sub(CONTEXT); // 1-indexed, inclusive
+	let ctx_before_start = start_line.saturating_sub(CONTEXT).max(1); // 1-indexed, inclusive, never 0
 	if ctx_before_start > 1 {
 		diff.push("...".to_string());
 	}

--- a/src/sandbox/linux.rs
+++ b/src/sandbox/linux.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Linux sandbox backend using Landlock LSM.
+//!
+//! Landlock is available since kernel 5.13. On older kernels the crate
+//! operates in best-effort mode and we log a warning instead of failing.
+//!
+//! Access model:
+//! - Landlock rules are purely additive (union) — a parent grant cannot be
+//!   revoked for a subpath. This means read-blocking specific dirs (e.g. ~/.ssh)
+//!   while allowing reads everywhere else is not possible with Landlock v1-v3.
+//! - We therefore apply the practical safe default:
+//!   - Read-only (ReadFile | ReadDir | Execute) on `/` — whole filesystem readable
+//!   - Read+write on cwd and ~/.local/share (MCP server state/logs)
+//!   - All writes outside those two paths are denied
+//! - Sensitive credential dirs (~/.ssh, ~/.aws, etc.) are protected from
+//!   *writes* but remain readable. This matches the macOS write-only baseline.
+//!   True read isolation on Linux requires namespaces/seccomp — out of scope here.
+
+use anyhow::Result;
+use landlock::{
+	make_bitflags, path_beneath_rules, Access, AccessFs, Ruleset, RulesetAttr, RulesetCreatedAttr,
+	RulesetStatus, ABI,
+};
+
+pub fn apply(dir: &std::path::Path) -> Result<()> {
+	let abi = ABI::V3;
+	let all_access = AccessFs::from_all(abi);
+	// Read-only rights: read files, list dirs, execute — intersected with ABI support.
+	let read_only = make_bitflags!(AccessFs::{ReadFile | ReadDir | Execute}) & all_access;
+
+	let home = dirs::home_dir().unwrap_or_default();
+	let xdg_data_home = home.join(".local").join("share");
+
+	let mut ruleset = Ruleset::default().handle_access(all_access)?.create()?;
+
+	// Read-only on the whole filesystem so MCP servers can read system libs,
+	// configs, and project files outside cwd.
+	ruleset = ruleset.add_rules(path_beneath_rules(["/"], read_only))?;
+
+	// Read+write on cwd and XDG data home (MCP server logs/state).
+	let mut rw_paths: Vec<&std::path::Path> = vec![dir];
+	if xdg_data_home.exists() {
+		rw_paths.push(xdg_data_home.as_path());
+	}
+	ruleset = ruleset.add_rules(path_beneath_rules(rw_paths, all_access))?;
+
+	let status = ruleset.restrict_self()?;
+
+	match status.ruleset {
+		RulesetStatus::FullyEnforced => {
+			crate::log_info!(
+				"Sandbox active (Landlock fully enforced): writes locked to {}",
+				dir.display()
+			);
+		}
+		RulesetStatus::PartiallyEnforced => {
+			crate::log_info!(
+				"Sandbox active (Landlock partially enforced — older kernel): writes locked to {}",
+				dir.display()
+			);
+		}
+		RulesetStatus::NotEnforced => {
+			crate::log_info!(
+				"Sandbox requested but Landlock is not enforced on this kernel — running without restrictions."
+			);
+		}
+	}
+
+	Ok(())
+}

--- a/src/sandbox/linux.rs
+++ b/src/sandbox/linux.rs
@@ -22,9 +22,9 @@
 //!   revoked for a subpath. This means read-blocking specific dirs (e.g. ~/.ssh)
 //!   while allowing reads everywhere else is not possible with Landlock v1-v3.
 //! - We therefore apply the practical safe default:
-//!   - Read-only (ReadFile | ReadDir | Execute) on `/` — whole filesystem readable
-//!   - Read+write on cwd and ~/.local/share (MCP server state/logs)
-//!   - All writes outside those two paths are denied
+//!   • Read-only (ReadFile | ReadDir | Execute) on `/` — whole filesystem readable
+//!   • Read+write on cwd and ~/.local/share (MCP server state/logs)
+//!   • All writes outside those two paths are denied
 //! - Sensitive credential dirs (~/.ssh, ~/.aws, etc.) are protected from
 //!   *writes* but remain readable. This matches the macOS write-only baseline.
 //!   True read isolation on Linux requires namespaces/seccomp — out of scope here.

--- a/src/sandbox/macos.rs
+++ b/src/sandbox/macos.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! macOS sandbox backend using Apple Seatbelt (`sandbox_init(3)`).
+//!
+//! `sandbox_init` applies a Scheme-like policy to the current process and all
+//! children it spawns. The CLI tool `sandbox-exec` is deprecated but the
+//! underlying C library function remains stable across all macOS versions.
+//!
+//! Policy: allow everything by default, deny all file writes, then re-allow
+//! writes only inside the target directory plus essential system paths.
+
+use anyhow::{bail, Result};
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int};
+
+extern "C" {
+	/// Apply a Seatbelt sandbox profile to the current process.
+	/// Returns 0 on success, -1 on failure (errorbuf is set).
+	fn sandbox_init(profile: *const c_char, flags: u64, errorbuf: *mut *mut c_char) -> c_int;
+
+	/// Free the error string allocated by `sandbox_init`.
+	fn sandbox_free_error(errorbuf: *mut c_char);
+}
+
+pub fn apply(dir: &std::path::Path) -> Result<()> {
+	let dir_str = dir
+		.to_str()
+		.ok_or_else(|| anyhow::anyhow!("sandbox: working directory path is not valid UTF-8"))?;
+
+	// Resolve home dir and XDG data home (~/.local/share) so MCP servers (e.g. octocode)
+	// can write their logs/state there without being blocked.
+	let home = dirs::home_dir().unwrap_or_default();
+	let home_str = home.to_str().unwrap_or_default().to_owned();
+	let xdg_data_home = home.join(".local").join("share");
+	let xdg_data_home_str = xdg_data_home.to_str().unwrap_or_default().to_owned();
+
+	// Build the Seatbelt profile.
+	// - Allow everything by default (reads, network, process ops, etc.)
+	// - Deny reads of sensitive credential dirs (ssh keys, cloud creds, gpg keys)
+	// - Deny all file writes globally
+	// - Re-allow writes to:
+	//   • the target working directory (the whole point of the sandbox)
+	//   • ~/.local/share — XDG data home; MCP servers write logs/state here
+	//   • /dev — pipes, ttys, and other character devices
+	//   • /tmp, /private/tmp — standard temp files
+	//   • /private/var/folders — macOS per-user temp cache (used by many syscalls)
+	let profile = format!(
+		r#"(version 1)
+(allow default)
+(deny file-read* file-write*
+  (subpath "{home}/.ssh")
+  (subpath "{home}/.gnupg")
+  (subpath "{home}/.aws")
+  (subpath "{home}/.kube")
+  (subpath "{home}/.config/gcloud")
+  (subpath "{home}/.azure")
+  (subpath "{home}/.config/op")
+)
+(deny file-write*
+  (subpath "/")
+)
+(allow file-write*
+  (subpath "{dir}")
+  (subpath "{xdg_data_home}")
+  (subpath "/dev")
+  (subpath "/tmp")
+  (subpath "/private/tmp")
+  (subpath "/private/var/folders")
+)"#,
+		home = home_str,
+		dir = dir_str,
+		xdg_data_home = xdg_data_home_str,
+	);
+
+	let profile_cstr = CString::new(profile)
+		.map_err(|_| anyhow::anyhow!("sandbox: profile contains null byte"))?;
+
+	let mut errorbuf: *mut c_char = std::ptr::null_mut();
+
+	let ret = unsafe { sandbox_init(profile_cstr.as_ptr(), 0, &mut errorbuf) };
+
+	if ret != 0 {
+		let msg = if errorbuf.is_null() {
+			"unknown error".to_string()
+		} else {
+			let s = unsafe { CStr::from_ptr(errorbuf) }
+				.to_string_lossy()
+				.into_owned();
+			unsafe { sandbox_free_error(errorbuf) };
+			s
+		};
+		bail!("sandbox_init failed: {}", msg);
+	}
+
+	crate::log_info!(
+		"Sandbox active (Seatbelt): writes locked to {}",
+		dir.display()
+	);
+	Ok(())
+}

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Filesystem sandbox: restrict all writes to the current working directory.
+//!
+//! Applies an OS-level write restriction to the current process and all its
+//! children (spawned shells, MCP servers, sub-agents). Reads are unrestricted.
+//!
+//! Platform support:
+//! - Linux: Landlock LSM (kernel 5.13+). Gracefully degrades on older kernels.
+//! - macOS: Seatbelt via `sandbox_init(3)` C FFI.
+//! - Other: no-op with a warning log.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+/// Apply filesystem write sandbox, locking all writes to `dir` and its subtree.
+///
+/// Must be called early — before spawning any child processes — so the
+/// restriction is inherited by all children automatically.
+pub fn apply(dir: &std::path::Path) -> anyhow::Result<()> {
+	#[cfg(target_os = "linux")]
+	{
+		linux::apply(dir)
+	}
+
+	#[cfg(target_os = "macos")]
+	{
+		macos::apply(dir)
+	}
+
+	#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+	{
+		let _ = dir;
+		crate::log_info!("Sandbox requested but not supported on this platform — running without write restrictions.");
+		Ok(())
+	}
+}

--- a/src/session/chat/conversation_compression.rs
+++ b/src/session/chat/conversation_compression.rs
@@ -668,11 +668,23 @@ pub async fn check_and_compress_conversation(
 	session: &mut ChatSession,
 	config: &Config,
 	operation_rx: tokio::sync::watch::Receiver<bool>,
+	force: bool,
 ) -> Result<bool> {
 	let (should_check, target_ratio) = should_check_compression(session, config).await;
-	if !should_check {
+
+	if !force && !should_check {
 		return Ok(false);
 	}
+	let target_ratio = if force {
+		config
+			.compression
+			.pressure_levels
+			.iter()
+			.map(|l| l.target_ratio)
+			.fold(2.0_f64, f64::max)
+	} else {
+		target_ratio
+	};
 
 	// Check for cancellation before starting compression (which involves an API call)
 	if *operation_rx.borrow() {
@@ -743,7 +755,7 @@ pub async fn check_and_compress_conversation(
 	)
 	.await?;
 
-	if !should_compress {
+	if !force && !should_compress {
 		log_debug!("AI decided compression not beneficial at this point");
 		animation_manager.stop_current().await;
 		return Ok(false);

--- a/src/session/chat/response/tool_result_processor.rs
+++ b/src/session/chat/response/tool_result_processor.rs
@@ -117,6 +117,7 @@ pub async fn process_tool_results(
 					chat_session,
 					config,
 					operation_cancelled.clone(),
+					false,
 				)
 				.await
 			{
@@ -278,11 +279,11 @@ pub async fn process_tool_results(
 		};
 
 	// 🗜️ ADAPTIVE CONVERSATION COMPRESSION: Check if context should be compressed
-	// This runs AFTER plan compression (which handles structured plan content)
 	if let Err(e) = crate::session::chat::conversation_compression::check_and_compress_conversation(
 		chat_session,
 		config,
 		operation_cancelled.clone(),
+		false,
 	)
 	.await
 	{

--- a/src/session/chat/session/api_prep.rs
+++ b/src/session/chat/session/api_prep.rs
@@ -36,6 +36,7 @@ pub async fn prepare_for_api_call(
 		chat_session,
 		config,
 		operation_rx.clone(),
+		false,
 	)
 	.await
 	{

--- a/src/session/chat/session/commands/done.rs
+++ b/src/session/chat/session/commands/done.rs
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// /done command handler - compress conversation context (same as automatic session compression)
+// /done command handler - force-compress conversation context regardless of thresholds
 
 use super::super::core::ChatSession;
 use crate::config::Config;
 use anyhow::Result;
 use colored::Colorize;
 
-/// Compress conversation context, identical to the automatic pressure-based compression.
-///
-/// Runs `check_and_compress_conversation` directly — the AI decides whether compression
-/// is beneficial and produces a summary, preserving recent turns and all instructions.
+/// Force-compress conversation context, bypassing all automatic threshold/cooldown/cost guards.
+/// The user explicitly requested compression, so we always run it.
 pub async fn handle_done(
 	session: &mut ChatSession,
 	config: &Config,
@@ -33,6 +31,7 @@ pub async fn handle_done(
 			session,
 			config,
 			operation_cancelled,
+			true,
 		)
 		.await
 		{
@@ -41,10 +40,7 @@ pub async fn handle_done(
 				true
 			}
 			Ok(false) => {
-				println!(
-					"{}",
-					"ℹ️  No compression needed at this point.".bright_cyan()
-				);
+				println!("{}", "ℹ️  Nothing to compress.".bright_cyan());
 				false
 			}
 			Err(e) => {

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -616,6 +616,7 @@ pub async fn run_interactive_session<T: std::fmt::Debug>(args: &T, config: &Conf
 				&mut chat_session,
 				&current_config,
 				operation_rx.clone(),
+				false,
 			)
 			.await
 			{


### PR DESCRIPTION
- Add landlock dependency for Linux sandboxing
- Apply filesystem sandbox before MCP server starts
- Linux: allow writes only in cwd and ~/.local/share
- macOS: deny writes outside cwd and system temp dirs
- Protect credential directories on both platforms