### PR TITLE
feat(config): support mcp-*.toml override configs and fix auto-bind t…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "octolib"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431c675b9f1a9067060202f9aa2ee4ae4400ca2fc63ed06d21ff466b8870bd44"
+checksum = "d47b940996a9f12b226eb4e1634202aaeb740943a241b0b9487e4c815da7767d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2690,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -137,6 +137,69 @@ All defaults live in `config-templates/default.toml` (782 lines). The resolved c
 
 Config flow: `default.toml` → `load()` in `src/config/loading.rs` → merge with user config → `get_merged_config_for_role()` applies role overrides.
 
+### MCP Server Activation Flow
+
+How a server goes from config TOML to callable tool in a session:
+
+```
+Config::load()
+  └─ load_and_merge_toml_from_directory(config_dir)
+       ├─ regular *.toml files (config.toml, mcp.toml, roles.toml, …) — alphabetical
+       └─ mcp-*.toml override files                                    — alphabetical, LAST
+       merge_toml_values: tables deep-merge, [[arrays of tables]] concat + dedup by `name`
+       (last entry wins → mcp-*.toml overrides anything with the same server name)
+         → toml::Value → Config (serde) → config.mcp.servers = global registry
+         → config.build_role_map() indexes roles by full name (including `domain:spec`)
+
+resolve_config_and_role(tag)       [CLI `run`/`acp`/`server` + `/role`]
+  ├─ plain tag  (`developer`)               → (config, "developer")
+  └─ agent tag (`developer:general`)        → fetch tap manifest, resolve
+                                              capabilities/inputs/env/deps,
+                                              merge_agent_toml(base, manifest),
+                                              inject role name = full tag
+                                              → (merged_config, "developer:general")
+
+get_merged_config_for_role(role)   [src/config/mod.rs]
+  └─ get_enabled_servers_for_role
+       ├─ EXPLICIT : servers named in role.mcp.server_refs
+       └─ AUTO-BIND: servers whose auto_bind contains the role name (exact match,
+                     including `:` — `auto_bind = ["developer:general"]`)
+  └─ PATCH role_map[role] so downstream readers see a consistent view:
+       • server_refs  += auto-bind names
+       • allowed_tools += "<name>:*" for each auto-bind server (ONLY if allowed_tools
+                          was non-empty; empty = unrestricted, nothing to patch)
+  → merged.mcp.servers = only this role's active servers
+
+initialize_mcp_for_role(role, merged_config)
+  ├─ initialize_servers_for_role  — spawns stdio / opens http / registers builtins
+  └─ tool_map::initialize_tool_map — builds global TOOL_MAP
+
+TOOL_MAP (tool_name → McpServerConfig)
+  ├─ config servers   (merged_config.mcp.servers)
+  ├─ dynamic servers  (mcp add/enable at runtime)
+  └─ dynamic agents   (agent add/enable at runtime)
+```
+
+**Load order matters.** `mcp-*.toml` files load AFTER base files (regardless of
+alphabetical position) so they override same-named servers in `mcp.toml`. Without
+this, `mcp.toml` would lexicographically sort after `mcp-foo.toml` and silently
+overwrite the override's fields (e.g. `auto_bind`). See `is_mcp_extension_file`
+in `src/config/loading.rs`.
+
+**Persisted servers** (`mcp persist`): writes `<config_dir>/mcp-<name>.toml` with
+`auto_bind = ["<role>"]`. Picked up automatically on next startup via the
+mcp-override load order above. No manual `server_refs` edit needed.
+
+**`allowed_tools` gotcha**: a non-empty `allowed_tools` list (e.g.
+`["core:*", "filesystem:*"]`) silently filters tools from servers NOT listed.
+`get_merged_config_for_role` auto-appends `"<server>:*"` for every auto-bind
+server to prevent this. Empty list = no restriction, no patching.
+
+**Role name = full tag.** Agent tags like `developer:general` become the literal
+role name in `role_map` and in `auto_bind` matching. An `auto_bind` value of
+`"developer"` will NOT match the tag `"developer:general"` — the colon is part
+of the identity.
+
 ### MCP Tool Routing
 
 1. `initialize_mcp_for_role()` builds the tool map from config-defined servers

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -92,6 +92,15 @@ fn dedup_tables_by_name(arr: Vec<toml::Value>) -> toml::Value {
 
 /// Load and merge all TOML files from a directory
 /// Order: config.toml first, then other *.toml files in alphabetical order
+/// `mcp-*.toml` files are treated as overrides and loaded last.
+/// `mcp.toml` (no dash) is a regular file and loads in normal alphabetical order.
+fn is_mcp_extension_file(path: &Path) -> bool {
+	path.file_name()
+		.and_then(|n| n.to_str())
+		.map(|n| n.starts_with("mcp-") && n.ends_with(".toml"))
+		.unwrap_or(false)
+}
+
 fn load_and_merge_toml_from_directory(dir: &Path) -> Result<toml::Value> {
 	let mut merged: Option<toml::Value> = None;
 
@@ -102,8 +111,18 @@ fn load_and_merge_toml_from_directory(dir: &Path) -> Result<toml::Value> {
 		.filter(|p| p.is_file() && p.extension().map(|e| e == "toml").unwrap_or(false))
 		.collect();
 
-	// Sort for deterministic loading order
-	files.sort();
+	// Load order: all regular files first (alphabetical), then `mcp-*.toml` files last.
+	// `mcp-*.toml` are special overrides — they must merge AFTER the base so their
+	// fields (e.g. `auto_bind`) win when a server with the same name exists in `mcp.toml`.
+	files.sort_by(|a, b| {
+		let a_is_mcp_ext = is_mcp_extension_file(a);
+		let b_is_mcp_ext = is_mcp_extension_file(b);
+		match (a_is_mcp_ext, b_is_mcp_ext) {
+			(true, false) => std::cmp::Ordering::Greater,
+			(false, true) => std::cmp::Ordering::Less,
+			_ => a.cmp(b),
+		}
+	});
 
 	for file in &files {
 		let content = fs::read_to_string(file)
@@ -692,6 +711,188 @@ tools = []
 		assert!(server_names.contains(&"clt"));
 		assert!(!server_names.contains(&"core")); // Should not be included
 		assert!(!server_names.contains(&"filesystem")); // Should not be included
+	}
+
+	/// Config with auto_bind servers for testing auto-bind behavior.
+	/// - `auto_bound` binds to the `developer` role via `auto_bind`
+	/// - `other_bound` binds to `assistant` only (should NOT appear for developer)
+	fn get_test_config_with_auto_bind() -> String {
+		let mut config = include_str!("../../config-templates/default.toml").to_string();
+		config.push_str(
+			r#"
+
+[[roles]]
+name = "developer"
+temperature = 0.3
+top_p = 0.7
+top_k = 20
+system = "Developer."
+welcome = "Hi."
+mcp = { server_refs = ["explicit"], allowed_tools = ["explicit:*"] }
+
+[[roles]]
+name = "assistant"
+temperature = 0.5
+top_p = 0.9
+top_k = 40
+system = "Assistant."
+welcome = "Hi."
+mcp = { server_refs = [], allowed_tools = [] }
+
+[[mcp.servers]]
+name = "explicit"
+type = "stdio"
+command = "explicit"
+args = []
+timeout_seconds = 30
+tools = []
+
+[[mcp.servers]]
+name = "auto_bound"
+type = "stdio"
+command = "auto_bound"
+args = []
+timeout_seconds = 30
+tools = []
+auto_bind = ["developer"]
+
+[[mcp.servers]]
+name = "other_bound"
+type = "stdio"
+command = "other"
+args = []
+timeout_seconds = 30
+tools = []
+auto_bind = ["assistant"]
+"#,
+		);
+		config
+	}
+
+	#[test]
+	fn test_auto_bind_server_appears_in_merged_servers() {
+		let mut config: Config = toml::from_str(&get_test_config_with_auto_bind()).expect("parse");
+		config.build_role_map();
+
+		let merged = config.get_merged_config_for_role("developer");
+		let names: Vec<&str> = merged.mcp.servers.iter().map(|s| s.name()).collect();
+
+		assert!(
+			names.contains(&"explicit"),
+			"explicit server missing: {names:?}"
+		);
+		assert!(
+			names.contains(&"auto_bound"),
+			"auto_bound server missing: {names:?}"
+		);
+		assert!(
+			!names.contains(&"other_bound"),
+			"other_bound should NOT auto-bind to developer: {names:?}"
+		);
+	}
+
+	#[test]
+	fn test_auto_bind_patches_server_refs_in_role_map() {
+		let mut config: Config = toml::from_str(&get_test_config_with_auto_bind()).expect("parse");
+		config.build_role_map();
+
+		let merged = config.get_merged_config_for_role("developer");
+		let role_entry = merged
+			.role_map
+			.get("developer")
+			.expect("developer role must exist");
+
+		assert!(
+			role_entry
+				.mcp
+				.server_refs
+				.contains(&"auto_bound".to_string()),
+			"auto_bound must be added to role_map server_refs, got: {:?}",
+			role_entry.mcp.server_refs
+		);
+		assert!(
+			role_entry.mcp.server_refs.contains(&"explicit".to_string()),
+			"explicit server_ref must survive: {:?}",
+			role_entry.mcp.server_refs
+		);
+	}
+
+	#[test]
+	fn test_auto_bind_patches_allowed_tools_wildcard() {
+		let mut config: Config = toml::from_str(&get_test_config_with_auto_bind()).expect("parse");
+		config.build_role_map();
+
+		let merged = config.get_merged_config_for_role("developer");
+
+		// allowed_tools is non-empty (`explicit:*`) so patching must add `auto_bound:*`
+		assert!(
+			merged
+				.mcp
+				.allowed_tools
+				.contains(&"auto_bound:*".to_string()),
+			"auto_bound:* must be appended to allowed_tools, got: {:?}",
+			merged.mcp.allowed_tools
+		);
+		assert!(
+			merged.mcp.allowed_tools.contains(&"explicit:*".to_string()),
+			"explicit:* must survive: {:?}",
+			merged.mcp.allowed_tools
+		);
+
+		// Role map must mirror the merged allowed_tools.
+		let role_entry = merged.role_map.get("developer").unwrap();
+		assert_eq!(
+			role_entry.mcp.allowed_tools, merged.mcp.allowed_tools,
+			"role_map allowed_tools must match merged.mcp.allowed_tools"
+		);
+	}
+
+	#[test]
+	fn test_auto_bind_empty_allowed_tools_stays_empty() {
+		// When allowed_tools is empty = unrestricted → nothing to patch
+		let mut config_str = get_test_config_with_auto_bind();
+		// swap developer role to have empty allowed_tools
+		config_str = config_str.replace(
+			r#"mcp = { server_refs = ["explicit"], allowed_tools = ["explicit:*"] }"#,
+			r#"mcp = { server_refs = ["explicit"], allowed_tools = [] }"#,
+		);
+
+		let mut config: Config = toml::from_str(&config_str).expect("parse");
+		config.build_role_map();
+
+		let merged = config.get_merged_config_for_role("developer");
+		assert!(
+			merged.mcp.allowed_tools.is_empty(),
+			"empty allowed_tools must remain empty (unrestricted mode), got: {:?}",
+			merged.mcp.allowed_tools
+		);
+		// server_refs still patched even when allowed_tools is empty
+		let role_entry = merged.role_map.get("developer").unwrap();
+		assert!(
+			role_entry
+				.mcp
+				.server_refs
+				.contains(&"auto_bound".to_string()),
+			"auto_bound must still be in server_refs even when allowed_tools is empty"
+		);
+	}
+
+	#[test]
+	fn test_auto_bind_does_not_leak_across_roles() {
+		let mut config: Config = toml::from_str(&get_test_config_with_auto_bind()).expect("parse");
+		config.build_role_map();
+
+		let merged = config.get_merged_config_for_role("assistant");
+		let names: Vec<&str> = merged.mcp.servers.iter().map(|s| s.name()).collect();
+
+		assert!(
+			names.contains(&"other_bound"),
+			"other_bound must bind to assistant: {names:?}"
+		);
+		assert!(
+			!names.contains(&"auto_bound"),
+			"auto_bound (developer-only) must NOT leak to assistant: {names:?}"
+		);
 	}
 
 	#[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -542,10 +542,51 @@ impl Config {
 			crate::log_debug!("TRACE: Adding server '{}' to merged config", server.name());
 		}
 
+		// Auto-bind servers land in enabled_servers but are NOT in role_mcp_config.server_refs.
+		// Downstream code reads server_refs in many places (layers, tool filtering, prompt, command executor).
+		// To keep everything consistent we:
+		//   1. add auto-bind names to server_refs
+		//   2. add "<name>:*" patterns to allowed_tools (only when non-empty = restricted mode)
+		// Both the returned McpConfig AND the role_map entry are patched so any reader sees the same truth.
+		let explicit_refs: std::collections::HashSet<&str> = role_mcp_config
+			.server_refs
+			.iter()
+			.map(|s| s.as_str())
+			.collect();
+		let auto_bind_names: Vec<String> = enabled_servers
+			.iter()
+			.map(|s| s.name().to_string())
+			.filter(|name| !explicit_refs.contains(name.as_str()))
+			.collect();
+
+		let mut patched_server_refs = role_mcp_config.server_refs.clone();
+		for name in &auto_bind_names {
+			if !patched_server_refs.contains(name) {
+				patched_server_refs.push(name.clone());
+			}
+		}
+
+		let mut patched_allowed_tools = role_mcp_config.allowed_tools.clone();
+		if !patched_allowed_tools.is_empty() {
+			for name in &auto_bind_names {
+				let wildcard = format!("{}:*", name);
+				if !patched_allowed_tools.contains(&wildcard) {
+					patched_allowed_tools.push(wildcard);
+				}
+			}
+		}
+
 		merged.mcp = McpConfig {
-			servers: enabled_servers, // Only role-enabled servers (with runtime injection)
-			allowed_tools: role_mcp_config.allowed_tools.clone(),
+			servers: enabled_servers,
+			allowed_tools: patched_allowed_tools.clone(),
 		};
+
+		// Patch the role entry in role_map so downstream readers of
+		// config.role_map[role].mcp.server_refs see auto-bind servers.
+		if let Some(role_entry) = merged.role_map.get_mut(mode) {
+			role_entry.mcp.server_refs = patched_server_refs;
+			role_entry.mcp.allowed_tools = patched_allowed_tools;
+		}
 
 		// Role-specific layers are now managed by workflows
 		// Keep merged.layers as original registry for agent tools

--- a/src/mcp/core/dynamic.rs
+++ b/src/mcp/core/dynamic.rs
@@ -167,51 +167,88 @@ pub async fn enable_server(
 
 /// Disable an enabled server: mark disabled and remove cached functions.
 ///
-/// The server config stays registered; use `enable_server` to re-activate.
-/// Also unregisters the tools from the global tool map.
+/// Works on BOTH dynamic and config-loaded servers:
+/// - Dynamic server already in session registry → flipped to `enabled=false`.
+/// - Config-loaded server (from `config.mcp.servers`, including auto-bound) →
+///   registered into the session's dynamic registry as `enabled=false` so
+///   subsequent `enable`/`persist` actions can find it. Its tools are stripped
+///   from the global TOOL_MAP so the LLM no longer sees them.
 ///
-/// Session-aware: uses session-scoped registry when in a session context,
-/// falls back to global singleton for CLI mode.
-pub fn disable_server(name: &str) -> Result<()> {
-	// Check if we're in a session context
+/// The underlying process (if any) is NOT killed — re-enabling reuses it via
+/// the cached function list.
+///
+/// Also unregisters the tools from the global tool map.
+pub fn disable_server(name: &str, config: Option<&crate::config::Config>) -> Result<()> {
+	// 1. Session-scoped dynamic registry (preferred path for servers already tracked there).
 	if let Some(session_id) = crate::session::context::current_session_id() {
 		if crate::session::context::disable_dynamic_server_for_session(&session_id, name) {
-			// Get tool names before they're removed
-			let tool_names: Vec<String> =
-				crate::session::context::get_dynamic_server_functions_for_session(
-					&session_id,
-					name,
-				)
-				.map(|funcs| funcs.iter().map(|f| f.name.clone()).collect())
-				.unwrap_or_default();
-			// Unregister the tools from the global tool map
+			// Server was in the dynamic registry — collect its cached tool names
+			// BEFORE disable removed them. `disable_dynamic_server_for_session`
+			// already cleared `functions`, so fall back to scanning the tool_map.
+			let tool_names = crate::mcp::tool_map::get_tools_for_server(name);
 			crate::mcp::tool_map::unregister_dynamic_server_tools(name, &tool_names);
-			// Clear the global function cache so stale definitions don't linger
 			crate::mcp::server::clear_function_cache_for_server(name);
 			return Ok(());
 		}
+
+		// 2. Not in dynamic registry — look it up in the merged role config.
+		if let Some(server_config) =
+			config.and_then(|c| c.mcp.servers.iter().find(|s| s.name() == name))
+		{
+			// Register a session-scoped "shadow" entry so persist/enable can see it.
+			crate::session::context::register_dynamic_server_for_session(
+				&session_id,
+				server_config.clone(),
+			);
+			// Strip tools from the global tool_map for this session.
+			let tool_names = crate::mcp::tool_map::get_tools_for_server(name);
+			crate::mcp::tool_map::unregister_dynamic_server_tools(name, &tool_names);
+			crate::mcp::server::clear_function_cache_for_server(name);
+			return Ok(());
+		}
+
 		anyhow::bail!("Server '{}' not found", name);
 	}
 
-	// Fall back to global singleton for CLI mode
+	// CLI / non-session mode — fall back to the global singleton.
 	let manager = get_manager();
 	let mut state = manager.write().unwrap();
-	if !state.servers.contains_key(name) {
-		anyhow::bail!("Server '{}' not found", name);
-	}
-	state.enabled.insert(name.to_string(), false);
-	let tool_names: Vec<String> = state
-		.functions
-		.get(name)
-		.map(|f| f.iter().map(|f| f.name.clone()).collect())
-		.unwrap_or_default();
-	state.functions.remove(name);
-	drop(state); // Release lock before calling tool_map
+	if state.servers.contains_key(name) {
+		state.enabled.insert(name.to_string(), false);
+		let tool_names: Vec<String> = state
+			.functions
+			.get(name)
+			.map(|f| f.iter().map(|f| f.name.clone()).collect())
+			.unwrap_or_default();
+		state.functions.remove(name);
+		drop(state);
 
-	crate::mcp::tool_map::unregister_dynamic_server_tools(name, &tool_names);
-	// Clear the global function cache so stale definitions don't linger
-	crate::mcp::server::clear_function_cache_for_server(name);
-	Ok(())
+		crate::mcp::tool_map::unregister_dynamic_server_tools(name, &tool_names);
+		crate::mcp::server::clear_function_cache_for_server(name);
+		return Ok(());
+	}
+	drop(state);
+
+	// Not dynamic — try the config-loaded servers (CLI path).
+	if let Some(server_config) =
+		config.and_then(|c| c.mcp.servers.iter().find(|s| s.name() == name))
+	{
+		// Stuff it into the global singleton so enable/persist find it later.
+		let manager = get_manager();
+		let mut state = manager.write().unwrap();
+		state
+			.servers
+			.insert(name.to_string(), server_config.clone());
+		state.enabled.insert(name.to_string(), false);
+		drop(state);
+
+		let tool_names = crate::mcp::tool_map::get_tools_for_server(name);
+		crate::mcp::tool_map::unregister_dynamic_server_tools(name, &tool_names);
+		crate::mcp::server::clear_function_cache_for_server(name);
+		return Ok(());
+	}
+
+	anyhow::bail!("Server '{}' not found", name)
 }
 
 /// Remove a dynamic MCP server by name
@@ -420,26 +457,48 @@ pub struct PersistResult {
 /// Writes `<config_dir>/mcp-<name>.toml` with `[[mcp.servers]]` format
 /// so it gets auto-loaded and merged on next startup.
 ///
-/// If the server is currently enabled, sets auto_bind to the current role.
-/// If the server is disabled, clears auto_bind (so it won't auto-activate).
+/// Works on BOTH dynamic and config-loaded servers:
+/// - Dynamic server → uses its `enabled` flag from the session/global registry.
+/// - Config-loaded server (not in the dynamic registry) → treated as enabled,
+///   since config servers that reach this point are actively serving tools.
+///   (A `disable` call registers the server into the dynamic registry with
+///   `enabled=false`, so the dynamic lookup will pick it up as disabled.)
 ///
-/// Session-aware: uses session-scoped registry when in a session context,
-/// falls back to global singleton for CLI mode.
-pub fn persist_server(name: &str) -> Result<PersistResult> {
+/// `auto_bind` rule:
+/// - enabled → `auto_bind = [current_role]` (next session auto-activates it)
+/// - disabled → `auto_bind = None` (file persists but won't auto-load)
+pub fn persist_server(name: &str, config: Option<&crate::config::Config>) -> Result<PersistResult> {
+	// Lookup order: dynamic registry (session or global) first → config servers.
 	let (server, is_enabled) =
 		if let Some(session_id) = crate::session::context::current_session_id() {
-			crate::session::context::get_dynamic_server_for_session(&session_id, name)
-				.ok_or_else(|| anyhow::anyhow!("Server '{}' not registered", name))?
+			if let Some(found) =
+				crate::session::context::get_dynamic_server_for_session(&session_id, name)
+			{
+				found
+			} else if let Some(server_config) =
+				config.and_then(|c| c.mcp.servers.iter().find(|s| s.name() == name))
+			{
+				// Config-loaded server that was never disabled — treat as enabled.
+				(server_config.clone(), true)
+			} else {
+				anyhow::bail!("Server '{}' not found", name);
+			}
 		} else {
 			let manager = get_manager();
 			let state = manager.read().unwrap();
-			let server = state
-				.servers
-				.get(name)
-				.cloned()
-				.ok_or_else(|| anyhow::anyhow!("Server '{}' not registered", name))?;
-			let is_enabled = *state.enabled.get(name).unwrap_or(&false);
-			(server, is_enabled)
+			if let Some(server) = state.servers.get(name).cloned() {
+				let is_enabled = *state.enabled.get(name).unwrap_or(&false);
+				(server, is_enabled)
+			} else {
+				drop(state);
+				if let Some(server_config) =
+					config.and_then(|c| c.mcp.servers.iter().find(|s| s.name() == name))
+				{
+					(server_config.clone(), true)
+				} else {
+					anyhow::bail!("Server '{}' not found", name);
+				}
+			}
 		};
 
 	// Determine auto_bind based on enabled state and current role
@@ -574,9 +633,9 @@ pub async fn execute_mcp_command(
 		"list" => handle_list(call, config).await,
 		"add" => handle_add(call).await,
 		"enable" => handle_enable(call).await,
-		"disable" => handle_disable(call).await,
+		"disable" => handle_disable(call, config).await,
 		"remove" => handle_remove(call).await,
-		"persist" => handle_persist(call).await,
+		"persist" => handle_persist(call, config).await,
 		"unpersist" => handle_unpersist(call).await,
 		_ => Ok(McpToolResult::error(
 			call.tool_name.clone(),
@@ -845,7 +904,10 @@ async fn handle_enable(call: &crate::mcp::McpToolCall) -> Result<McpToolResult> 
 	}
 }
 
-async fn handle_disable(call: &crate::mcp::McpToolCall) -> Result<McpToolResult> {
+async fn handle_disable(
+	call: &crate::mcp::McpToolCall,
+	config: &crate::config::Config,
+) -> Result<McpToolResult> {
 	let params = &call.parameters;
 
 	let name = match params.get("name").and_then(|v| v.as_str()) {
@@ -859,7 +921,7 @@ async fn handle_disable(call: &crate::mcp::McpToolCall) -> Result<McpToolResult>
 		}
 	};
 
-	match disable_server(&name) {
+	match disable_server(&name, Some(config)) {
 		Ok(()) => Ok(McpToolResult::success(
 			call.tool_name.clone(),
 			call.tool_id.clone(),
@@ -902,7 +964,10 @@ async fn handle_remove(call: &crate::mcp::McpToolCall) -> Result<McpToolResult> 
 	}
 }
 
-async fn handle_persist(call: &crate::mcp::McpToolCall) -> Result<McpToolResult> {
+async fn handle_persist(
+	call: &crate::mcp::McpToolCall,
+	config: &crate::config::Config,
+) -> Result<McpToolResult> {
 	let params = &call.parameters;
 
 	let name = match params.get("name").and_then(|v| v.as_str()) {
@@ -916,7 +981,7 @@ async fn handle_persist(call: &crate::mcp::McpToolCall) -> Result<McpToolResult>
 		}
 	};
 
-	match persist_server(&name) {
+	match persist_server(&name, Some(config)) {
 		Ok(result) => {
 			let msg = match &result.auto_bind {
 				Some(roles) => {
@@ -1036,7 +1101,7 @@ mod tests {
 		}
 
 		// Persist — should include auto_bind = ["developer"]
-		let result = persist_server("__test_persist_autobind").unwrap();
+		let result = persist_server("__test_persist_autobind", None).unwrap();
 
 		// Verify the PersistResult
 		assert_eq!(
@@ -1081,7 +1146,7 @@ mod tests {
 		register_server(server).unwrap();
 
 		// Persist while disabled — auto_bind should be None
-		let result = persist_server("__test_persist_disabled").unwrap();
+		let result = persist_server("__test_persist_disabled", None).unwrap();
 
 		assert_eq!(
 			result.auto_bind, None,

--- a/src/mcp/core/skill.rs
+++ b/src/mcp/core/skill.rs
@@ -1068,6 +1068,9 @@ async fn execute_use(call: &McpToolCall, silent: bool) -> Result<McpToolResult, 
 			name,
 			session_id
 		);
+		// Note: silent callers (skill_auto::auto_activate_skill, load_env_skills,
+		// /skill command handler) emit their own structured event since they know
+		// the context (auto-activation vs explicit command vs env load).
 	} else {
 		// Normal mode (AI-initiated): push to inbox for the main loop to process.
 		crate::session::inbox::push_inbox_message(crate::session::inbox::InboxMessage {
@@ -1079,6 +1082,14 @@ async fn execute_use(call: &McpToolCall, silent: bool) -> Result<McpToolResult, 
 			name,
 			session_id
 		);
+
+		// Emit structured lifecycle event for JSONL/WebSocket consumers
+		crate::mcp::process::send_notification_message(crate::websocket::ServerMessage::skill(
+			"use",
+			&name,
+			None,
+			session_id.clone(),
+		));
 	}
 
 	// Return short confirmation — the actual content is injected as a system message
@@ -1166,6 +1177,14 @@ fn execute_forget(call: &McpToolCall) -> Result<McpToolResult, String> {
 	crate::session::context::request_skill_compression(&session_id);
 
 	crate::log_debug!("skill: forgot '{}' from session {}", name, session_id);
+
+	// Emit structured lifecycle event for JSONL/WebSocket consumers
+	crate::mcp::process::send_notification_message(crate::websocket::ServerMessage::skill(
+		"forget",
+		&name,
+		None,
+		session_id.clone(),
+	));
 
 	let msg = if offloaded.is_empty() {
 		format!(

--- a/src/mcp/core/skill.rs
+++ b/src/mcp/core/skill.rs
@@ -1147,7 +1147,7 @@ fn execute_forget(call: &McpToolCall) -> Result<McpToolResult, String> {
 		let remaining =
 			crate::session::context::decrement_capability_refcount(&session_id, server_name);
 		if remaining == 0 {
-			if let Err(e) = crate::mcp::core::dynamic::disable_server(server_name) {
+			if let Err(e) = crate::mcp::core::dynamic::disable_server(server_name, None) {
 				crate::log_debug!("skill: offload disable '{}': {}", server_name, e);
 			}
 			crate::mcp::core::dynamic::remove_server(server_name);

--- a/src/mcp/core/skill_auto.rs
+++ b/src/mcp/core/skill_auto.rs
@@ -115,9 +115,27 @@ pub async fn load_env_skills(session: &mut crate::session::chat::session::ChatSe
 				if let Some(content) = super::skill::take_silent_skill_content() {
 					let _ = session.add_user_message(&content);
 				}
+				// Emit structured event for JSONL/WebSocket consumers
+				if let Some(sid) = &session_id {
+					crate::mcp::process::send_notification_message(
+						crate::websocket::ServerMessage::skill(
+							"activate",
+							&name_str,
+							Some("env(OCTOMIND_SKILLS)".to_string()),
+							sid.clone(),
+						),
+					);
+				}
 			}
 			Err(e) => {
-				eprintln!("OCTOMIND_SKILLS: skill '{}' failed: {}", name, e);
+				let suppress = crate::config::with_thread_config(|c| c.output_mode())
+					.map(|m| m.should_suppress_cli_output())
+					.unwrap_or(false);
+				if !suppress {
+					eprintln!("OCTOMIND_SKILLS: skill '{}' failed: {}", name, e);
+				} else {
+					crate::log_debug!("OCTOMIND_SKILLS: skill '{}' failed: {}", name, e);
+				}
 			}
 		}
 	}
@@ -348,7 +366,24 @@ async fn auto_activate_skill(
 			if let Some(content) = super::skill::take_silent_skill_content() {
 				let _ = session.add_user_message(&content);
 			}
-			if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+
+			// Emit structured event for JSONL/WebSocket consumers
+			if let Some(sid) = crate::session::context::current_session_id() {
+				crate::mcp::process::send_notification_message(
+					crate::websocket::ServerMessage::skill(
+						"activate",
+						name,
+						Some(trigger.to_string()),
+						sid,
+					),
+				);
+			}
+
+			// Plain-text print: only when not suppressing CLI output (i.e. skip for jsonl/websocket)
+			let suppress = crate::config::with_thread_config(|c| c.output_mode())
+				.map(|m| m.should_suppress_cli_output())
+				.unwrap_or(false);
+			if !suppress && std::io::IsTerminal::is_terminal(&std::io::stderr()) {
 				use colored::Colorize;
 				eprintln!(
 					"{} {} {}",

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -359,7 +359,18 @@ pub async fn get_available_functions(config: &crate::config::Config) -> Vec<McpF
 	}
 
 	let mut functions = Vec::new();
+	let session_id = crate::session::context::current_session_id();
 	for server in &config.mcp.servers {
+		// Skip config servers that are disabled in the dynamic registry
+		if let Some(ref sid) = session_id {
+			if let Some((_, enabled)) =
+				crate::session::context::get_dynamic_server_for_session(sid, server.name())
+			{
+				if !enabled {
+					continue;
+				}
+			}
+		}
 		functions.extend(server_functions_for(server, config).await);
 	}
 

--- a/src/mcp/tool_map.rs
+++ b/src/mcp/tool_map.rs
@@ -162,6 +162,38 @@ pub fn get_all_tool_names() -> Vec<String> {
 	state.tool_to_server.keys().cloned().collect()
 }
 
+/// Get all tool names that belong to a given server in the initialized tool map.
+///
+/// Used by the `mcp` tool's `disable` action to temporarily strip a
+/// config-loaded server's tools from the session's tool map.
+///
+/// # Returns
+/// * Vector of tool names belonging to `server_name`.
+/// * Empty vector if not initialized or the server has no tools registered.
+pub fn get_tools_for_server(server_name: &str) -> Vec<String> {
+	let tool_map_state = match TOOL_MAP.get() {
+		Some(state) => state,
+		None => return Vec::new(),
+	};
+
+	let state = tool_map_state.read().unwrap();
+	if !state.initialized {
+		return Vec::new();
+	}
+
+	state
+		.tool_to_server
+		.iter()
+		.filter_map(|(tool, server)| {
+			if server.name() == server_name {
+				Some(tool.clone())
+			} else {
+				None
+			}
+		})
+		.collect()
+}
+
 /// Get all unique server names from the initialized tool map
 ///
 /// # Returns

--- a/src/mcp/tool_map.rs
+++ b/src/mcp/tool_map.rs
@@ -319,8 +319,20 @@ pub fn unregister_dynamic_server_tools(server_name: &str, tool_names: &[String])
 async fn build_tool_server_map_impl(config: &Config) -> Result<HashMap<String, McpServerConfig>> {
 	let mut tool_map = HashMap::new();
 	let enabled_servers: Vec<McpServerConfig> = config.mcp.servers.to_vec();
+	let session_id = crate::session::context::current_session_id();
 
 	for server in enabled_servers {
+		// Skip config servers that are disabled in the dynamic registry
+		if let Some(ref sid) = session_id {
+			if let Some((_, enabled)) =
+				crate::session::context::get_dynamic_server_for_session(sid, server.name())
+			{
+				if !enabled {
+					continue;
+				}
+			}
+		}
+
 		// Get all functions this server provides
 		let server_functions = match server.connection_type() {
 			McpConnectionType::Builtin => {

--- a/src/session/chat/session/commands/skill.rs
+++ b/src/session/chat/session/commands/skill.rs
@@ -213,6 +213,12 @@ async fn handle_use(session: &mut ChatSession, name: &str) -> Result<CommandResu
 			if let Some(content) = crate::mcp::core::skill::take_silent_skill_content() {
 				let _ = session.add_user_message(&content);
 			}
+			// Emit structured lifecycle event for JSONL/WebSocket consumers
+			if let Some(sid) = crate::session::context::current_session_id() {
+				crate::mcp::process::send_notification_message(
+					crate::websocket::ServerMessage::skill("use", name, None, sid),
+				);
+			}
 		}
 		Err(e) => {
 			let data = json!({"subcommand": "error", "message": format!("Error: {}", e)});

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -166,15 +166,23 @@ pub async fn run_interactive_session<T: std::fmt::Debug>(args: &T, config: &Conf
 
 		// Done initializing — clear spinner, print skills
 		if let Some(sp) = spinner {
-			// Print skills through spinner before clearing
-			if let Some(sid) = crate::session::context::current_session_id() {
-				let active = crate::session::context::get_active_skills(&sid);
-				for name in &active {
-					sp.println(format!(
-						"{} {}",
-						"Using skill:".dimmed(),
-						name.bright_cyan()
-					));
+			// Print skills through spinner before clearing.
+			// Guard with should_suppress_cli_output so JSONL/WebSocket modes don't
+			// leak plain-text "Using skill:" lines into structured output — the
+			// Skill(activate) events emitted via notification_sender cover those modes.
+			let suppress = crate::config::with_thread_config(|c| c.output_mode())
+				.map(|m| m.should_suppress_cli_output())
+				.unwrap_or(false);
+			if !suppress {
+				if let Some(sid) = crate::session::context::current_session_id() {
+					let active = crate::session::context::get_active_skills(&sid);
+					for name in &active {
+						sp.println(format!(
+							"{} {}",
+							"Using skill:".dimmed(),
+							name.bright_cyan()
+						));
+					}
 				}
 			}
 			sp.disable_steady_tick();

--- a/src/websocket/protocol.rs
+++ b/src/websocket/protocol.rs
@@ -159,6 +159,22 @@ pub struct ErrorPayload {
 	pub message: String,
 }
 
+/// Skill lifecycle event (activate via auto-activation, explicit use, or forget).
+/// Emitted for structured output modes (JSONL, WebSocket) so clients can track
+/// which skills are currently shaping the session context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillPayload {
+	/// Lifecycle action: "activate" (auto-activation), "use" (explicit), "forget".
+	pub action: String,
+	/// Skill name (e.g. "programming-rust").
+	pub name: String,
+	/// For `action = "activate"`: the matched rule that fired (e.g. "file(Cargo.toml)").
+	/// Absent for explicit use/forget.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub trigger: Option<String>,
+	pub session_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpNotificationPayload {
 	/// MCP server name that sent the notification
@@ -190,6 +206,8 @@ pub enum ServerMessage {
 	Error(ErrorPayload),
 	/// Notification received from an MCP server (e.g. progress, log messages)
 	McpNotification(McpNotificationPayload),
+	/// Skill lifecycle event (activate / use / forget) — emitted for structured output
+	Skill(SkillPayload),
 }
 
 impl ServerMessage {
@@ -202,6 +220,20 @@ impl ServerMessage {
 			message,
 			session_id,
 			data: None,
+		})
+	}
+
+	pub fn skill(
+		action: impl Into<String>,
+		name: impl Into<String>,
+		trigger: Option<String>,
+		session_id: impl Into<String>,
+	) -> Self {
+		ServerMessage::Skill(SkillPayload {
+			action: action.into(),
+			name: name.into(),
+			trigger,
+			session_id: session_id.into(),
 		})
 	}
 }
@@ -474,6 +506,30 @@ mod tests {
 		let json = serde_json::to_string(&msg).unwrap();
 		assert!(json.contains("\"type\":\"cost\""));
 		assert!(json.contains("\"session_tokens\":1234"));
+	}
+
+	#[test]
+	fn test_server_message_skill_serialization_with_trigger() {
+		let msg = ServerMessage::skill(
+			"activate",
+			"programming-rust",
+			Some("file(Cargo.toml)".to_string()),
+			"sess_123",
+		);
+		let json = serde_json::to_string(&msg).unwrap();
+		assert!(json.contains("\"type\":\"skill\""));
+		assert!(json.contains("\"action\":\"activate\""));
+		assert!(json.contains("\"name\":\"programming-rust\""));
+		assert!(json.contains("\"trigger\":\"file(Cargo.toml)\""));
+	}
+
+	#[test]
+	fn test_server_message_skill_serialization_without_trigger() {
+		let msg = ServerMessage::skill("forget", "programming-rust", None, "sess_123");
+		let json = serde_json::to_string(&msg).unwrap();
+		assert!(json.contains("\"type\":\"skill\""));
+		assert!(json.contains("\"action\":\"forget\""));
+		assert!(!json.contains("trigger"));
 	}
 
 	#[test]


### PR DESCRIPTION
…racking

- Document MCP server activation flow
- Add is_mcp_extension_file() helper to identify override files
- Load order: regular configs first, then mcp-*.toml overrides last
- Override files merge after base so their fields win for same server names
- Track auto-bind servers in server_refs to match enabled_servers
- Patch both merged.mcp and role_map for consistent downstream data
- Add wildcard patterns to allowed_tools only in restricted mode
- Add tests for auto_bind server injection into role configs
- Ensure auto_bind does not leak servers across role boundaries