### PR TITLE
feat(logging): add structured file tracing for ACP and WebSocket modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1966,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "url",
  "urlencoding",
  "uuid",
@@ -2876,6 +2886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,6 +3450,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3557,6 +3606,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ thiserror = "2.0"
 open = "5"
 tracing = { version = "0.1", default-features = false }
 agent-client-protocol = "0.10.0"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -30,6 +30,36 @@ use crate::config::Config;
 
 /// Run the ACP agent over stdio until the client disconnects.
 pub async fn run(config: Config, role: String) -> Result<()> {
+	// In ACP mode stdout/stderr are reserved for JSON-RPC, so init failures
+	// are written to a fallback file instead of eprintln.
+	let write_init_error = |msg: String| {
+		if let Ok(logs_dir) = crate::directories::get_logs_dir() {
+			let log_file = logs_dir.join("acp-init-errors.log");
+			if let Ok(mut file) = std::fs::OpenOptions::new()
+				.create(true)
+				.append(true)
+				.open(&log_file)
+			{
+				use std::io::Write;
+				let _ = writeln!(file, "{msg}");
+			}
+		}
+	};
+
+	// Initialize tracing for ACP mode - logs to file, not stdout/stderr
+	let log_level = config.log_level.as_str();
+	if let Err(e) = crate::logging::tracing_setup::init_tracing(
+		crate::logging::tracing_setup::LoggingMode::Acp,
+		log_level,
+	) {
+		write_init_error(format!("Failed to initialize tracing: {e}"));
+	}
+
+	// Initialize ACP error sink for structured error logging
+	if let Err(e) = crate::logging::AcpErrorSink::initialize() {
+		write_init_error(format!("Failed to initialize ACP error sink: {e}"));
+	}
+
 	let local = tokio::task::LocalSet::new();
 
 	local

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -33,6 +33,16 @@ pub struct ServerArgs {
 pub async fn execute(args: &ServerArgs, config: &octomind::Config) -> Result<(), anyhow::Error> {
 	use octomind::websocket::WebSocketServer;
 
+	// Initialize tracing for WebSocket mode - logs to file
+	// stdout/stderr are used for server status messages
+	let log_level = config.log_level.as_str();
+	if let Err(e) = octomind::logging::tracing_setup::init_tracing(
+		octomind::logging::tracing_setup::LoggingMode::WebSocket,
+		log_level,
+	) {
+		eprintln!("Warning: Failed to initialize tracing: {}", e);
+	}
+
 	// Create and start WebSocket server
 	let server = WebSocketServer::new(&args.host, args.port, config.clone(), args.role.clone())?;
 	server.start().await?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -95,6 +95,15 @@ impl LogLevel {
 	pub fn is_debug_enabled(&self) -> bool {
 		matches!(self, LogLevel::Debug)
 	}
+
+	/// Get string representation for tracing
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			LogLevel::None => "off",
+			LogLevel::Info => "info",
+			LogLevel::Debug => "debug",
+		}
+	}
 }
 
 // REMOVED: All default functions - config must be complete and explicit
@@ -498,82 +507,148 @@ where
 {
 	CURRENT_CONFIG.with(|c| (*c.borrow()).as_ref().map(f))
 }
+// ============================================================================
+// LOGGING MACROS
+// ============================================================================
+// These macros route log output based on whether tracing is initialized:
+// - Tracing initialized (CLI/ACP/WebSocket): use tracing (stderr or file)
+// - No tracing: use colored println/eprintln for CLI
+//
+// IMPORTANT: In ACP/WebSocket mode, tracing writes to file only.
+// stdout/stderr are reserved for JSON-RPC protocol communication.
 
-/// Info logging macro with automatic cyan coloring
-/// Shows info messages when log level is Info OR Debug
-/// Suppressed in JSONL mode to avoid mixing plain text with JSON output
+/// Info logging macro with automatic cyan coloring (CLI) or tracing (ACP/WebSocket).
+/// Shows info messages when log level is Info OR Debug.
 #[macro_export]
 macro_rules! log_info {
 	($fmt:expr) => {
 		if let Some(should_log) = $crate::config::with_thread_config(|config| {
-			config.get_log_level().is_info_enabled() && !config.output_mode().should_suppress_cli_output()
+			config.get_log_level().is_info_enabled()
 		}) {
 			if should_log {
-				use colored::Colorize;
-				println!("{}", $fmt.cyan());
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::info!("{}", $fmt);
+				} else {
+					use colored::Colorize;
+					$crate::println!("{}", $fmt.cyan());
+				}
 			}
 		}
 	};
 	($fmt:expr, $($arg:expr),*) => {
 		if let Some(should_log) = $crate::config::with_thread_config(|config| {
-			config.get_log_level().is_info_enabled() && !config.output_mode().should_suppress_cli_output()
+			config.get_log_level().is_info_enabled()
 		}) {
 			if should_log {
-				use colored::Colorize;
-				println!("{}", format!($fmt, $($arg),*).cyan());
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::info!($fmt, $($arg),*);
+				} else {
+					use colored::Colorize;
+					$crate::println!("{}", format!($fmt, $($arg),*).cyan());
+				}
 			}
 		}
 	};
 }
 
