### PR TITLE
feat(mcp): implement margin gate for semantic skill activation

### DIFF
--- a/src/mcp/core/skill.rs
+++ b/src/mcp/core/skill.rs
@@ -55,12 +55,24 @@ pub struct SkillMeta {
 	/// Declarative activation rules. Empty = manual only.
 	pub rules: Vec<Vec<ActivateCheck>>,
 }
-/// Default cosine threshold for `semantic(phrase)` checks. Looser than the
-/// capability auto-activation threshold (0.42 + 0.05 margin) because the
-/// skill DSL composes via DNF — a single semantic check is one signal in
-/// an AND-group, not the whole gate. Authors override per check via
-/// `semantic(phrase, 0.55)` syntax.
-pub const SEMANTIC_DEFAULT_THRESHOLD: f32 = 0.45;
+/// Default cosine floor for `semantic(phrase)` checks. Empirically tuned for
+/// BGE-small-en-v1.5: at 0.45 long mixed-topic prompts produce a flood of
+/// loosely-related matches (e.g. a "humanize the landing page" prompt clears
+/// `marketing-guest-posting` paraphrases purely on lexical overlap with
+/// "blogs"/"landing"). 0.55 is the floor where most lexical-overlap noise
+/// drops out; the actual precision lever is the margin gate applied across
+/// candidate skills in `skill_auto`. Authors override per check via
+/// `semantic(phrase, 0.6)` syntax.
+pub const SEMANTIC_DEFAULT_THRESHOLD: f32 = 0.55;
+
+/// Required gap between top-1 and top-2 semantic-only skill scores in a
+/// single activation cycle. Mirrors `capability::AUTO_ACTIVATE_MARGIN`. When
+/// two skills are near-tied on cosine (typical for ambiguous prompts where
+/// "landing page" pulls marketing/copy/ad skills together), neither fires
+/// — better to abstain than activate the wrong one. Skills that match via
+/// any deterministic check (file/content/grep/match/etc.) bypass this gate;
+/// hand-authored regex/keyword rules are precise by construction.
+pub const SEMANTIC_MARGIN: f32 = 0.05;
 
 /// Individual activation check within a group.
 #[derive(Debug, Clone)]

--- a/src/mcp/core/skill_auto.rs
+++ b/src/mcp/core/skill_auto.rs
@@ -371,35 +371,108 @@ pub async fn run_activation(
 	let semantic_scores = compute_semantic_scores(content, &entries, &active_skills).await;
 	let semantic_ref = semantic_scores.as_ref();
 
+	// Bucket each skill into one of three outcomes:
+	//   - deterministic match: a fully-non-semantic AND-group matched
+	//     (file/content/grep/match/env/bin/session/workdir). These are
+	//     hand-authored, precise — fire unconditionally, no margin gate.
+	//   - semantic candidate: only semantic-bearing groups matched. The
+	//     skill enters a winner-take-all selection where the top scorer
+	//     must beat #2 by SEMANTIC_MARGIN to fire. Prevents the avalanche
+	//     where ambiguous prompts ("rewrite my landing page text") clear
+	//     the floor for many marketing/copy skills at once.
+	//   - no match: skipped silently.
+	let mut deterministic: Vec<(String, String)> = Vec::new();
+	let mut semantic_candidates: Vec<(f32, String, String)> = Vec::new();
+
 	for entry in &entries {
 		if active_skills.contains(&entry.name) {
 			continue;
 		}
 
-		// Evaluate AND-groups in order; first fully-matching group wins and
-		// becomes the trigger we surface to the user.
-		let mut matched: Option<String> = None;
+		let mut det_trigger: Option<String> = None;
+		let mut sem_best: Option<(f32, String)> = None;
+
 		for group in &entry.rules {
-			if group
+			if !group
 				.iter()
 				.all(|check| check.matches(content, workdir, &session_name, semantic_ref))
 			{
-				matched = Some(
-					group
-						.iter()
-						.map(|c| c.to_string())
-						.collect::<Vec<_>>()
-						.join(" "),
-				);
+				continue;
+			}
+
+			let trigger = group
+				.iter()
+				.map(|c| c.to_string())
+				.collect::<Vec<_>>()
+				.join(" ");
+
+			let has_semantic = group
+				.iter()
+				.any(|c| matches!(c, super::skill::ActivateCheck::Semantic { .. }));
+
+			if !has_semantic {
+				det_trigger = Some(trigger);
 				break;
+			}
+
+			let group_score = group
+				.iter()
+				.filter_map(|c| match c {
+					super::skill::ActivateCheck::Semantic { phrase, .. } => {
+						semantic_ref.and_then(|s| s.get(phrase)).copied()
+					}
+					_ => None,
+				})
+				.fold(f32::NEG_INFINITY, f32::max);
+
+			let group_score = if group_score.is_finite() {
+				group_score
+			} else {
+				0.0
+			};
+
+			match &sem_best {
+				Some((best, _)) if group_score <= *best => {}
+				_ => sem_best = Some((group_score, trigger)),
 			}
 		}
 
-		if let Some(trigger) = matched {
-			crate::log_debug!("skill_auto: activated '{}' via [{}]", entry.name, trigger);
-			auto_activate_skill(&entry.name, &trigger, session).await;
+		if let Some(trigger) = det_trigger {
+			deterministic.push((entry.name.clone(), trigger));
+		} else if let Some((score, trigger)) = sem_best {
+			semantic_candidates.push((score, entry.name.clone(), trigger));
 		} else {
 			crate::log_debug!("skill_auto: no rule matched for '{}'", entry.name);
+		}
+	}
+
+	for (name, trigger) in &deterministic {
+		crate::log_debug!("skill_auto: activated '{}' via [{}]", name, trigger);
+		auto_activate_skill(name, trigger, session).await;
+	}
+
+	semantic_candidates.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+	if let Some((top1, name, trigger)) = semantic_candidates.first().cloned() {
+		let top2 = semantic_candidates.get(1).map(|x| x.0).unwrap_or(0.0);
+		if top1 - top2 >= super::skill::SEMANTIC_MARGIN {
+			crate::log_debug!(
+				"skill_auto: activated '{}' via [{}] (semantic top1={:.3}, top2={:.3}, margin ok)",
+				name,
+				trigger,
+				top1,
+				top2
+			);
+			auto_activate_skill(&name, &trigger, session).await;
+		} else {
+			crate::log_debug!(
+				"skill_auto: {} semantic candidate(s) abstained — top1={:.3} top2={:.3} gap {:.3} < {} (winner: '{}')",
+				semantic_candidates.len(),
+				top1,
+				top2,
+				top1 - top2,
+				super::skill::SEMANTIC_MARGIN,
+				name
+			);
 		}
 	}
 }

--- a/src/session/chat/edit_mode.rs
+++ b/src/session/chat/edit_mode.rs
@@ -85,14 +85,74 @@ impl EmacsWithShortcutHelp {
 	}
 }
 