-/// Debug logging macro with automatic bright blue coloring
+/// Debug logging macro with automatic bright blue coloring (CLI) or tracing (ACP/WebSocket).
 #[macro_export]
 macro_rules! log_debug {
 	($fmt:expr) => {
-		if let Some(should_log) = $crate::config::with_thread_config(|config| config.get_log_level().is_debug_enabled()) {
-		if should_log {
-		use colored::Colorize;
-		println!("{}", $fmt.bright_blue());
-		}
+		if let Some(should_log) = $crate::config::with_thread_config(|config| {
+			config.get_log_level().is_debug_enabled()
+		}) {
+			if should_log {
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::debug!("{}", $fmt);
+				} else {
+					use colored::Colorize;
+					$crate::println!("{}", $fmt.bright_blue());
+				}
+			}
 		}
 	};
 	($fmt:expr, $($arg:expr),*) => {
-		if let Some(should_log) = $crate::config::with_thread_config(|config| config.get_log_level().is_debug_enabled()) {
-		if should_log {
-		use colored::Colorize;
-	println!("{}", format!($fmt, $($arg),*).bright_blue());
-	}
-	}
+		if let Some(should_log) = $crate::config::with_thread_config(|config| {
+			config.get_log_level().is_debug_enabled()
+		}) {
+			if should_log {
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::debug!($fmt, $($arg),*);
+				} else {
+					use colored::Colorize;
+					$crate::println!("{}", format!($fmt, $($arg),*).bright_blue());
+				}
+			}
+		}
 	};
 }
 
-/// Error logging macro with automatic bright red coloring
-/// Always visible regardless of log level (errors should always be shown)
+/// Error logging macro with automatic bright red coloring (CLI) or tracing + file (ACP/WebSocket).
+/// Always visible regardless of log level.
+/// In ACP mode, also writes to the dedicated error sink for structured JSONL error tracking.
 #[macro_export]
 macro_rules! log_error {
 	($fmt:expr) => {{
-		use colored::Colorize;
-		eprintln!("{}", $fmt.bright_red());
-		}};
+		if $crate::logging::tracing_setup::is_tracing_initialized() {
+			tracing::error!("{}", $fmt);
+			// In ACP mode, also write to the structured error sink
+			if $crate::logging::tracing_setup::is_structured_output_mode() {
+				if let Some(sink) = $crate::logging::AcpErrorSink::get_global() {
+					let _ = sink.log_error_simple($fmt);
+				}
+			}
+		} else {
+			use colored::Colorize;
+			$crate::eprintln!("{}", $fmt.bright_red());
+		}
+	}};
 	($fmt:expr, $($arg:expr),*) => {{
-		use colored::Colorize;
-		eprintln!("{}", format!($fmt, $($arg),*).bright_red());
-		}};
+		if $crate::logging::tracing_setup::is_tracing_initialized() {
+			tracing::error!($fmt, $($arg),*);
+			if $crate::logging::tracing_setup::is_structured_output_mode() {
+				if let Some(sink) = $crate::logging::AcpErrorSink::get_global() {
+					let _ = sink.log_error_simple(&format!($fmt, $($arg),*));
+				}
+			}
+		} else {
+			use colored::Colorize;
+			$crate::eprintln!("{}", format!($fmt, $($arg),*).bright_red());
+		}
+	}};
 }
 