-/// Probe the clipboard synchronously. Image takes priority; otherwise inspect
-/// the text clipboard for a path/file URL pointing to a supported video file.
+/// Probe the clipboard synchronously. A video file reference takes priority
+/// over the image representation, because macOS Finder exposes BOTH a file
+/// URL (NSURL pasteboard / `«class furl»`) AND a thumbnail icon when a video
+/// file is copied — without this ordering we would attach the thumbnail and
+/// silently drop the actual video. Falls back to the clipboard image otherwise.
 /// Returns `None` if nothing usable is on the clipboard.
 fn try_capture_clipboard() -> Option<PendingClipboardItem> {
+	if let Some(video) = try_capture_clipboard_video() {
+		return Some(PendingClipboardItem::Video(video));
+	}
+
 	if let Ok(Some(image)) = ImageProcessor::load_from_clipboard() {
 		return Some(PendingClipboardItem::Image(image));
 	}
 
+	None
+}
+
+/// Resolve a clipboard reference to a supported video file.
+///
+/// On macOS, Finder copies put the absolute file path on the NSURL pasteboard
+/// (`«class furl»`) while the text pasteboard holds only the bare filename.
+/// We query NSURL via `osascript` first, then fall back to a text-path probe
+/// for users who manually copied an absolute path or `file://` URL.
+fn try_capture_clipboard_video() -> Option<crate::session::video::VideoAttachment> {
+	#[cfg(target_os = "macos")]
+	if let Some(att) = try_capture_clipboard_video_furl_macos() {
+		return Some(att);
+	}
+
+	try_capture_clipboard_video_text()
+}
+
+/// macOS-only: ask AppleScript for the POSIX path of a file URL on the
+/// clipboard. Returns `None` if no `furl` is present or it isn't a supported
+/// video file.
+#[cfg(target_os = "macos")]
+fn try_capture_clipboard_video_furl_macos() -> Option<crate::session::video::VideoAttachment> {
+	let output = std::process::Command::new("osascript")
+		.args([
+			"-e",
+			"try",
+			"-e",
+			"POSIX path of (the clipboard as «class furl»)",
+			"-e",
+			"end try",
+		])
+		.output()
+		.ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let path_str = String::from_utf8(output.stdout).ok()?;
+	let trimmed = path_str.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	let path = std::path::PathBuf::from(trimmed);
+	if !path.is_file() || !VideoProcessor::is_supported_video(&path) {
+		return None;
+	}
+	VideoProcessor::load_from_path(&path).ok()
+}
+
+/// Inspect the text clipboard for a single path/file URL pointing to a
+/// supported video file. Used as a fallback for users who copied a typed
+/// path (e.g. from a terminal) and on platforms without a file-URL pasteboard.
+fn try_capture_clipboard_video_text() -> Option<crate::session::video::VideoAttachment> {
 	let mut clipboard = arboard::Clipboard::new().ok()?;
 	let text = clipboard.get_text().ok()?;
 	let trimmed = text.trim();
@@ -111,9 +171,7 @@ fn try_capture_clipboard() -> Option<PendingClipboardItem> {
 		return None;
 	}
 
-	VideoProcessor::load_from_path(&expanded)
-		.ok()
-		.map(PendingClipboardItem::Video)
+	VideoProcessor::load_from_path(&expanded).ok()
 }
 
 fn format_image_label(att: &crate::session::image::ImageAttachment) -> String {


### PR DESCRIPTION
- Increase default semantic threshold from 0.45 to 0.55
- Add margin gate to prevent activation on ambiguous semantic matches
- Separate deterministic matches from semantic-only candidates
- Allow deterministic rules to bypass the winner-take-all margin gate
- Sort semantic candidates and require 0.05 gap between top scores