-/// Conditional logging - prints different messages based on log level
+/// Conditional logging - prints different messages based on log level.
 #[macro_export]
 macro_rules! log_conditional {
 	(debug: $debug_msg:expr, info: $info_msg:expr, none: $none_msg:expr) => {
 		if let Some(level) = $crate::config::with_thread_config(|config| config.get_log_level()) {
 			match level {
-				$crate::config::LogLevel::Debug => println!("{}", $debug_msg),
-				$crate::config::LogLevel::Info => println!("{}", $info_msg),
-				$crate::config::LogLevel::None => println!("{}", $none_msg),
+				$crate::config::LogLevel::Debug => {
+					if $crate::logging::tracing_setup::is_tracing_initialized() {
+						tracing::debug!("{}", $debug_msg);
+					} else {
+						$crate::println!("{}", $debug_msg);
+					}
+				}
+				$crate::config::LogLevel::Info => {
+					if $crate::logging::tracing_setup::is_tracing_initialized() {
+						tracing::info!("{}", $info_msg);
+					} else {
+						$crate::println!("{}", $info_msg);
+					}
+				}
+				$crate::config::LogLevel::None => {
+					if $crate::logging::tracing_setup::is_tracing_initialized() {
+						tracing::info!("{}", $none_msg);
+					} else {
+						$crate::println!("{}", $none_msg);
+					}
+				}
 			}
 		} else {
 			// Fallback if no config is set
-			println!("{}", $none_msg);
+			$crate::println!("{}", $none_msg);
 		}
 	};
 	(debug: $debug_msg:expr, default: $default_msg:expr) => {
@@ -581,13 +656,21 @@ macro_rules! log_conditional {
 			$crate::config::with_thread_config(|config| config.get_log_level().is_debug_enabled())
 		{
 			if should_debug {
-				println!("{}", $debug_msg);
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::debug!("{}", $debug_msg);
+				} else {
+					$crate::println!("{}", $debug_msg);
+				}
 			} else {
-				println!("{}", $default_msg);
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::info!("{}", $default_msg);
+				} else {
+					$crate::println!("{}", $default_msg);
+				}
 			}
 		} else {
 			// Fallback if no config is set
-			println!("{}", $default_msg);
+			$crate::println!("{}", $default_msg);
 		}
 	};
 	(info: $info_msg:expr, default: $default_msg:expr) => {
@@ -595,13 +678,21 @@ macro_rules! log_conditional {
 			$crate::config::with_thread_config(|config| config.get_log_level().is_info_enabled())
 		{
 			if should_info {
-				println!("{}", $info_msg);
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::info!("{}", $info_msg);
+				} else {
+					$crate::println!("{}", $info_msg);
+				}
 			} else {
-				println!("{}", $default_msg);
+				if $crate::logging::tracing_setup::is_tracing_initialized() {
+					tracing::info!("{}", $default_msg);
+				} else {
+					$crate::println!("{}", $default_msg);
+				}
 			}
 		} else {
 			// Fallback if no config is set
-			println!("{}", $default_msg);
+			$crate::println!("{}", $default_msg);
 		}
 	};
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -528,7 +528,9 @@ macro_rules! log_info {
 			if should_log {
 				if $crate::logging::tracing_setup::is_tracing_initialized() {
 					tracing::info!("{}", $fmt);
-				} else {
+				} else if $crate::config::with_thread_config(|config| {
+					!config.output_mode().should_suppress_cli_output()
+				}).unwrap_or(true) {
 					use colored::Colorize;
 					$crate::println!("{}", $fmt.cyan());
 				}
@@ -542,7 +544,9 @@ macro_rules! log_info {
 			if should_log {
 				if $crate::logging::tracing_setup::is_tracing_initialized() {
 					tracing::info!($fmt, $($arg),*);
-				} else {
+				} else if $crate::config::with_thread_config(|config| {
+					!config.output_mode().should_suppress_cli_output()
+				}).unwrap_or(true) {
 					use colored::Colorize;
 					$crate::println!("{}", format!($fmt, $($arg),*).cyan());
 				}
@@ -561,7 +565,9 @@ macro_rules! log_debug {
 			if should_log {
 				if $crate::logging::tracing_setup::is_tracing_initialized() {
 					tracing::debug!("{}", $fmt);
-				} else {
+				} else if $crate::config::with_thread_config(|config| {
+					!config.output_mode().should_suppress_cli_output()
+				}).unwrap_or(true) {
 					use colored::Colorize;
 					$crate::println!("{}", $fmt.bright_blue());
 				}
@@ -575,7 +581,9 @@ macro_rules! log_debug {
 			if should_log {
 				if $crate::logging::tracing_setup::is_tracing_initialized() {
 					tracing::debug!($fmt, $($arg),*);
-				} else {
+				} else if $crate::config::with_thread_config(|config| {
+					!config.output_mode().should_suppress_cli_output()
+				}).unwrap_or(true) {
 					use colored::Colorize;
 					$crate::println!("{}", format!($fmt, $($arg),*).bright_blue());
 				}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ macro_rules! eprint {
 pub mod acp;
 pub mod config;
 pub mod directories;
+pub mod logging;
 pub mod mcp;
 pub mod providers;
 pub mod session;
@@ -98,6 +99,9 @@ pub mod websocket;
 
 // Re-export commonly used items for convenience
 pub use config::Config;
+
+// Re-export logging types
+pub use logging::AcpErrorSink;
 
 // Re-export workflow types
 pub use session::workflows::{PatternParser, StepExecutor, WorkflowOrchestrator};

--- a/src/logging/acp_error.rs
+++ b/src/logging/acp_error.rs
@@ -1,0 +1,154 @@
+// Copyright 2025 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ACP-specific error sink.
+//!
+//! When running as an ACP agent, stderr is used for JSON-RPC protocol.
+//! This module provides a dedicated file-based error sink for ACP mode.
+
+use anyhow::{Context, Result};
+use serde_json::Value as JsonValue;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+/// Global ACP error sink instance.
+static ACP_ERROR_SINK: std::sync::OnceLock<Arc<AcpErrorSink>> = std::sync::OnceLock::new();
+
+/// ACP error sink for logging errors to a dedicated file.
+///
+/// This is used when running in ACP mode where stderr is reserved
+/// for JSON-RPC protocol communication.
+///
+/// Thread-safe and can be accessed globally via [`get_global`].
+pub struct AcpErrorSink {
+	file: Mutex<Option<std::fs::File>>,
+	path: PathBuf,
+}
+
+impl AcpErrorSink {
+	/// Create a new ACP error sink.
+	fn new(path: PathBuf) -> Result<Self> {
+		// Ensure parent directory exists
+		if let Some(parent) = path.parent() {
+			if !parent.exists() {
+				std::fs::create_dir_all(parent)
+					.with_context(|| format!("Failed to create logs directory: {:?}", parent))?;
+			}
+		}
+
+		Ok(Self {
+			file: Mutex::new(None),
+			path,
+		})
+	}
+
+	/// Initialize the global ACP error sink.
+	///
+	/// This should be called once at startup when running in ACP mode.
+	/// The sink writes to `~/.local/share/octomind/logs/acp-errors.jsonl`.
+	pub fn initialize() -> Result<Arc<Self>> {
+		let logs_dir = crate::directories::get_logs_dir()?;
+		let path = logs_dir.join("acp-errors.jsonl");
+
+		let sink = Arc::new(Self::new(path)?);
+
+		// Try to set as global, but don't fail if already set
+		let _ = ACP_ERROR_SINK.set(sink.clone());
+
+		Ok(sink)
+	}
+
+	/// Get the global ACP error sink, if initialized.
+	pub fn get_global() -> Option<Arc<Self>> {
+		ACP_ERROR_SINK.get().cloned()
+	}
+
+	/// Log a simple error message (convenience method for macros).
+	///
+	/// This is a simplified version of `log_error` that doesn't require context.
+	pub fn log_error_simple(&self, error: &str) -> Result<()> {
+		let timestamp = chrono::Utc::now().to_rfc3339();
+		let session_id = std::env::current_dir()
+			.ok()
+			.and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+			.unwrap_or_else(|| "unknown".to_string());
+
+		let entry = serde_json::json!({
+			"timestamp": timestamp,
+			"session_id": session_id,
+			"error": error
+		});
+
+		self.write_entry(&entry)
+	}
+
+	/// Write an entry to the log file.
+	fn write_entry(&self, entry: &JsonValue) -> Result<()> {
+		let mut file_guard = self.file.lock().unwrap();
+
+		if file_guard.is_none() {
+			let file = OpenOptions::new()
+				.create(true)
+				.append(true)
+				.open(&self.path)
+				.with_context(|| format!("Failed to open ACP error log: {:?}", self.path))?;
+			*file_guard = Some(file);
+		}
+
+		let file = file_guard.as_mut().unwrap();
+		let content =
+			serde_json::to_string(entry).with_context(|| "Failed to serialize error entry")?;
+
+		writeln!(file, "{}", content).with_context(|| "Failed to write error entry")?;
+
+		// Flush immediately for errors
+		file.flush().with_context(|| "Failed to flush error log")?;
+
+		Ok(())
+	}
+}
+
+impl Drop for AcpErrorSink {
+	fn drop(&mut self) {
+		// Ensure file is flushed on drop
+		if let Ok(mut file_guard) = self.file.lock() {
+			if let Some(file) = file_guard.as_mut() {
+				let _ = file.flush();
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use tempfile::tempdir;
+
+	#[test]
+	fn test_acp_error_sink_path() {
+		let dir = tempdir().unwrap();
+		let logs_dir = dir.path().join("logs");
+		std::fs::create_dir_all(&logs_dir).unwrap();
+
+		let path = logs_dir.join("acp-errors.jsonl");
+		let sink = AcpErrorSink::new(path.clone()).unwrap();
+
+		sink.log_error_simple("Test error").unwrap();
+
+		let content = std::fs::read_to_string(&path).unwrap();
+		assert!(content.contains("Test error"));
+	}
+}

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,0 +1,45 @@
+// Copyright 2025 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Logging infrastructure for Octomind.
+//!
+//! This module provides:
+//! - **ACP error sink** (`acp_error`): Dedicated error logging for ACP mode
+//! - **Tracing setup** (`tracing_setup`): Mode-aware logging initialization
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ~/.local/share/octomind/logs/
+//! ├── acp-debug.log       ← ACP tracing output
+//! ├── acp-errors.jsonl    ← ACP-specific error sink
+//! └── websocket-debug.log ← WebSocket tracing output
+//! ```
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! // At startup (ACP mode):
+//! init_tracing(LoggingMode::Acp, "debug")?;
+//! AcpErrorSink::initialize()?;
+//!
+//! // In code:
+//! log_debug!("Processing request");  // → tracing::debug! (file in ACP mode)
+//! log_error!("Failed: {}", err);     // → tracing::error! + AcpErrorSink
+//! ```
+
+pub mod acp_error;
+pub mod tracing_setup;
+
+pub use acp_error::AcpErrorSink;

--- a/src/logging/tracing_setup.rs
+++ b/src/logging/tracing_setup.rs
@@ -1,0 +1,288 @@
+// Copyright 2025 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tracing setup for structured logging.
+//!
+//! Provides initialization for the `tracing` crate with support for:
+//! - Console output (CLI mode) - colored stderr
+//! - File output (ACP/WebSocket mode) - file-based logging
+//! - Global logging mode tracking for macros
+//!
+//! ## Architecture
+//!
+//! The logging system uses a two-tier approach:
+//! 1. **Global mode tracking** (`LOGGING_MODE`): Set once at startup, read by macros
+//! 2. **Tracing subscriber**: Configured based on mode (CLI → stderr, ACP/WebSocket → file)
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! // At startup (before any logging):
+//! init_tracing(LoggingMode::Acp, "debug")?;
+//!
+//! // In code, use macros that respect the mode:
+//! log_debug!("Processing request");  // → tracing::debug! in ACP mode
+//! log_info!("Request completed");    // → tracing::info! in ACP mode
+//! log_error!("Failed: {}", err);     // → tracing::error! + file in ACP mode
+//! ```
+
+use anyhow::{Context, Result};
+use std::sync::Arc;
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+
+/// Logging mode based on how Octomind is running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggingMode {
+	/// CLI mode - log to stderr with colors
+	Cli,
+	/// ACP mode - log to file only (stdout/stderr reserved for JSON-RPC)
+	Acp,
+	/// WebSocket mode - log to file only
+	WebSocket,
+	/// Silent mode - no logging
+	Silent,
+}
+
+// ============================================================================
+// GLOBAL LOGGING MODE TRACKER
+// ============================================================================
+
+/// Global logging mode - set once at startup, read by macros.
+/// Uses OnceLock for thread-safe initialization.
+static LOGGING_MODE: std::sync::OnceLock<LoggingMode> = std::sync::OnceLock::new();
+
+/// Set the global logging mode. Should be called once at startup.
+pub fn set_logging_mode(mode: LoggingMode) {
+	let _ = LOGGING_MODE.set(mode);
+}
+
+/// Get the current logging mode. Returns None if not initialized.
+#[inline]
+pub fn get_logging_mode() -> Option<LoggingMode> {
+	LOGGING_MODE.get().copied()
+}
+
+/// Check if we're in ACP or WebSocket mode (structured output modes).
+/// In these modes, stdout/stderr are reserved for protocol communication.
+#[inline]
+pub fn is_structured_output_mode() -> bool {
+	matches!(
+		get_logging_mode(),
+		Some(LoggingMode::Acp | LoggingMode::WebSocket)
+	)
+}
+
+/// Check if tracing is initialized (subscriber has been set).
+#[inline]
+pub fn is_tracing_initialized() -> bool {
+	tracing::dispatcher::has_been_set()
+}
+
+// ============================================================================
+// TRACING INITIALIZATION
+// ============================================================================
+
+/// Initialize tracing for the given mode.
+///
+/// This should be called once at startup.
+/// Sets both the global logging mode and initializes the tracing subscriber.
+pub fn init_tracing(mode: LoggingMode, log_level: &str) -> Result<()> {
+	// Set global logging mode first (even if tracing already initialized)
+	set_logging_mode(mode);
+
+	// Check if already initialized
+	if tracing::dispatcher::has_been_set() {
+		return Ok(());
+	}
+
+	match mode {
+		LoggingMode::Cli => init_cli_logging(log_level),
+		LoggingMode::Acp => init_acp_logging(log_level),
+		LoggingMode::WebSocket => init_websocket_logging(log_level),
+		LoggingMode::Silent => init_silent_logging(),
+	}
+}
+
+/// Initialize CLI logging.
+///
+/// In CLI mode, user-facing output goes through the colored log macros (log_info!, log_debug!,
+/// log_error!) which write directly to stdout/stderr. Tracing is only initialized here if
+/// RUST_LOG is explicitly set, allowing developers to capture internal tracing events.
+fn init_cli_logging(_log_level: &str) -> Result<()> {
+	// Only set up a tracing subscriber if the developer explicitly requested it via RUST_LOG.
+	// Without RUST_LOG, the log macros use colored println/eprintln — no tracing noise for users.
+	if std::env::var("RUST_LOG").is_ok() {
+		let filter = EnvFilter::from_env("RUST_LOG");
+
+		let subscriber = tracing_subscriber::fmt()
+			.with_writer(std::io::stderr)
+			.with_target(false)
+			.with_thread_ids(false)
+			.with_file(false)
+			.with_line_number(false)
+			.with_span_events(FmtSpan::CLOSE)
+			.with_env_filter(filter)
+			.finish();
+
+		tracing::subscriber::set_global_default(subscriber)
+			.with_context(|| "Failed to set tracing subscriber")?;
+	}
+
+	Ok(())
+}
+
+/// Initialize ACP logging (file only, stderr reserved for JSON-RPC).
+fn init_acp_logging(log_level: &str) -> Result<()> {
+	let logs_dir = crate::directories::get_logs_dir()?;
+	let log_file = logs_dir.join("acp-debug.log");
+
+	let file = std::fs::OpenOptions::new()
+		.create(true)
+		.append(true)
+		.open(&log_file)
+		.with_context(|| format!("Failed to open log file: {:?}", log_file))?;
+
+	let filter = create_env_filter(log_level)?;
+
+	let subscriber = tracing_subscriber::fmt()
+		.with_writer(Arc::new(file))
+		.with_target(true)
+		.with_thread_ids(true)
+		.with_file(true)
+		.with_line_number(true)
+		.with_span_events(FmtSpan::CLOSE)
+		.with_env_filter(filter)
+		.finish();
+
+	tracing::subscriber::set_global_default(subscriber)
+		.with_context(|| "Failed to set tracing subscriber")?;
+
+	Ok(())
+}
+
+/// Initialize WebSocket logging (file only).
+fn init_websocket_logging(log_level: &str) -> Result<()> {
+	let logs_dir = crate::directories::get_logs_dir()?;
+	let log_file = logs_dir.join("websocket-debug.log");
+
+	let file = std::fs::OpenOptions::new()
+		.create(true)
+		.append(true)
+		.open(&log_file)
+		.with_context(|| format!("Failed to open log file: {:?}", log_file))?;
+
+	let filter = create_env_filter(log_level)?;
+
+	let subscriber = tracing_subscriber::fmt()
+		.with_writer(Arc::new(file))
+		.with_target(true)
+		.with_thread_ids(true)
+		.with_file(true)
+		.with_line_number(true)
+		.with_span_events(FmtSpan::CLOSE)
+		.with_env_filter(filter)
+		.finish();
+
+	tracing::subscriber::set_global_default(subscriber)
+		.with_context(|| "Failed to set tracing subscriber")?;
+
+	Ok(())
+}
+
+/// Initialize silent logging (no output).
+fn init_silent_logging() -> Result<()> {
+	let subscriber = tracing_subscriber::fmt()
+		.with_writer(std::io::sink)
+		.with_env_filter(EnvFilter::new("off"))
+		.finish();
+
+	tracing::subscriber::set_global_default(subscriber)
+		.with_context(|| "Failed to set tracing subscriber")?;
+
+	Ok(())
+}
+
+/// Create an environment filter from the log level.
+fn create_env_filter(level: &str) -> Result<EnvFilter> {
+	let filter_str = match level.to_lowercase().as_str() {
+		"debug" => "debug",
+		"info" => "info",
+		"warn" => "warn",
+		"error" => "error",
+		"trace" => "trace",
+		"off" => "off",
+		_ => "info",
+	};
+
+	// Allow override via RUST_LOG environment variable
+	let filter = if std::env::var("RUST_LOG").is_ok() {
+		EnvFilter::from_env("RUST_LOG")
+	} else {
+		EnvFilter::new(filter_str)
+	};
+
+	Ok(filter)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_create_env_filter() {
+		// Test that filters are created successfully
+		assert!(create_env_filter("debug").is_ok());
+		assert!(create_env_filter("info").is_ok());
+		assert!(create_env_filter("warn").is_ok());
+		assert!(create_env_filter("error").is_ok());
+		assert!(create_env_filter("trace").is_ok());
+		assert!(create_env_filter("off").is_ok());
+		// Unknown level defaults to info
+		assert!(create_env_filter("unknown").is_ok());
+	}
+
+	#[test]
+	fn test_logging_mode_tracking() {
+		// Test that we can set and get logging mode
+		// Note: OnceLock can only be set once, so we test the getter
+		// The setter is tested implicitly by init_tracing
+		let mode = get_logging_mode();
+		// Mode might be None if tests run before any init
+		assert!(
+			mode.is_none()
+				|| matches!(
+					mode,
+					Some(
+						LoggingMode::Cli
+							| LoggingMode::Acp | LoggingMode::WebSocket
+							| LoggingMode::Silent
+					)
+				)
+		);
+	}
+
+	#[test]
+	fn test_is_structured_output_mode() {
+		// Without initialization, should return false
+		// (or true if a previous test initialized it to Acp/WebSocket)
+		let _ = is_structured_output_mode();
+	}
+
+	#[test]
+	fn test_is_tracing_initialized() {
+		// Test that we can check if tracing is initialized
+		// This should not panic
+		let _ = is_tracing_initialized();
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,23 @@ async fn initialize_mcp_for_role_with_progress(
 }
 
 async fn run_with_cleanup(args: CliArgs, config: Config) -> Result<(), anyhow::Error> {
+	// Initialize tracing based on the command being run.
+	// ACP initializes its own tracing in acp/mod.rs (must happen before LocalSet).
+	// Server initializes in commands/server.rs (needs WebSocket mode).
+	// CLI commands (Session/Run) initialize here so the first log_debug! in main() is covered.
+	let log_level = config.log_level.as_str();
+	match &args.command {
+		Commands::Session(_) | Commands::Run(_) => {
+			if let Err(e) = octomind::logging::tracing_setup::init_tracing(
+				octomind::logging::tracing_setup::LoggingMode::Cli,
+				log_level,
+			) {
+				eprintln!("Warning: Failed to initialize tracing: {e}");
+			}
+		}
+		_ => {}
+	}
+
 	// Initialize MCP servers and tool map once at startup for commands that need them
 	match &args.command {
 		Commands::Session(session_args) => {

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -45,6 +45,7 @@ async fn print_command_output(
 // Run an interactive session
 pub async fn run_interactive_session<T: std::fmt::Debug>(args: &T, config: &Config) -> Result<()> {
 	// Setup and initialize session using helper function
+
 	let (mut chat_session, config_for_role, role, mut first_message_processed) =
 		setup_and_initialize_session(args, config).await?;
 	// Get current directory for file operations - use thread-local if set (ACP/WebSocket), otherwise process cwd
@@ -815,6 +816,7 @@ pub async fn run_interactive_session_with_input<T: std::fmt::Debug>(
 	initial_input: &str,
 ) -> Result<()> {
 	// Setup and initialize session using helper function
+
 	let (mut chat_session, config_for_role, role, first_message_processed) =
 		setup_and_initialize_session(args, config).await?;
 


### PR DESCRIPTION
- Add tracing-subscriber with env-filter support
- Initialize file logging for ACP and WebSocket modes
- Reserve stdout/stderr for JSON-RPC in ACP mode
- Replace println with tracing macros
- Add AcpErrorSink for structured error logging