### PR TITLE
feat(mcp): delegate tap-run execution to external ACP subprocess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -527,7 +527,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -979,7 +979,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2283,7 +2283,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3193,7 +3193,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3252,7 +3252,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3811,7 +3811,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4663,7 +4663,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4737,7 +4737,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4746,16 +4746,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4773,31 +4764,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4807,22 +4781,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4831,22 +4793,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4855,22 +4805,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4879,22 +4817,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -173,7 +173,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
 dependencies = [
  "clap",
 ]
@@ -527,7 +527,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1595,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2424,9 +2424,9 @@ dependencies = [
 
 [[package]]
 name = "octolib"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a48c8b9d580511ddd1e7d241e2fe45dbcb87ff0a8c8df52c3dd66f259904d2"
+checksum = "296b110a5974266f1fa12e32cc05751de3a676e72fc6f14e72ba529ce19a45a7"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2830,7 +2830,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3193,7 +3193,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3252,7 +3252,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3642,7 +3642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3811,7 +3811,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4663,7 +4663,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4737,7 +4737,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4746,7 +4746,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4764,14 +4773,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4781,10 +4807,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4793,10 +4831,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4805,10 +4855,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4817,10 +4879,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ overflow-checks = false # Disable overflow checks in release mode
 
 [dependencies]
 # octolib = { path = "../octolib", default-features = false, features = ["fastembed"] }
-octolib = { version = "0.21.0", default-features = false, features = ["fastembed"] }
+octolib = { version = "0.21.1", default-features = false, features = ["fastembed"] }
 rmcp = { version = "1.6.0", default-features = false }
 
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time", "process", "fs", "sync", "signal", "io-std", "net"] }
@@ -49,7 +49,7 @@ rustls-webpki = ">=0.103.12"
 anyhow = "1.0.102"
 serde_json = "1.0.149"
 clap = { version = "4.6.1", features = ["derive"] }
-clap_complete = "4.6.3"
+clap_complete = "4.6.4"
 toml = "1.1"
 lazy_static = "1.5.0"
 fuzzy-matcher = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,23 +34,23 @@ overflow-checks = false # Disable overflow checks in release mode
 [dependencies]
 # octolib = { path = "../octolib", default-features = false, features = ["fastembed"] }
 octolib = { version = "0.21.0", default-features = false, features = ["fastembed"] }
-rmcp = { version = "1.4.0", default-features = false }
+rmcp = { version = "1.6.0", default-features = false }
 
-tokio = { version = "1.52.0", features = ["rt-multi-thread", "macros", "time", "process", "fs", "sync", "signal", "io-std", "net"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time", "process", "fs", "sync", "signal", "io-std", "net"] }
 crossterm = "0.29.0"
 indicatif = "0.18.4"
 parking_lot = "0.12.5"
 chrono = { version = "0.4.44", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
-uuid = { version = "1.20.0", features = ["v4"] }
+uuid = { version = "1.23.1", features = ["v4"] }
 tiktoken-rs = "0.11.0" # Token counter
-reqwest = { version = "0.13.2", features = ["json", "rustls", "gzip"], default-features = false }
+reqwest = { version = "0.13.3", features = ["json", "rustls", "gzip"], default-features = false }
 rustls-webpki = ">=0.103.12"
 anyhow = "1.0.102"
 serde_json = "1.0.149"
-clap = { version = "4.5.61", features = ["derive"] }
-clap_complete = "4.5.67"
-toml = "1.0"
+clap = { version = "4.6.1", features = ["derive"] }
+clap_complete = "4.6.3"
+toml = "1.1"
 lazy_static = "1.5.0"
 fuzzy-matcher = "0.3.7"
 tokio-util = { version = "0.7", features = ["rt", "compat"] }
@@ -69,7 +69,7 @@ ignore = "0.4.25"
 futures = "0.3.32"
 dotenvy = "0.15.7"
 arboard = "3.6.1"
-image = { version = "0.25.6", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 viuer = "0.11.0"
 base64 = "0.22"
 urlencoding = "2.1.3"

--- a/doc/README.md
+++ b/doc/README.md
@@ -30,6 +30,7 @@ For users working with Octomind day-to-day.
 | [Learning](usage/13-learning.md) | Cross-session adaptive learning |
 | [Skills](usage/15-skills.md) | Auto-expanding skills, capabilities, validators |
 | [Token Efficiency](usage/16-token-efficiency.md) | Capabilities, auto-activation, LRU eviction |
+| [Local Tools](usage/17-local-tools.md) | Project-local shebang scripts auto-exposed as MCP tools |
 
 ## Integration Guide
 

--- a/doc/usage/07-mcp-tools.md
+++ b/doc/usage/07-mcp-tools.md
@@ -4,13 +4,14 @@ Octomind uses the Model Context Protocol (MCP) to provide AI models with externa
 
 ## Architecture
 
-Octomind ships with four MCP servers:
+Octomind ships with five MCP servers:
 
 | Server | Type | Description |
 |--------|------|-------------|
 | `core` | builtin | High-level day-to-day tools: planning, scheduling, capability discovery, tap-role launch |
 | `runtime` | builtin | Low-level harness reconfiguration: register MCP servers, manage dynamic agents, load skills |
 | `agent` | builtin | Delegates tasks to configured ACP sub-agents (each `[[agents]]` entry exposes an `agent_<name>` tool) |
+| `local` | builtin | Project-local shebang-script tools auto-discovered from `<workdir>/.agents/tools/`. See [Local Tools](17-local-tools.md). |
 | `filesystem` | stdio (`octofs`) | File operations, shell commands, code analysis |
 
 `core` and `runtime` are the two split halves of what used to be a single `core` server. The split separates "what the agent uses to do work" (`core`) from "what reconfigures the harness mid-session" (`runtime`).

--- a/doc/usage/17-local-tools.md
+++ b/doc/usage/17-local-tools.md
@@ -1,0 +1,194 @@
+# Local Tools
+
+Drop a shebang script into `<workdir>/.agents/tools/<name>` and it becomes an MCP tool — auto-discovered, role-agnostic, no config required. The script's leading comment block declares the schema; octomind converts it to a JSON-Schema tool definition the model can call.
+
+This is the lightweight cousin of [Skills](15-skills.md). Skills inject **instructions**; local tools expose **executable actions**. Use local tools when the project itself wants to bolt on an action ("publish to staging", "check this lint rule", "fetch our internal status board") without touching the role config or shipping a full MCP server.
+
+## Quickstart
+
+```bash
+mkdir -p .agents/tools
+cat > .agents/tools/echo <<'EOF'
+#!/usr/bin/env bash
+# @description Echo a message back, optionally uppercased.
+# @param *message string The text to echo
+# @param uppercase boolean Uppercase the output
+
+if [[ "${OCTOMIND_PARAM_UPPERCASE:-false}" == "true" ]]; then
+  printf '%s\n' "$OCTOMIND_PARAM_MESSAGE" | tr '[:lower:]' '[:upper:]'
+else
+  printf '%s\n' "$OCTOMIND_PARAM_MESSAGE"
+fi
+EOF
+chmod +x .agents/tools/echo
+
+octomind run developer:general
+```
+
+In the session, the model now sees `echo` under server `local`.
+
+## File Contract
+
+| Aspect | Rule |
+|---|---|
+| **Path** | `<workdir>/.agents/tools/<tool-name>` (no extension) |
+| **Tool name** | The filename. Must match `[A-Za-z0-9_-]+`. Hidden files and bad names skipped. |
+| **Executable** | Must be `chmod +x`. Non-executable files are skipped (logged at debug). |
+| **Shebang** | Line 1 may be a `#!...` shebang. Skipped during header parsing. Required for the OS to actually run the file. |
+| **Header** | Leading comment block. Comment prefixes `#`, `//`, `--` are recognized. Parsing stops at the first non-comment, non-blank line, or after 80 lines. |
+
+Any `#`-comment language works (bash, python, ruby, lua, perl, R, julia, awk, …). For `//` use Node/Deno (the interpreter strips the shebang itself); for `--` use Lua/Haskell/SQL-shell wrappers.
+
+## Header Schema
+
+```bash
+#!/usr/bin/env bash
+# @description Short summary the model sees in the tool list. Continuation
+# lines without an @ tag append to the previous tag — keep multi-line
+# descriptions readable.
+# @param *target string Path to operate on
+# @param force boolean Overwrite if the destination exists
+# @param count integer Number of iterations
+```
+
+### Tags
+
+| Tag | Required | Notes |
+|---|---|---|
+| `@description` (or `@desc`) | yes | Free text. Continuation lines (no leading `@`) append to it. |
+| `@param NAME TYPE DESC` | repeatable | Declares a parameter. See below. |
+
+Unknown tags are ignored with a debug log so the format can grow without breaking existing tools.
+
+### Parameter syntax
+
+```
+@param [*]NAME TYPE DESCRIPTION...
+```
+
+- **Required** — prefix the name with `*` (e.g. `*target`). Mirrors how octomind renders required params in `/tools` output.
+- **Optional** — no prefix. This is the default.
+- **TYPE** — one of `string`, `number`, `integer`, `boolean`, `array`, `object`. Common aliases (`str`, `int`, `bool`, `list`, `obj`) are normalized. Unknown types fall back to `string`.
+- **DESCRIPTION** — everything after the type, joined with single spaces. Shown in the tool's parameter docs.
+
+Example with all flavors:
+
+```bash
+# @param *target string  Required path argument
+# @param force boolean   Optional flag (no * prefix)
+# @param count integer   Optional, default behavior left to the script
+# @param tags array      Optional list, JSON-encoded on stdin
+```
+
+### Schema generation
+
+The header is converted to a standard JSON-Schema tool definition:
+
+```json
+{
+  "name": "echo",
+  "description": "Echo a message back, optionally uppercased.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "message":   {"type": "string",  "description": "The text to echo"},
+      "uppercase": {"type": "boolean", "description": "Uppercase the output"}
+    },
+    "required": ["message"]
+  }
+}
+```
+
+The model's harness validates against this schema before the tool runs — required-param enforcement, type checking, and per-tool documentation come for free.
+
+## Calling Convention
+
+When the model invokes the tool, octomind spawns the script with:
+
+| Channel | Contains |
+|---|---|
+| **stdin** | JSON object of all params (`{"message":"hi","uppercase":true}`). One write, then EOF. |
+| **env `OCTOMIND_PARAM_<UPPER>`** | Each param as a separate env var. Strings/numbers/bools become their natural string form; arrays/objects are JSON-stringified. |
+| **env `OCTOMIND_TOOL_NAME`** | The tool name, in case one binary handles multiple. |
+| **env `OCTOMIND_WORKDIR`** | The session's working directory (also `cwd`). |
+| **stdout** | Result content shown to the model. |
+| **stderr** | Appended to the result with an `[stderr]` marker. |
+| **exit code** | Non-zero → reported as a tool error (stderr + stdout included in the message). |
+
+Pick whichever input style fits the language. Bash scripts usually read env vars; Python scripts often parse stdin JSON. Both arrive every call.
+
+### Bash example (env-driven)
+
+```bash
+#!/usr/bin/env bash
+# @description Greet someone politely.
+# @param *who string Person to greet
+# @param shout boolean Yell the greeting
+set -euo pipefail
+greeting="Hello, ${OCTOMIND_PARAM_WHO}"
+[[ "${OCTOMIND_PARAM_SHOUT:-false}" == "true" ]] && greeting="${greeting^^}!"
+printf '%s\n' "$greeting"
+```
+
+### Python example (stdin JSON)
+
+```python
+#!/usr/bin/env python3
+# @description Sum a list of integers.
+# @param *values array JSON list of integers, e.g. [1,2,3]
+import json, sys
+params = json.load(sys.stdin)
+print(sum(params["values"]))
+```
+
+### Node example
+
+```javascript
+#!/usr/bin/env node
+// @description Capitalize a string.
+// @param *text string Input text
+let buf = '';
+process.stdin.on('data', d => buf += d);
+process.stdin.on('end', () => {
+  const { text } = JSON.parse(buf || '{}');
+  console.log(text.toUpperCase());
+});
+```
+
+## Discovery & Lifecycle
+
+- **When**: every turn. Discovery is a `read_dir` of `<workdir>/.agents/tools/` plus a header parse per file. Cheap, no caching needed.
+- **Where**: the **session's current working directory**. If the workdir tool changes the directory mid-session, the next turn's tool list reflects the new location.
+- **Always-on**: appended to every role's tool list automatically. There is no `[mcp.servers]` entry to add and no `allowed_tools` filter — local tools are role-agnostic by design (matches the `OCTOMIND_SKILLS` shape, but driven by file presence rather than env).
+- **Lowest priority on collision**: if a local tool's name matches a config-defined or dynamic tool, the config/dynamic tool wins. You can't accidentally hijack `shell` by naming a script `shell`.
+- **Hot reload**: edit a file and save — the next tool call sees the new schema/body. No session restart needed.
+
+## Errors and Edge Cases
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tool doesn't appear in `/tools` | Not executable | `chmod +x .agents/tools/<name>` |
+| Tool doesn't appear in `/tools` | Header missing `@description` | Add the line; debug log shows `parse … failed: missing @description` |
+| Tool doesn't appear in `/tools` | Filename has `.` (e.g. `mytool.sh`) | Drop the extension — `mytool` |
+| Tool returns non-JSON garbage | Script writes binary on stdout | Stick to text; or base64-encode |
+| Tool times out | Default 5-minute cap | Make the script faster or split into multiple calls |
+| Param values look wrong | Forgot `*` and the script assumed required | Add `*` to the name in the header |
+
+Enable `OCTOMIND_LOG=debug` to see why specific files were skipped during discovery.
+
+## Security Notes
+
+Local tools are **arbitrary code on disk** — by definition they run with the same privileges as octomind. The intent is "the project author wrote these scripts and committed them to the repo." Treat `.agents/tools/` like `package.json` `scripts:` or a `Makefile`: trust the source.
+
+If you check out a third-party project that ships local tools, audit them before running an octomind session there. The same auto-discovery that makes the feature pleasant also means malicious files run on first use.
+
+## Comparison
+
+| Need | Use |
+|---|---|
+| Inject domain *instructions* into context | [Skills](15-skills.md) |
+| One-off project-specific *action* (publish, lint, fetch internal data) | **Local tools** |
+| Reusable cross-project tool with schema, prompts, multi-step logic | Author a tap with an MCP server |
+| Tool that needs a long-lived process | External `stdio`/`http` MCP server, configured in `[[mcp.servers]]` |
+
+Local tools are deliberately the simplest layer — one file, one shebang, one header. Reach for the heavier mechanisms only when you outgrow them.

--- a/src/acp/agent.rs
+++ b/src/acp/agent.rs
@@ -25,9 +25,9 @@ use agent_client_protocol::{
 	CancelNotification, Client, ContentBlock, ContentChunk, EmbeddedResourceResource, ExtRequest,
 	ExtResponse, Implementation, InitializeRequest, InitializeResponse, LoadSessionRequest,
 	LoadSessionResponse, McpCapabilities, McpServer, NewSessionRequest, NewSessionResponse,
-	PromptCapabilities, PromptRequest, PromptResponse, ProtocolVersion, SessionNotification,
-	SessionUpdate, StopReason, ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
-	UnstructuredCommandInput,
+	PromptCapabilities, PromptRequest, PromptResponse, ProtocolVersion, SessionInfoUpdate,
+	SessionNotification, SessionUpdate, StopReason, ToolCall, ToolCallStatus, ToolCallUpdate,
+	ToolCallUpdateFields, UnstructuredCommandInput,
 };
 
 use crate::config::mcp::McpServerConfig;
@@ -855,6 +855,38 @@ impl agent_client_protocol::Agent for OctomindAgent {
 								),
 							);
 							Some(SessionUpdate::ToolCallUpdate(update))
+						}
+						// Forward cost / token usage as a SessionInfoUpdate carrying an
+						// `octomind.usage` block in `_meta`. We don't gate on the unstable
+						// `UsageUpdate` variant — `_meta` is the spec-blessed extensibility
+						// channel and works on all 0.10.x clients that pass `_meta` through.
+						// Side-channel: we send the notification ourselves here (bypassing
+						// the `update` pattern below) because we need to attach `meta`.
+						ServerMessage::Cost(p) => {
+							if let Some(conn) = conn_for_task.as_ref() {
+								let mut meta = serde_json::Map::new();
+								meta.insert(
+									"octomind.usage".to_string(),
+									serde_json::json!({
+										"session_tokens":     p.session_tokens,
+										"session_cost":       p.session_cost,
+										"input_tokens":       p.input_tokens,
+										"output_tokens":      p.output_tokens,
+										"cache_read_tokens":  p.cache_read_tokens,
+										"cache_write_tokens": p.cache_write_tokens,
+										"reasoning_tokens":   p.reasoning_tokens,
+									}),
+								);
+								let notif = SessionNotification::new(
+									session_id_for_task.clone(),
+									SessionUpdate::SessionInfoUpdate(SessionInfoUpdate::new()),
+								)
+								.meta(meta);
+								if let Err(e) = conn.session_notification(notif).await {
+									log_error!("ACP: failed to send usage notification: {}", e);
+								}
+							}
+							None
 						}
 						_ => None,
 					};

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -308,8 +308,22 @@ impl RoleMcpConfig {
 				let mut server = server_config.clone();
 				// Apply role-specific tool filtering if specified
 				if !self.allowed_tools.is_empty() {
-					// Convert patterns to actual tool names for this server
-					let filtered_tools = self.expand_patterns_for_server(server_name);
+					// Convert patterns to actual tool names for this server.
+					let mut filtered_tools = self.expand_patterns_for_server(server_name);
+					// Union runtime capability extras when the role applies a
+					// restrictive filter (non-empty result). When the role
+					// already grants `<server>:*` for this server,
+					// `expand_patterns_for_server` returns an empty Vec to mean
+					// "all tools" — leave it untouched, since extras are
+					// already implicitly allowed.
+					if !filtered_tools.is_empty() {
+						for extra in crate::config::runtime_overlay::extras_for_server(server_name)
+						{
+							if !filtered_tools.iter().any(|t| t == &extra) {
+								filtered_tools.push(extra);
+							}
+						}
+					}
 					// Update tools based on server type
 					server = match server {
 						McpServerConfig::Builtin {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,8 @@ pub mod validation;
 
 pub mod registry;
 
+pub mod runtime_overlay;
+
 pub mod pipelines;
 
 pub mod workflows;

--- a/src/config/runtime_overlay.rs
+++ b/src/config/runtime_overlay.rs
@@ -1,0 +1,189 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime tool-allowlist overlay for dynamic capability activation.
+//!
+//! When a capability is activated at runtime via `capability enable <name>`,
+//! its `[roles.mcp] allowed_tools` patterns must extend the role's effective
+//! per-server tool filter for *that session*, without mutating the role's
+//! authored config. This module owns that overlay.
+//!
+//! The overlay is consulted by [`crate::config::RoleMcpConfig::get_enabled_servers`]
+//! during config merge: when the role's filter is restrictive (non-empty
+//! `allowed_tools`), runtime extras for each affected server are unioned into
+//! the per-server `tools` field. Capabilities declared in the role manifest
+//! (`capabilities = [...]`) bypass this — they were already merged at boot
+//! by `agent::registry::resolve_capabilities`.
+//!
+//! Lifecycle:
+//! - `set_capability_extras(cap_name, per_server)` — install on activation.
+//! - `clear_capability_extras(cap_name)` — remove on deactivation/eviction.
+//! - `extras_for_server(server_name)` — union of bare tool names contributed
+//!   by every currently-active capability for that server. Stable order, no
+//!   duplicates.
+//!
+//! Storage is process-global to mirror `ACTIVE_CAPABILITIES` in
+//! `src/mcp/core/capability.rs`. Both are runtime registries with the same
+//! lifetime; tying them to per-session scope would only matter for multi-
+//! session daemon mode, which is out of scope here.
+
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+
+/// `cap_name -> server_name -> bare tool names contributed for that server`.
+type Registry = HashMap<String, HashMap<String, Vec<String>>>;
+
+static OVERLAY: OnceLock<RwLock<Registry>> = OnceLock::new();
+
+fn registry() -> &'static RwLock<Registry> {
+	OVERLAY.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Install or replace this capability's per-server tool contributions.
+/// Subsequent merges of any role that enables one of these servers will
+/// expose the union of static + runtime extras for it.
+pub fn set_capability_extras(cap_name: &str, per_server: HashMap<String, Vec<String>>) {
+	let mut reg = match registry().write() {
+		Ok(r) => r,
+		Err(_) => return,
+	};
+	if per_server.is_empty() {
+		reg.remove(cap_name);
+	} else {
+		reg.insert(cap_name.to_string(), per_server);
+	}
+}
+
+/// Drop every server contribution for this capability. Called on
+/// `capability disable` and on LRU eviction.
+pub fn clear_capability_extras(cap_name: &str) {
+	if let Ok(mut reg) = registry().write() {
+		reg.remove(cap_name);
+	}
+}
+
+/// Union of bare tool names contributed by every active capability for
+/// `server_name`. Order is insertion order across capabilities; duplicates
+/// are deduplicated. Empty when no capability has registered an extra for
+/// this server.
+pub fn extras_for_server(server_name: &str) -> Vec<String> {
+	let reg = match registry().read() {
+		Ok(r) => r,
+		Err(_) => return Vec::new(),
+	};
+	let mut out: Vec<String> = Vec::new();
+	for per_server in reg.values() {
+		if let Some(tools) = per_server.get(server_name) {
+			for t in tools {
+				if !out.iter().any(|x| x == t) {
+					out.push(t.clone());
+				}
+			}
+		}
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn fresh_registry() {
+		if let Ok(mut r) = registry().write() {
+			r.clear();
+		}
+	}
+
+	#[test]
+	fn extras_unions_across_capabilities() {
+		fresh_registry();
+		let mut shell_map = HashMap::new();
+		shell_map.insert("octofs".to_string(), vec!["shell".to_string()]);
+		set_capability_extras("shell", shell_map);
+
+		let mut fs_map = HashMap::new();
+		fs_map.insert(
+			"octofs".to_string(),
+			vec!["text_editor".to_string(), "view".to_string()],
+		);
+		set_capability_extras("filesystem-write", fs_map);
+
+		let mut got = extras_for_server("octofs");
+		got.sort();
+		let mut expected = vec![
+			"shell".to_string(),
+			"text_editor".to_string(),
+			"view".to_string(),
+		];
+		expected.sort();
+		assert_eq!(got, expected);
+	}
+
+	#[test]
+	fn clear_removes_only_named_capability() {
+		fresh_registry();
+		let mut a = HashMap::new();
+		a.insert("svr".to_string(), vec!["one".to_string()]);
+		set_capability_extras("a", a);
+
+		let mut b = HashMap::new();
+		b.insert("svr".to_string(), vec!["two".to_string()]);
+		set_capability_extras("b", b);
+
+		clear_capability_extras("a");
+
+		let got = extras_for_server("svr");
+		assert_eq!(got, vec!["two".to_string()]);
+	}
+
+	#[test]
+	fn empty_per_server_is_treated_as_clear() {
+		fresh_registry();
+		let mut a = HashMap::new();
+		a.insert("svr".to_string(), vec!["one".to_string()]);
+		set_capability_extras("a", a);
+
+		// Calling with empty map removes the capability rather than
+		// inserting an empty entry — keeps the registry tight.
+		set_capability_extras("a", HashMap::new());
+		assert!(extras_for_server("svr").is_empty());
+	}
+
+	#[test]
+	fn unknown_server_returns_empty() {
+		fresh_registry();
+		assert!(extras_for_server("never-seen").is_empty());
+	}
+
+	#[test]
+	fn duplicates_within_one_server_are_deduped() {
+		fresh_registry();
+		let mut a = HashMap::new();
+		a.insert(
+			"svr".to_string(),
+			vec!["x".to_string(), "y".to_string(), "x".to_string()],
+		);
+		set_capability_extras("a", a);
+
+		let mut b = HashMap::new();
+		b.insert("svr".to_string(), vec!["y".to_string(), "z".to_string()]);
+		set_capability_extras("b", b);
+
+		let got = extras_for_server("svr");
+		assert_eq!(got.len(), 3);
+		assert!(got.contains(&"x".to_string()));
+		assert!(got.contains(&"y".to_string()));
+		assert!(got.contains(&"z".to_string()));
+	}
+}

--- a/src/mcp/agent/functions.rs
+++ b/src/mcp/agent/functions.rs
@@ -218,8 +218,13 @@ async fn execute_config_agent(
 		// Spawn the async task
 		let handle = tokio::spawn(async move {
 			let run = async move {
+				let mut parts = command.split_whitespace();
+				let program = parts.next().unwrap_or("");
+				let args: Vec<&str> = parts.collect();
 				let output =
-					match run_acp_command(&command, &task_owned, &workdir_owned, cancel_rx).await {
+					match run_acp_command(program, &args, &task_owned, &workdir_owned, cancel_rx)
+						.await
+					{
 						Ok(text) => text,
 						Err(e) => format!("ERROR: {e:#}"),
 					};
@@ -249,14 +254,10 @@ async fn execute_config_agent(
 	}
 
 	// Synchronous path (default)
-	match run_acp_command(
-		&agent_config.command,
-		task,
-		&workdir,
-		watch::channel(false).1,
-	)
-	.await
-	{
+	let mut parts = agent_config.command.split_whitespace();
+	let program = parts.next().unwrap_or("");
+	let args: Vec<&str> = parts.collect();
+	match run_acp_command(program, &args, task, &workdir, watch::channel(false).1).await {
 		Ok(output) => Ok(McpToolResult::success(
 			call.tool_name.clone(),
 			call.tool_id.clone(),
@@ -656,20 +657,19 @@ fn run_dynamic_agent_in_process(
 
 /// Spawn the ACP command, drive initialize → session/new → session/prompt.
 /// Used by both agents and layers to execute via ACP protocol.
+///
+/// `program` is the executable path; `args` are CLI arguments passed verbatim.
+/// Callers that have a single "program plus space-separated args" string should
+/// split it themselves (e.g. via `split_whitespace`) before calling.
 pub async fn run_acp_command(
-	command: &str,
+	program: &str,
+	args: &[&str],
 	task: &str,
 	workdir: &std::path::Path,
 	mut cancel_rx: watch::Receiver<bool>,
 ) -> Result<String> {
-	let mut parts = command.split_whitespace();
-	let program = parts
-		.next()
-		.ok_or_else(|| anyhow::anyhow!("Empty command"))?;
-	let args: Vec<&str> = parts.collect();
-
 	let mut child = Command::new(program)
-		.args(&args)
+		.args(args)
 		.current_dir(workdir)
 		.stdin(std::process::Stdio::piped())
 		.stdout(std::process::Stdio::piped())

--- a/src/mcp/agent/functions.rs
+++ b/src/mcp/agent/functions.rs
@@ -745,6 +745,11 @@ pub async fn run_acp_command(
 		.await?;
 
 	let mut output = String::new();
+	// Captured prompt-response error: if the subprocess returns
+	// `{"id":3,"error":{...}}` we want to surface it instead of silently
+	// returning an empty string. Without this the parent sees `output: ""`
+	// with status `done` even when the API call inside the subprocess failed.
+	let mut prompt_error: Option<Value> = None;
 
 	loop {
 		// Check for cancellation before each line read
@@ -777,9 +782,13 @@ pub async fn run_acp_command(
 			Err(_) => continue,
 		};
 
-		// Collect agent_message_chunk text from notifications
+		// Forward session/update notifications to the parent's notification
+		// sink so the user sees thinking, tool calls, and tool results
+		// streamed live — the same shape the parent renders for its own
+		// in-process tool calls.
 		if msg.get("method").and_then(|m| m.as_str()) == Some("session/update") {
 			if let Some(update) = msg.pointer("/params/update") {
+				forward_session_update_to_parent(update);
 				if update.get("sessionUpdate").and_then(|u| u.as_str())
 					== Some("agent_message_chunk")
 				{
@@ -790,8 +799,12 @@ pub async fn run_acp_command(
 			}
 		}
 
-		// Stop when we get the prompt response (id=3)
+		// Stop when we get the prompt response (id=3). Capture any error
+		// payload so we can fail the call instead of returning empty output.
 		if msg.get("id").and_then(|i| i.as_u64()) == Some(3) {
+			if let Some(err) = msg.get("error") {
+				prompt_error = Some(err.clone());
+			}
 			break;
 		}
 	}
@@ -800,7 +813,119 @@ pub async fn run_acp_command(
 	drop(stdin);
 	let _ = child.wait().await;
 
+	if let Some(err) = prompt_error {
+		let trimmed = output.trim();
+		let detail = err
+			.get("message")
+			.and_then(|m| m.as_str())
+			.map(|s| s.to_string())
+			.unwrap_or_else(|| err.to_string());
+		if trimmed.is_empty() {
+			return Err(anyhow::anyhow!("ACP prompt failed: {detail}"));
+		}
+		return Err(anyhow::anyhow!(
+			"ACP prompt failed: {detail}\n\nPartial output:\n{trimmed}"
+		));
+	}
+
 	Ok(output.trim().to_string())
+}
+
+/// Convert an ACP `session/update` notification into a `ServerMessage` and
+/// push it through the parent's notification sender. Lets `agent_*`, `tap`,
+/// and layer subprocess events render on the parent's output sink (CLI
+/// stream, JSONL, websocket) instead of being silently dropped.
+fn forward_session_update_to_parent(update: &Value) {
+	let kind = match update.get("sessionUpdate").and_then(|u| u.as_str()) {
+		Some(k) => k,
+		None => return,
+	};
+	let session_id =
+		crate::session::context::current_session_id().unwrap_or_else(|| String::from("acp"));
+
+	let msg = match kind {
+		"agent_message_chunk" => {
+			let text = update
+				.pointer("/content/text")
+				.and_then(|t| t.as_str())
+				.unwrap_or("");
+			if text.is_empty() {
+				return;
+			}
+			crate::websocket::ServerMessage::Assistant(crate::websocket::AssistantPayload {
+				content: text.to_string(),
+				session_id,
+			})
+		}
+		"agent_thought_chunk" => {
+			let text = update
+				.pointer("/content/text")
+				.and_then(|t| t.as_str())
+				.unwrap_or("");
+			if text.is_empty() {
+				return;
+			}
+			crate::websocket::ServerMessage::Thinking(crate::websocket::ThinkingPayload {
+				content: text.to_string(),
+				session_id,
+			})
+		}
+		"tool_call" => {
+			let tool_id = update
+				.get("toolCallId")
+				.and_then(|s| s.as_str())
+				.unwrap_or("")
+				.to_string();
+			let title = update
+				.get("title")
+				.and_then(|s| s.as_str())
+				.unwrap_or("")
+				.to_string();
+			let raw_input = update
+				.get("rawInput")
+				.cloned()
+				.unwrap_or(serde_json::Value::Null);
+			crate::websocket::ServerMessage::ToolUse(crate::websocket::ToolUsePayload {
+				tool: title,
+				tool_id,
+				server: String::new(),
+				params: raw_input,
+				session_id,
+			})
+		}
+		"tool_call_update" => {
+			let tool_id = update
+				.get("toolCallId")
+				.and_then(|s| s.as_str())
+				.unwrap_or("")
+				.to_string();
+			let status = update.get("status").and_then(|s| s.as_str()).unwrap_or("");
+			// Only surface terminal updates as ToolResult — intermediate
+			// status flips would otherwise emit duplicate "result" rows.
+			let success = match status {
+				"completed" => true,
+				"failed" => false,
+				_ => return,
+			};
+			let raw_output = update
+				.get("rawOutput")
+				.map(|v| match v {
+					Value::String(s) => s.clone(),
+					other => other.to_string(),
+				})
+				.unwrap_or_default();
+			crate::websocket::ServerMessage::ToolResult(crate::websocket::ToolResultPayload {
+				tool: String::new(),
+				tool_id,
+				server: String::new(),
+				content: raw_output,
+				success,
+				session_id,
+			})
+		}
+		_ => return,
+	};
+	crate::mcp::process::send_notification_message(msg);
 }
 
 /// Read lines until we find a JSON-RPC response with the given id, return it.

--- a/src/mcp/core/capability.rs
+++ b/src/mcp/core/capability.rs
@@ -188,13 +188,20 @@ fn evict_lru_if_full(config: &Config) {
 	// Compute the disable plan under one write lock so refcounts are
 	// consistent: read the LRU's server list, remove it from the
 	// registry, then count remaining references for each server.
+	//
+	// `kill` here means "tear down the underlying MCP server process", not
+	// "strip this cap's tools". Two reasons to keep the server alive:
+	//   1. Another active capability still references it (refcount > 0).
+	//   2. The role's static config declares it — the role still owns it
+	//      regardless of dynamic-cap activity.
 	let plan: Option<(String, Vec<DisablePlanEntry>)> = {
 		let mut reg = registry().write().unwrap();
 		select_lru_in(&mut reg).map(|(lru_name, server_tools)| {
 			let entries = server_tools
 				.into_iter()
 				.map(|(srv, tools)| {
-					let kill = server_refcount(&reg, &srv, &lru_name) == 0;
+					let static_owned = config.mcp.servers.iter().any(|s| s.name() == srv);
+					let kill = !static_owned && server_refcount(&reg, &srv, &lru_name) == 0;
 					(srv, tools, kill)
 				})
 				.collect();
@@ -203,6 +210,10 @@ fn evict_lru_if_full(config: &Config) {
 	};
 
 	if let Some((name, entries)) = plan {
+		// Drop overlay contributions before stripping tools so the next
+		// merge sees the reduced filter.
+		crate::config::runtime_overlay::clear_capability_extras(&name);
+
 		let server_count = entries.len();
 		for (srv, tools, kill) in &entries {
 			if let Err(e) =
@@ -434,39 +445,15 @@ async fn handle_enable(call: &McpToolCall, config: &Config) -> Result<McpToolRes
 	// the success message can distinguish "all-tools" from "filter-applied".
 	let mut any_filter_applied = false;
 
+	// Per-server tool contributions for the runtime overlay. Only servers
+	// that are already in the role's static config get an overlay entry —
+	// fully-dynamic servers are surfaced through `dynamic::get_all_functions`
+	// and don't need overlay extras to be visible.
+	let mut overlay_per_server: std::collections::HashMap<String, Vec<String>> =
+		std::collections::HashMap::new();
+
 	for server in &resolved.mcp_servers {
 		let server_name = server.name().to_string();
-
-		// If the role's manifest declared this capability via
-		// `capabilities = [...]`, the resolver already inlined the
-		// capability's `[[mcp.servers]]` block into `config.mcp.servers`
-		// at boot, and the standard MCP init exposes its tools through
-		// the static path. Re-registering the same server in the dynamic
-		// registry would surface every tool twice in `get_available_functions`
-		// (and once more in `mcp list` / `mcp info`). Skip the dynamic
-		// register/enable pair for these servers — they're already live —
-		// and don't track them in `activated_server_tools` either, since
-		// LRU eviction shouldn't tear down tools that belong to the role's
-		// persistent surface.
-		let already_in_static = config.mcp.servers.iter().any(|s| s.name() == server_name);
-
-		if already_in_static {
-			activated_servers.push(server_name);
-			continue;
-		}
-
-		// Register if not already in the dynamic registry (idempotent on conflicts).
-		if !crate::mcp::core::dynamic::is_dynamic(&server_name) {
-			if let Err(e) = crate::mcp::core::dynamic::register_server(server.clone()) {
-				return Ok(McpToolResult::error(
-					call.tool_name.clone(),
-					call.tool_id.clone(),
-					format!(
-						"Failed to register server '{server_name}' for capability '{name}': {e}"
-					),
-				));
-			}
-		}
 
 		// Compute the filter for *this* server. `allowed_tools` patterns in
 		// capability TOMLs are namespace-prefixed (e.g., `playwright:*`,
@@ -480,6 +467,64 @@ async fn handle_enable(call: &McpToolCall, config: &Config) -> Result<McpToolRes
 		let filter_for_this = filter_for_server(&resolved.allowed_tools, &server_name);
 		if filter_for_this.is_some() {
 			any_filter_applied = true;
+		}
+
+		// Two activation paths share the same registry/overlay/tool-map
+		// shape so disable/eviction is uniform regardless of where the
+		// server originated.
+		//
+		// 1. Server already in the role's static config (declared by the
+		//    role's `capabilities = [...]` at boot). The MCP init already
+		//    exposes its tools via the static path, but this capability's
+		//    `allowed_tools` for that server may include names the role's
+		//    own filter rejects. We extend the role's effective filter
+		//    via the runtime overlay (consulted by
+		//    `RoleMcpConfig::get_enabled_servers`) AND register the bare
+		//    tool names in the global tool_map so dispatch can route them.
+		// 2. Server is fully dynamic (capability brought it in at runtime).
+		//    Register + enable through the dynamic registry as before; the
+		//    dynamic `get_all_functions` path surfaces its tools, no
+		//    overlay needed.
+		let already_in_static = config.mcp.servers.iter().any(|s| s.name() == server_name);
+
+		if already_in_static {
+			let bare_names: Vec<String> = filter_for_this.clone().unwrap_or_default();
+
+			// Register THIS cap's named tools in the global tool_map so the
+			// dispatcher can route a call like `octofs:shell` even though
+			// the role's static filter never listed it. Empty `bare_names`
+			// (capability allows all tools from this server) is a no-op
+			// here — the static path already mapped them.
+			if !bare_names.is_empty() {
+				if let Some(server_config) =
+					config.mcp.servers.iter().find(|s| s.name() == server_name)
+				{
+					crate::mcp::tool_map::register_dynamic_server_tools(
+						&server_name,
+						server_config,
+						&bare_names,
+					);
+				}
+				overlay_per_server.insert(server_name.clone(), bare_names.clone());
+			}
+
+			activated_tools.extend(bare_names.iter().cloned());
+			activated_server_tools.push((server_name.clone(), bare_names));
+			activated_servers.push(server_name);
+			continue;
+		}
+
+		// Fully dynamic — register + enable.
+		if !crate::mcp::core::dynamic::is_dynamic(&server_name) {
+			if let Err(e) = crate::mcp::core::dynamic::register_server(server.clone()) {
+				return Ok(McpToolResult::error(
+					call.tool_name.clone(),
+					call.tool_id.clone(),
+					format!(
+						"Failed to register server '{server_name}' for capability '{name}': {e}"
+					),
+				));
+			}
 		}
 
 		match crate::mcp::core::dynamic::enable_server(&server_name, filter_for_this).await {
@@ -498,6 +543,10 @@ async fn handle_enable(call: &McpToolCall, config: &Config) -> Result<McpToolRes
 			}
 		}
 	}
+
+	// Publish overlay entries so the next config merge picks up this
+	// capability's contributions to static servers' filters.
+	crate::config::runtime_overlay::set_capability_extras(&name, overlay_per_server);
 
 	mark_active(&name, activated_server_tools);
 
@@ -553,6 +602,11 @@ async fn handle_disable(call: &McpToolCall, config: &Config) -> Result<McpToolRe
 	// consistent: pull THIS cap's (server, tools) record, remove the
 	// cap from the registry, then count remaining references for each
 	// server. Mirrors `evict_lru_if_full`.
+	//
+	// `kill` only flips true when no other active capability references
+	// the server AND the server is not in the role's static config. The
+	// static-config check stops `disable` from tearing down servers the
+	// role still relies on (the LRU eviction path uses the same rule).
 	let plan: Option<Vec<DisablePlanEntry>> = {
 		let mut reg = registry().write().unwrap();
 		reg.remove(&name).map(|state| {
@@ -560,7 +614,8 @@ async fn handle_disable(call: &McpToolCall, config: &Config) -> Result<McpToolRe
 				.server_tools
 				.into_iter()
 				.map(|(srv, tools)| {
-					let kill = server_refcount(&reg, &srv, &name) == 0;
+					let static_owned = config.mcp.servers.iter().any(|s| s.name() == srv);
+					let kill = !static_owned && server_refcount(&reg, &srv, &name) == 0;
 					(srv, tools, kill)
 				})
 				.collect()
@@ -580,15 +635,20 @@ async fn handle_disable(call: &McpToolCall, config: &Config) -> Result<McpToolRe
 		}
 	};
 
+	// Drop the overlay entry so the next merge sees the reduced per-server
+	// filter for static servers this cap was contributing to. Order matters:
+	// clear before tool_map updates so the two stay in sync if a concurrent
+	// merge reads them.
+	crate::config::runtime_overlay::clear_capability_extras(&name);
+
 	let mut disabled_servers: Vec<String> = Vec::new();
 	for (srv, tools, kill) in &plan {
-		// Skip non-dynamic servers entirely (they were never registered
-		// here, so there's nothing to do — matches old handle_disable
-		// behaviour). For shared servers (kill=false), strip only this
-		// cap's tools regardless of dynamic-vs-config status.
-		if !crate::mcp::core::dynamic::is_dynamic(srv) && *kill {
-			continue;
-		}
+		// Always strip THIS cap's tool entries from the global tool_map,
+		// even on static servers — the cap brought them in via the runtime
+		// overlay, so they need to leave the map when it's disabled.
+		// `kill=false` selects the strip-only path inside
+		// `disable_server_tools`; static servers reach this branch via the
+		// `static_owned` rule above.
 		if let Err(e) =
 			crate::mcp::core::dynamic::disable_server_tools(srv, tools, *kill, Some(config))
 		{
@@ -998,15 +1058,32 @@ async fn activate_capability_inline(name: &str, config: &Config) -> Result<Vec<S
 
 	let mut activated_servers: Vec<String> = Vec::new();
 	let mut activated_server_tools: Vec<(String, Vec<String>)> = Vec::new();
+	let mut overlay_per_server: std::collections::HashMap<String, Vec<String>> =
+		std::collections::HashMap::new();
 	for server in &resolved.mcp_servers {
 		let server_name = server.name().to_string();
+		let filter = filter_for_server(&resolved.allowed_tools, &server_name);
 
-		// Server already provided by the role's static config (capability
-		// inlined at boot via `capabilities = [...]` in the manifest).
-		// Re-registering would double the tool surface — skip the dynamic
-		// register/enable, and don't track for LRU eviction since the static
-		// surface isn't ours to tear down. Mirrors `handle_enable`.
+		// Server already provided by the role's static config — extend
+		// rather than re-register. Mirrors the `already_in_static` branch
+		// in `handle_enable`. The overlay extends the role's per-server
+		// filter at next merge; tool_map registration makes named tools
+		// dispatchable now.
 		if config.mcp.servers.iter().any(|s| s.name() == server_name) {
+			let bare_names: Vec<String> = filter.clone().unwrap_or_default();
+			if !bare_names.is_empty() {
+				if let Some(server_config) =
+					config.mcp.servers.iter().find(|s| s.name() == server_name)
+				{
+					crate::mcp::tool_map::register_dynamic_server_tools(
+						&server_name,
+						server_config,
+						&bare_names,
+					);
+				}
+				overlay_per_server.insert(server_name.clone(), bare_names.clone());
+			}
+			activated_server_tools.push((server_name.clone(), bare_names));
 			activated_servers.push(server_name);
 			continue;
 		}
@@ -1014,14 +1091,13 @@ async fn activate_capability_inline(name: &str, config: &Config) -> Result<Vec<S
 		if !crate::mcp::core::dynamic::is_dynamic(&server_name) {
 			crate::mcp::core::dynamic::register_server(server.clone())?;
 		}
-		// Per-server bare-name filter (strips `<server>:` namespace from
-		// capability `allowed_tools` patterns; see `filter_for_server`).
-		let filter = filter_for_server(&resolved.allowed_tools, &server_name);
 		let functions = crate::mcp::core::dynamic::enable_server(&server_name, filter).await?;
 		let bare_names: Vec<String> = functions.iter().map(|f| f.name.clone()).collect();
 		activated_server_tools.push((server_name.clone(), bare_names));
 		activated_servers.push(server_name);
 	}
+
+	crate::config::runtime_overlay::set_capability_extras(name, overlay_per_server);
 	mark_active(name, activated_server_tools);
 	Ok(activated_servers)
 }

--- a/src/mcp/core/local_tool.rs
+++ b/src/mcp/core/local_tool.rs
@@ -1,0 +1,614 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Project-local MCP tools — shebang scripts at `<workdir>/.agents/tools/<name>`.
+//!
+//! Auto-discovered every turn from disk; no config, no env var. Mirrors the
+//! always-on injection shape of `OCTOMIND_SKILLS` but driven purely by file
+//! presence, so any project can drop in tools without editing the role config.
+//!
+//! ## File contract
+//!
+//! - Path: `<workdir>/.agents/tools/<tool-name>`
+//! - Filename = tool name (must match `[A-Za-z0-9_-]+`).
+//! - File must be executable (`chmod +x`). Non-executable files are skipped.
+//! - First line may be a shebang (`#!...`); skipped during header parsing.
+//! - The leading comment block (lines starting with `#`, `//`, or `--`) defines
+//!   the tool schema. Parsing stops at the first non-comment, non-blank line, or
+//!   after `HEADER_MAX_LINES`.
+//!
+//! ## Header schema
+//!
+//! ```text
+//! #!/usr/bin/env bash
+//! # @description Short summary of what the tool does.
+//! # Continuation lines (no @ prefix) append to the previous tag.
+//! # @param *target string Path to operate on    (required: leading *)
+//! # @param force boolean Overwrite existing      (optional: no *)
+//! # @param *count integer Iterations
+//! ```
+//!
+//! - `@description` is required (or `@desc`).
+//! - `@param NAME TYPE DESCRIPTION` — repeatable. TYPE ∈
+//!   `{string, number, integer, boolean, array, object}` (default `string`).
+//!   Prefix the name with `*` to mark the param as required:
+//!   `@param *target string Path to operate on`. Unmarked = optional. This
+//!   mirrors how octomind renders the schema in `/tools` output.
+//! - Unknown tags are ignored with a debug log.
+//!
+//! ## Calling convention (script side)
+//!
+//! - stdin: JSON object of all params (`{"target":"x.txt","force":true}`).
+//! - env: `OCTOMIND_PARAM_<UPPERCASE_NAME>` for each param (string form;
+//!   complex values JSON-stringified). Plus `OCTOMIND_TOOL_NAME`,
+//!   `OCTOMIND_WORKDIR`.
+//! - cwd: the session's working directory.
+//! - stdout = success content shown to the model.
+//! - stderr appended to the result with an `[stderr]` marker.
+//! - non-zero exit = error result.
+
+use crate::mcp::{McpFunction, McpToolCall, McpToolResult};
+use anyhow::Result;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+/// Project-relative tools directory.
+pub const TOOLS_DIR: &str = ".agents/tools";
+
+/// Synthetic builtin server name reserved for project-local tools.
+pub const SERVER_NAME: &str = "local";
+
+/// Maximum leading lines scanned for the header. Prevents reading entire files
+/// when the contract is "header is at the top".
+const HEADER_MAX_LINES: usize = 80;
+
+/// Default tool execution timeout if not overridden.
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
+#[derive(Debug, Clone)]
+pub struct LocalToolMeta {
+	pub name: String,
+	pub description: String,
+	pub params: Vec<ParamDef>,
+	pub path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParamDef {
+	pub name: String,
+	pub ty: String,
+	pub description: String,
+	pub required: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Scan `<workdir>/.agents/tools/` and return one entry per valid tool file.
+pub fn discover(workdir: &Path) -> Vec<LocalToolMeta> {
+	let dir = workdir.join(TOOLS_DIR);
+	let entries = match std::fs::read_dir(&dir) {
+		Ok(e) => e,
+		Err(_) => return Vec::new(),
+	};
+
+	let mut out = Vec::new();
+	for ent in entries.flatten() {
+		let path = ent.path();
+		if !path.is_file() {
+			continue;
+		}
+
+		let fname = match path.file_name().and_then(|n| n.to_str()) {
+			Some(n) => n,
+			None => continue,
+		};
+		if !is_valid_tool_name(fname) {
+			continue;
+		}
+		if !is_executable(&path) {
+			crate::log_debug!(
+				"local_tool: '{}' not executable (chmod +x to enable)",
+				path.display()
+			);
+			continue;
+		}
+
+		match parse_file(&path, fname) {
+			Ok(meta) => out.push(meta),
+			Err(e) => crate::log_debug!("local_tool: parse {} failed: {}", path.display(), e),
+		}
+	}
+	out
+}
+
+/// MCP function definitions for all local tools in the current session's workdir.
+pub fn get_all_functions() -> Vec<McpFunction> {
+	let workdir = crate::mcp::workdir::get_thread_working_directory();
+	discover(&workdir)
+		.into_iter()
+		.map(|t| t.to_function())
+		.collect()
+}
+
+/// True if a tool with `name` exists in the current session's workdir.
+pub fn is_local_tool(name: &str) -> bool {
+	let workdir = crate::mcp::workdir::get_thread_working_directory();
+	discover(&workdir).iter().any(|t| t.name == name)
+}
+
+/// Execute a local-tool call. Spawns the script, pipes JSON params on stdin,
+/// captures stdout/stderr, returns the result.
+pub async fn execute(call: &McpToolCall) -> Result<McpToolResult> {
+	let workdir = crate::mcp::workdir::get_thread_working_directory();
+	let tools = discover(&workdir);
+	let tool = tools
+		.iter()
+		.find(|t| t.name == call.tool_name)
+		.ok_or_else(|| {
+			anyhow::anyhow!(
+				"local tool '{}' not found in {}/{}",
+				call.tool_name,
+				workdir.display(),
+				TOOLS_DIR
+			)
+		})?;
+
+	let params_json = serde_json::to_string(&call.parameters).unwrap_or_else(|_| "{}".to_string());
+
+	let mut cmd = tokio::process::Command::new(&tool.path);
+	cmd.current_dir(&workdir);
+	cmd.env("OCTOMIND_TOOL_NAME", &tool.name);
+	cmd.env("OCTOMIND_WORKDIR", workdir.display().to_string());
+
+	if let Some(obj) = call.parameters.as_object() {
+		for (k, v) in obj {
+			let val = match v {
+				Value::String(s) => s.clone(),
+				Value::Null => String::new(),
+				Value::Bool(b) => b.to_string(),
+				Value::Number(n) => n.to_string(),
+				_ => serde_json::to_string(v).unwrap_or_default(),
+			};
+			cmd.env(format!("OCTOMIND_PARAM_{}", k.to_uppercase()), val);
+		}
+	}
+
+	cmd.stdin(std::process::Stdio::piped());
+	cmd.stdout(std::process::Stdio::piped());
+	cmd.stderr(std::process::Stdio::piped());
+
+	let mut child = cmd
+		.spawn()
+		.map_err(|e| anyhow::anyhow!("spawn '{}' failed: {}", tool.path.display(), e))?;
+
+	if let Some(mut stdin) = child.stdin.take() {
+		use tokio::io::AsyncWriteExt;
+		let _ = stdin.write_all(params_json.as_bytes()).await;
+		let _ = stdin.shutdown().await;
+	}
+
+	let output = tokio::time::timeout(
+		std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+		child.wait_with_output(),
+	)
+	.await
+	.map_err(|_| {
+		anyhow::anyhow!(
+			"local tool '{}' timed out after {}s",
+			tool.name,
+			DEFAULT_TIMEOUT_SECS
+		)
+	})?
+	.map_err(|e| anyhow::anyhow!("wait for '{}' failed: {}", tool.name, e))?;
+
+	let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+	let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+	if !output.status.success() {
+		let mut msg = format!(
+			"local tool '{}' exited with status {}",
+			tool.name, output.status
+		);
+		if !stderr.is_empty() {
+			msg.push_str("\n[stderr]\n");
+			msg.push_str(stderr.trim_end());
+		}
+		if !stdout.is_empty() {
+			msg.push_str("\n[stdout]\n");
+			msg.push_str(stdout.trim_end());
+		}
+		return Ok(McpToolResult::error(
+			call.tool_name.clone(),
+			call.tool_id.clone(),
+			msg,
+		));
+	}
+
+	let mut content = stdout;
+	if !stderr.trim().is_empty() {
+		if !content.is_empty() && !content.ends_with('\n') {
+			content.push('\n');
+		}
+		content.push_str("[stderr]\n");
+		content.push_str(stderr.trim_end());
+	}
+
+	Ok(McpToolResult::success(
+		call.tool_name.clone(),
+		call.tool_id.clone(),
+		content,
+	))
+}
+
+// ---------------------------------------------------------------------------
+// Conversion: meta -> McpFunction
+// ---------------------------------------------------------------------------
+
+impl LocalToolMeta {
+	pub fn to_function(&self) -> McpFunction {
+		let mut props = serde_json::Map::new();
+		let mut required: Vec<String> = Vec::new();
+
+		for p in &self.params {
+			props.insert(
+				p.name.clone(),
+				json!({
+					"type": p.ty,
+					"description": p.description,
+				}),
+			);
+			if p.required {
+				required.push(p.name.clone());
+			}
+		}
+
+		McpFunction {
+			name: self.name.clone(),
+			description: self.description.clone(),
+			parameters: json!({
+				"type": "object",
+				"properties": Value::Object(props),
+				"required": required,
+			}),
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem helpers
+// ---------------------------------------------------------------------------
+
+fn is_valid_tool_name(s: &str) -> bool {
+	!s.is_empty()
+		&& !s.starts_with('-')
+		&& !s.starts_with('.')
+		&& s.chars()
+			.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+fn is_executable(p: &Path) -> bool {
+	#[cfg(unix)]
+	{
+		use std::os::unix::fs::PermissionsExt;
+		std::fs::metadata(p)
+			.map(|m| m.permissions().mode() & 0o111 != 0)
+			.unwrap_or(false)
+	}
+	#[cfg(not(unix))]
+	{
+		// On non-unix, treat any readable file as runnable; the OS will reject if not.
+		p.exists()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Header parsing
+// ---------------------------------------------------------------------------
+
+fn parse_file(path: &Path, name: &str) -> Result<LocalToolMeta> {
+	let content = std::fs::read_to_string(path)?;
+	let header = extract_header(&content);
+	parse_header(&header, path, name)
+}
+
+/// Extract the leading comment block. Skips a shebang on line 1.
+/// Stops at the first non-comment, non-blank line. Capped at HEADER_MAX_LINES.
+fn extract_header(content: &str) -> String {
+	let mut out = String::new();
+	let mut started = false;
+
+	for (i, line) in content.lines().take(HEADER_MAX_LINES).enumerate() {
+		if i == 0 && line.starts_with("#!") {
+			continue;
+		}
+		let trimmed = line.trim_start();
+
+		if trimmed.is_empty() {
+			if !started {
+				continue; // allow blank lines between shebang and header
+			}
+			break;
+		}
+
+		match strip_comment_prefix(trimmed) {
+			Some(rest) => {
+				started = true;
+				out.push_str(rest);
+				out.push('\n');
+			}
+			None => break, // first non-comment line ends the header
+		}
+	}
+	out
+}
+
+/// Strip a single comment prefix (`# `, `#`, `// `, `//`, `-- `, `--`).
+fn strip_comment_prefix(s: &str) -> Option<&str> {
+	if let Some(r) = s.strip_prefix("# ") {
+		return Some(r);
+	}
+	if let Some(r) = s.strip_prefix("#") {
+		return Some(r);
+	}
+	if let Some(r) = s.strip_prefix("// ") {
+		return Some(r);
+	}
+	if let Some(r) = s.strip_prefix("//") {
+		return Some(r);
+	}
+	if let Some(r) = s.strip_prefix("-- ") {
+		return Some(r);
+	}
+	if let Some(r) = s.strip_prefix("--") {
+		return Some(r);
+	}
+	None
+}
+
+fn parse_header(header: &str, path: &Path, name: &str) -> Result<LocalToolMeta> {
+	let mut description = String::new();
+	let mut params: Vec<ParamDef> = Vec::new();
+	let mut current_tag: Option<&'static str> = None;
+
+	for raw in header.lines() {
+		let line = raw.trim();
+		if line.is_empty() {
+			continue;
+		}
+
+		if let Some(rest) = line.strip_prefix('@') {
+			let mut split = rest.splitn(2, char::is_whitespace);
+			let tag = split.next().unwrap_or("").trim().to_lowercase();
+			let val = split.next().unwrap_or("").trim();
+
+			match tag.as_str() {
+				"description" | "desc" => {
+					if !description.is_empty() {
+						description.push('\n');
+					}
+					description.push_str(val);
+					current_tag = Some("description");
+				}
+				"param" | "arg" => {
+					if let Some(p) = parse_param_line(val) {
+						params.push(p);
+					} else {
+						crate::log_debug!(
+							"local_tool: malformed @param in {}: '{}'",
+							path.display(),
+							val
+						);
+					}
+					current_tag = None;
+				}
+				other => {
+					crate::log_debug!("local_tool: unknown tag @{} in {}", other, path.display());
+					current_tag = None;
+				}
+			}
+		} else if current_tag == Some("description") {
+			if !description.is_empty() && !description.ends_with('\n') {
+				description.push('\n');
+			}
+			description.push_str(line);
+		}
+	}
+
+	let description = description.trim().to_string();
+	if description.is_empty() {
+		return Err(anyhow::anyhow!(
+			"missing @description in {}",
+			path.display()
+		));
+	}
+
+	Ok(LocalToolMeta {
+		name: name.to_string(),
+		description,
+		params,
+		path: path.to_path_buf(),
+	})
+}
+
+/// Parse `NAME TYPE DESCRIPTION...` from the value half of `@param`.
+///
+/// A leading `*` on the name marks the param as required. No `*` = optional.
+/// This mirrors how octomind renders required params in `/tools` output, so
+/// the file format and the displayed schema use the same visual convention.
+fn parse_param_line(s: &str) -> Option<ParamDef> {
+	let mut it = s.split_whitespace();
+	let raw_name = it.next()?;
+
+	let (required, name) = if let Some(stripped) = raw_name.strip_prefix('*') {
+		(true, stripped.to_string())
+	} else {
+		(false, raw_name.to_string())
+	};
+	if name.is_empty() {
+		return None;
+	}
+
+	let ty_raw = it.next().unwrap_or("string").to_string();
+	let ty = normalize_type(&ty_raw);
+	let description = it.collect::<Vec<&str>>().join(" ");
+
+	Some(ParamDef {
+		name,
+		ty,
+		description,
+		required,
+	})
+}
+
+fn normalize_type(t: &str) -> String {
+	match t.to_lowercase().as_str() {
+		"str" | "string" => "string",
+		"int" | "integer" => "integer",
+		"num" | "number" | "float" => "number",
+		"bool" | "boolean" => "boolean",
+		"array" | "list" => "array",
+		"object" | "obj" | "map" => "object",
+		_ => "string",
+	}
+	.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_simple_header() {
+		let h = "@description Does the thing.\n@param *target string Path to file\n@param force boolean Overwrite\n";
+		let meta = parse_header(h, Path::new("/tmp/x"), "x").unwrap();
+		assert_eq!(meta.description, "Does the thing.");
+		assert_eq!(meta.params.len(), 2);
+		assert_eq!(meta.params[0].name, "target");
+		assert_eq!(meta.params[0].ty, "string");
+		assert!(meta.params[0].required);
+		assert_eq!(meta.params[1].name, "force");
+		assert_eq!(meta.params[1].ty, "boolean");
+		assert!(!meta.params[1].required);
+	}
+
+	#[test]
+	fn star_prefix_marks_required() {
+		// no star → optional (default)
+		let h = "@description x\n@param a string the a\n";
+		let m = parse_header(h, Path::new("/tmp/x"), "x").unwrap();
+		assert!(!m.params[0].required);
+
+		// star → required, name has no star
+		let h = "@description x\n@param *a string the a\n";
+		let m = parse_header(h, Path::new("/tmp/x"), "x").unwrap();
+		assert!(m.params[0].required);
+		assert_eq!(m.params[0].name, "a");
+	}
+
+	#[test]
+	fn lone_star_param_is_skipped() {
+		let h = "@description x\n@param * string oops\n@param *real string ok\n";
+		let m = parse_header(h, Path::new("/tmp/x"), "x").unwrap();
+		assert_eq!(m.params.len(), 1);
+		assert_eq!(m.params[0].name, "real");
+	}
+
+	#[test]
+	fn multiline_description_continues() {
+		let h = "@description Line one.\nLine two.\n@param x string The x\n";
+		let meta = parse_header(h, Path::new("/tmp/x"), "x").unwrap();
+		assert_eq!(meta.description, "Line one.\nLine two.");
+		assert_eq!(meta.params.len(), 1);
+	}
+
+	#[test]
+	fn header_extraction_skips_shebang_and_stops_at_code() {
+		let src = "#!/usr/bin/env bash\n# @description Hi.\n# @param a string the a\necho hello\n# not part of header\n";
+		let h = extract_header(src);
+		assert!(h.contains("@description Hi."));
+		assert!(h.contains("@param a"));
+		assert!(!h.contains("not part of header"));
+	}
+
+	#[test]
+	fn slash_slash_comments_work() {
+		let src = "#!/usr/bin/env node\n// @description JS tool\n// @param msg string The message\nconsole.log('hi')\n";
+		let h = extract_header(src);
+		let meta = parse_header(&h, Path::new("/tmp/x"), "x").unwrap();
+		assert_eq!(meta.description, "JS tool");
+		assert_eq!(meta.params[0].name, "msg");
+	}
+
+	#[test]
+	fn missing_description_errors() {
+		let h = "@param x string just a thing\n";
+		assert!(parse_header(h, Path::new("/tmp/x"), "x").is_err());
+	}
+
+	#[test]
+	fn invalid_names_rejected() {
+		assert!(!is_valid_tool_name(""));
+		assert!(!is_valid_tool_name(".hidden"));
+		assert!(!is_valid_tool_name("-leading-dash"));
+		assert!(!is_valid_tool_name("has space"));
+		assert!(!is_valid_tool_name("dot.ext"));
+		assert!(is_valid_tool_name("toola"));
+		assert!(is_valid_tool_name("tool_b"));
+		assert!(is_valid_tool_name("tool-3"));
+	}
+
+	#[test]
+	fn type_aliases_normalize() {
+		assert_eq!(normalize_type("str"), "string");
+		assert_eq!(normalize_type("INT"), "integer");
+		assert_eq!(normalize_type("bool"), "boolean");
+		assert_eq!(normalize_type("unknown"), "string");
+	}
+
+	#[test]
+	fn to_function_builds_schema() {
+		let meta = LocalToolMeta {
+			name: "doit".into(),
+			description: "Do it.".into(),
+			params: vec![
+				ParamDef {
+					name: "a".into(),
+					ty: "string".into(),
+					description: "the a".into(),
+					required: true,
+				},
+				ParamDef {
+					name: "b".into(),
+					ty: "integer".into(),
+					description: "the b".into(),
+					required: false,
+				},
+			],
+			path: PathBuf::from("/tmp/doit"),
+		};
+		let f = meta.to_function();
+		assert_eq!(f.name, "doit");
+		let req = f.parameters["required"].as_array().unwrap();
+		assert_eq!(req.len(), 1);
+		assert_eq!(req[0], "a");
+		assert_eq!(f.parameters["properties"]["a"]["type"], "string");
+		assert_eq!(f.parameters["properties"]["b"]["type"], "integer");
+	}
+}

--- a/src/mcp/core/mod.rs
+++ b/src/mcp/core/mod.rs
@@ -19,6 +19,7 @@ pub mod capability;
 pub mod dynamic;
 pub mod dynamic_agents;
 pub mod functions;
+pub mod local_tool;
 pub mod plan;
 pub mod schedule;
 pub mod skill;

--- a/src/mcp/core/tap.rs
+++ b/src/mcp/core/tap.rs
@@ -35,16 +35,15 @@
 //! tasks, `watch::Sender` cancellation, the embedding matcher).
 
 use anyhow::Result;
-use futures::future::BoxFuture;
 use serde_json::json;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 use tokio::sync::watch;
 
 use crate::config::Config;
+use crate::mcp::agent::functions::run_acp_command;
 use crate::mcp::{McpFunction, McpToolCall, McpToolResult};
 use crate::session::tap_runs::{self, TapJob, TapJobInfo, TapJobStatus};
-use crate::session::{ChatCompletionWithValidationParams, Message};
 
 // ---------------------------------------------------------------------------
 // Tool definition
@@ -332,25 +331,11 @@ async fn handle_run(call: &McpToolCall, _config: &Config) -> Result<McpToolResul
 		.map(|p| p.to_string_lossy().to_string())
 		.unwrap_or_else(|_| ".".to_string());
 
-	// Tap-runs always resolve the manifest against a freshly-loaded base
-	// config — never the parent session's already-merged config. The parent
-	// may have its own tap-merged role baked in, which would cause the
-	// resolver's "must define a new role" check to skip the manifest's role
-	// during merge and then fail.
-	let base_config = match crate::config::Config::load() {
-		Ok(c) => c,
-		Err(e) => {
-			return Ok(McpToolResult::error(
-				call.tool_name.clone(),
-				call.tool_id.clone(),
-				format!("Failed to load base config for tap-run: {e:#}"),
-			));
-		}
-	};
-
-	// Resolve (id, role, workdir, history, status, cancel_rx) for either resume or fresh run.
-	let (id, role, workdir, history, status, cancel_rx) = if let Some(sid) = session {
-		let (history, status, cancel_rx) = match tap_runs::get_handles(&sid) {
+	// Resolve (id, role, workdir, status, cancel_rx) for resume vs. fresh.
+	// Conversation history is persisted on disk by the ACP subprocess under
+	// the session name `<id>` — we don't track messages in-memory anymore.
+	let (id, role, workdir, status, cancel_rx) = if let Some(sid) = session {
+		let (status, cancel_rx) = match tap_runs::get_status_and_cancel(&sid) {
 			Some(h) => h,
 			None => {
 				return Ok(McpToolResult::error(
@@ -394,7 +379,7 @@ async fn handle_run(call: &McpToolCall, _config: &Config) -> Result<McpToolResul
 		if let Ok(mut s) = status.write() {
 			*s = TapJobStatus::Running;
 		}
-		(sid, info.role, info.workdir, history, status, cancel_rx)
+		(sid, info.role, info.workdir, status, cancel_rx)
 	} else {
 		let role = match role_param {
 			Some(t) => t,
@@ -408,7 +393,6 @@ async fn handle_run(call: &McpToolCall, _config: &Config) -> Result<McpToolResul
 		};
 		let workdir = workdir_param.unwrap_or(cwd_default);
 		let id = tap_runs::generate_id(&role);
-		let history = Arc::new(RwLock::new(Vec::<Message>::new()));
 		let status = Arc::new(RwLock::new(TapJobStatus::Running));
 		let (cancel_tx, cancel_rx) = watch::channel(false);
 		tap_runs::register_job(TapJob {
@@ -417,30 +401,57 @@ async fn handle_run(call: &McpToolCall, _config: &Config) -> Result<McpToolResul
 			workdir: workdir.clone(),
 			started_at: SystemTime::now(),
 			status: Arc::clone(&status),
-			history: Arc::clone(&history),
 			cancel_tx,
 		});
-		(id, role, workdir, history, status, cancel_rx)
+		(id, role, workdir, status, cancel_rx)
 	};
+
+	// Resolve the path to the currently-running octomind binary so the
+	// subprocess uses the same code, regardless of $PATH.
+	let exe = match std::env::current_exe() {
+		Ok(p) => p.to_string_lossy().to_string(),
+		Err(e) => {
+			if let Ok(mut s) = status.write() {
+				if *s == TapJobStatus::Running {
+					*s = TapJobStatus::Failed;
+				}
+			}
+			return Ok(McpToolResult::error(
+				call.tool_name.clone(),
+				call.tool_id.clone(),
+				format!("Failed to locate octomind binary: {e:#}"),
+			));
+		}
+	};
+	// `--name <id>` creates a fresh session if `<id>.jsonl` doesn't exist
+	// and resumes it if it does — works for both the first call and
+	// every subsequent turn against the same tap-run id.
+	let acp_args: Vec<String> = vec![
+		"acp".to_string(),
+		role.clone(),
+		"--name".to_string(),
+		id.clone(),
+	];
+	let workdir_path = std::path::PathBuf::from(&workdir);
 
 	if background {
 		let id_owned = id.clone();
 		let role_owned = role.clone();
-		let workdir_owned = workdir.clone();
+		let workdir_owned = workdir_path.clone();
 		let prompt_owned = prompt.clone();
-		let base_config_owned = base_config.clone();
-		let history_bg = Arc::clone(&history);
+		let exe_owned = exe.clone();
+		let args_owned = acp_args.clone();
 		let status_bg = Arc::clone(&status);
 		let session_id = crate::session::context::current_session_id();
 		tokio::spawn(async move {
 			let run = async move {
-				let outcome = run_tap_role(
-					role_owned.clone(),
-					prompt_owned,
-					workdir_owned,
-					history_bg,
+				let arg_refs: Vec<&str> = args_owned.iter().map(|s| s.as_str()).collect();
+				let outcome = run_acp_command(
+					&exe_owned,
+					&arg_refs,
+					&prompt_owned,
+					&workdir_owned,
 					cancel_rx,
-					base_config_owned,
 				)
 				.await;
 				let (terminal, content) = match outcome {
@@ -486,16 +497,9 @@ async fn handle_run(call: &McpToolCall, _config: &Config) -> Result<McpToolResul
 		));
 	}
 
-	// Foreground — block until the LLM round completes.
-	let outcome = run_tap_role(
-		role.clone(),
-		prompt.clone(),
-		workdir.clone(),
-		Arc::clone(&history),
-		cancel_rx,
-		base_config,
-	)
-	.await;
+	// Foreground — block until the ACP subprocess completes the prompt.
+	let arg_refs: Vec<&str> = acp_args.iter().map(|s| s.as_str()).collect();
+	let outcome = run_acp_command(&exe, &arg_refs, &prompt, &workdir_path, cancel_rx).await;
 	match outcome {
 		Ok(text) => {
 			if let Ok(mut s) = status.write() {
@@ -529,279 +533,6 @@ async fn handle_run(call: &McpToolCall, _config: &Config) -> Result<McpToolResul
 			))
 		}
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Runner — single-turn LLM loop against a resolved tap role.
-//
-// Mirrors the *technique* of `run_dynamic_agent_in_process` (system prompt +
-// user message → API call → tool call recursion → terminal text) but is a
-// separate code path: the tap subsystem doesn't share runtime types with
-// `agent_*`. Persists conversation in the supplied `history` Arc so resuming
-// the same id picks up where the prior turn left off.
-// ---------------------------------------------------------------------------
-
-fn run_tap_role(
-	role: String,
-	prompt: String,
-	workdir: String,
-	history: Arc<RwLock<Vec<Message>>>,
-	cancel_rx: watch::Receiver<bool>,
-	base_config: Config,
-) -> BoxFuture<'static, Result<String>> {
-	// `with_non_interactive` flips a task-local flag so any INPUT/ENV
-	// resolution that would otherwise prompt stdin returns a structured
-	// "missing input" error instead. Without this the parent agent's tool
-	// call deadlocks waiting for a user prompt that's unreachable from
-	// inside an MCP dispatch.
-	Box::pin(crate::agent::inputs::with_non_interactive(
-		run_tap_role_inner(role, prompt, workdir, history, cancel_rx, base_config),
-	))
-}
-
-async fn run_tap_role_inner(
-	role: String,
-	prompt: String,
-	workdir: String,
-	history: Arc<RwLock<Vec<Message>>>,
-	cancel_rx: watch::Receiver<bool>,
-	base_config: Config,
-) -> Result<String> {
-	if *cancel_rx.borrow() {
-		anyhow::bail!("Operation cancelled");
-	}
-
-	// Resolve role tag → merged config + role name. This pulls the tap
-	// manifest, resolves capabilities/inputs/deps, and merges into a
-	// runnable Config. `base_config` here is freshly loaded from disk by
-	// the caller — never the parent session's already-merged config.
-	let (resolved_config, role_name) =
-		crate::agent::resolver::resolve_config_and_role(Some(&role), &base_config, None).await?;
-
-	// `merge_agent_toml` does a *union* of mcp.servers (base + manifest), so
-	// `resolved_config.mcp.servers` still includes the user's local servers
-	// (e.g. http_test, github) that the role doesn't actually want. Run the
-	// merged config through `get_merged_config_for_role` to filter
-	// `mcp.servers` down to only what this role's `server_refs` enable —
-	// same shape `octomind run` uses for the standard flow.
-	let mut resolved_config = resolved_config.get_merged_config_for_role(&role_name);
-
-	// Apply per-run workdir override so filesystem tools target the right
-	// directory. Stored on Config so downstream tool execution honors it.
-	resolved_config.set_working_directory(std::path::PathBuf::from(&workdir));
-
-	let role_struct = resolved_config.get_role_config_struct(&role_name).clone();
-	let effective_model = role_struct
-		.model
-		.clone()
-		.unwrap_or_else(|| resolved_config.model.clone());
-	let temperature = role_struct.temperature;
-	let top_p = role_struct.top_p;
-	let top_k = role_struct.top_k;
-	let should_cache = crate::session::model_supports_caching(&effective_model);
-
-	let now = std::time::SystemTime::now()
-		.duration_since(std::time::UNIX_EPOCH)
-		.unwrap_or_default()
-		.as_secs();
-
-	// Append system (only on first turn) + user. Borrow guard scoped tight
-	// so we don't hold the lock across awaits.
-	{
-		let mut h = history.write().unwrap();
-		if h.is_empty() {
-			h.push(Message {
-				role: "system".to_string(),
-				content: role_struct.system.clone(),
-				timestamp: now,
-				cached: should_cache,
-				..Default::default()
-			});
-		}
-		h.push(Message {
-			role: "user".to_string(),
-			content: prompt.clone(),
-			timestamp: now,
-			cached: false,
-			..Default::default()
-		});
-	}
-
-	// Snapshot the history into an owned Vec — the guard's lifetime is
-	// confined to this block so it never spans a subsequent `.await`.
-	let mut conv_messages: Vec<Message> = {
-		let h = history.read().unwrap();
-		h.clone()
-	};
-
-	let validation_params = ChatCompletionWithValidationParams::new(
-		&conv_messages,
-		&effective_model,
-		temperature,
-		top_p,
-		top_k,
-		resolved_config.get_effective_max_tokens(),
-		&resolved_config,
-	)
-	.with_max_retries(resolved_config.max_retries)
-	.with_cancellation_token(cancel_rx.clone());
-
-	let response = crate::session::chat_completion_with_validation(validation_params).await?;
-
-	if *cancel_rx.borrow() {
-		anyhow::bail!("Operation cancelled");
-	}
-
-	let mut current_content = response.content;
-	let mut current_exchange = response.exchange;
-	let mut current_tool_calls_param = response.tool_calls;
-
-	loop {
-		if *cancel_rx.borrow() {
-			anyhow::bail!("Operation cancelled");
-		}
-
-		let current_tool_calls = if let Some(calls) = current_tool_calls_param.take() {
-			if !calls.is_empty() {
-				calls
-			} else {
-				crate::mcp::parse_tool_calls(&current_content)
-			}
-		} else {
-			crate::mcp::parse_tool_calls(&current_content)
-		};
-
-		if current_tool_calls.is_empty() {
-			break;
-		}
-
-		let original_tool_calls =
-			crate::session::chat::MessageHandler::extract_original_tool_calls(&current_exchange);
-		let assistant_msg = Message {
-			role: "assistant".to_string(),
-			content: current_content.clone(),
-			timestamp: std::time::SystemTime::now()
-				.duration_since(std::time::UNIX_EPOCH)
-				.unwrap_or_default()
-				.as_secs(),
-			cached: false,
-			tool_calls: original_tool_calls,
-			..Default::default()
-		};
-		conv_messages.push(assistant_msg.clone());
-		{
-			let mut h = history.write().unwrap();
-			h.push(assistant_msg);
-		}
-
-		let output_mode = crate::session::output::detect_output_mode(
-			resolved_config
-				.runtime_output_mode
-				.as_deref()
-				.unwrap_or("plain"),
-		);
-		let layer_params =
-			crate::session::chat::response::tool_execution::LayerToolExecutionParams {
-				tool_calls: current_tool_calls,
-				session_name: format!("tap_{role_name}"),
-				layer_name: format!("tap_{role_name}"),
-				operation_cancelled: Some(cancel_rx.clone()),
-				mode: output_mode,
-			};
-		let (tool_results, _) =
-			crate::session::chat::response::tool_execution::execute_layer_tool_calls_parallel(
-				&resolved_config,
-				layer_params,
-			)
-			.await?;
-
-		if *cancel_rx.borrow() {
-			anyhow::bail!("Operation cancelled");
-		}
-		if tool_results.is_empty() {
-			break;
-		}
-
-		for tool_result in &tool_results {
-			let raw_content = tool_result.extract_content();
-			let (tool_content, _) = crate::utils::truncation::truncate_mcp_response_global(
-				&raw_content,
-				resolved_config.mcp_response_tokens_threshold,
-			);
-			let tool_msg = Message {
-				role: "tool".to_string(),
-				content: tool_content,
-				timestamp: std::time::SystemTime::now()
-					.duration_since(std::time::UNIX_EPOCH)
-					.unwrap_or_default()
-					.as_secs(),
-				cached: false,
-				tool_call_id: Some(tool_result.tool_id.clone()),
-				name: Some(tool_result.tool_name.clone()),
-				..Default::default()
-			};
-			conv_messages.push(tool_msg.clone());
-			{
-				let mut h = history.write().unwrap();
-				h.push(tool_msg);
-			}
-		}
-
-		let follow_up_params = ChatCompletionWithValidationParams::new(
-			&conv_messages,
-			&effective_model,
-			temperature,
-			top_p,
-			top_k,
-			resolved_config.get_effective_max_tokens(),
-			&resolved_config,
-		)
-		.with_max_retries(resolved_config.max_retries)
-		.with_cancellation_token(cancel_rx.clone());
-
-		let follow_up = crate::session::chat_completion_with_validation(follow_up_params).await?;
-		if *cancel_rx.borrow() {
-			anyhow::bail!("Operation cancelled");
-		}
-
-		let has_tool_calls = if let Some(ref calls) = follow_up.tool_calls {
-			!calls.is_empty()
-		} else {
-			!crate::mcp::parse_tool_calls(&follow_up.content).is_empty()
-		};
-		let should_continue =
-			crate::session::chat::response::tool_result_processor::check_should_continue(
-				&follow_up,
-				&resolved_config,
-				has_tool_calls,
-			);
-
-		current_content = follow_up.content;
-		current_exchange = follow_up.exchange;
-		current_tool_calls_param = follow_up.tool_calls;
-
-		if !should_continue {
-			break;
-		}
-	}
-
-	// Append the final assistant message to history so resume sees it.
-	let final_msg = Message {
-		role: "assistant".to_string(),
-		content: current_content.clone(),
-		timestamp: std::time::SystemTime::now()
-			.duration_since(std::time::UNIX_EPOCH)
-			.unwrap_or_default()
-			.as_secs(),
-		cached: false,
-		..Default::default()
-	};
-	{
-		let mut h = history.write().unwrap();
-		h.push(final_msg);
-	}
-
-	Ok(current_content.trim().to_string())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -391,6 +391,10 @@ pub async fn get_available_functions(config: &crate::config::Config) -> Vec<McpF
 	functions.extend(crate::mcp::core::dynamic::get_all_functions());
 	functions.extend(crate::mcp::core::dynamic_agents::get_all_functions());
 
+	// Project-local tools (`<workdir>/.agents/tools/<name>`) — always-on,
+	// role-agnostic. Same shape as OCTOMIND_SKILLS but driven by disk presence.
+	functions.extend(crate::mcp::core::local_tool::get_all_functions());
+
 	functions
 }
 
@@ -687,6 +691,24 @@ async fn route_builtin_tool(
 			result.tool_id = call.tool_id.clone();
 			Ok(result)
 		}
+		"local" => {
+			crate::log_debug!(
+				"Executing '{}' via local-tool runner (.agents/tools)",
+				call.tool_name
+			);
+			let result = match core::local_tool::execute(call).await {
+				Ok(mut r) => {
+					r.tool_id = call.tool_id.clone();
+					r
+				}
+				Err(e) => McpToolResult::error(
+					call.tool_name.clone(),
+					call.tool_id.clone(),
+					format!("local tool '{}' failed: {}", call.tool_name, e),
+				),
+			};
+			Ok(result)
+		}
 		other => Err(anyhow::anyhow!("Unknown builtin server: {}", other)),
 	}
 }
@@ -716,8 +738,12 @@ async fn execute_tool_without_cancellation(
 					));
 				}
 			}
-			// Dynamic server tools: allow if from a config-defined server or owned by this session
-			if !core::dynamic::is_dynamic_by_tool(&call.tool_name) {
+			// Dynamic server tools: allow if from a config-defined server or owned by this session.
+			// Project-local tools live under the synthetic "local" server and are workdir-scoped,
+			// so they bypass this check (no session-ownership concept applies).
+			if !core::dynamic::is_dynamic_by_tool(&call.tool_name)
+				&& target_server.name() != core::local_tool::SERVER_NAME
+			{
 				let is_config_server = config
 					.mcp
 					.servers

--- a/src/mcp/tool_map.rs
+++ b/src/mcp/tool_map.rs
@@ -413,6 +413,20 @@ async fn build_tool_server_map_impl(config: &Config) -> Result<HashMap<String, M
 		};
 		tool_map.entry(tool_name).or_insert_with(|| agent_server);
 	}
+
+	// Project-local tools — `<workdir>/.agents/tools/<name>` shebang scripts.
+	// Lowest priority: `or_insert` keeps config/dynamic winners on collision,
+	// so a script can never shadow a real tool by accident.
+	for func in crate::mcp::core::local_tool::get_all_functions() {
+		let local_server = McpServerConfig::Builtin {
+			name: crate::mcp::core::local_tool::SERVER_NAME.to_string(),
+			timeout_seconds: 300,
+			tools: vec![func.name.clone()],
+			auto_bind: None,
+		};
+		tool_map.entry(func.name).or_insert(local_server);
+	}
+
 	Ok(tool_map)
 }
 

--- a/src/session/chat/markdown.rs
+++ b/src/session/chat/markdown.rs
@@ -720,16 +720,52 @@ impl Default for MarkdownRenderer {
 
 // Helper function to check if content looks like markdown
 pub fn is_markdown_content(content: &str) -> bool {
-	// Simple heuristics to detect markdown content
-	content.contains("```")
-		|| content.contains("# ")
-		|| content.contains("## ")
-		|| content.contains("### ")
+	// Simple heuristics to detect markdown content.
+	// Check line-anchored markers (lists, headings, quotes) so we don't
+	// require a leading newline before them, and detect inline code (`...`)
+	// independently of fenced blocks.
+	if content.contains("```")
 		|| content.contains("**")
-		|| content.contains("*")
-		|| content.contains("[")
-		|| content.contains("|")
-		|| content.contains("> ")
+		|| content.contains("__")
+		|| content.contains("](")
+	{
+		return true;
+	}
+
+	// Inline code: at least one matched pair of backticks on the same line.
+	if content.contains('`') {
+		for line in content.lines() {
+			if line.matches('`').count() >= 2 {
+				return true;
+			}
+		}
+	}
+
+	for raw in content.lines() {
+		let line = raw.trim_start();
+		if line.starts_with("# ")
+			|| line.starts_with("## ")
+			|| line.starts_with("### ")
+			|| line.starts_with("#### ")
+			|| line.starts_with("##### ")
+			|| line.starts_with("###### ")
+			|| line.starts_with("- ")
+			|| line.starts_with("* ")
+			|| line.starts_with("+ ")
+			|| line.starts_with("> ")
+			|| line.starts_with("| ")
+		{
+			return true;
+		}
+		// Ordered list: digits followed by ". "
+		let bytes = line.as_bytes();
+		let digits = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
+		if digits > 0 && bytes.get(digits) == Some(&b'.') && bytes.get(digits + 1) == Some(&b' ') {
+			return true;
+		}
+	}
+
+	false
 }
 
 #[cfg(test)]

--- a/src/session/layers/processor.rs
+++ b/src/session/layers/processor.rs
@@ -56,8 +56,10 @@ impl Layer for LayerProcessor {
 
 		// Execute via ACP protocol
 		let start = std::time::Instant::now();
-		let output =
-			run_acp_command(&self.config.command, &task, &workdir, operation_cancelled).await?;
+		let mut parts = self.config.command.split_whitespace();
+		let program = parts.next().unwrap_or("");
+		let args: Vec<&str> = parts.collect();
+		let output = run_acp_command(program, &args, &task, &workdir, operation_cancelled).await?;
 
 		// Return result with timing info
 		// Note: exchange/token_usage come from the ACP session's role config

--- a/src/session/tap_runs.rs
+++ b/src/session/tap_runs.rs
@@ -35,7 +35,6 @@ use std::time::SystemTime;
 use tokio::sync::watch;
 
 use crate::session::context::SessionId;
-use crate::session::Message;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TapJobStatus {
@@ -58,9 +57,10 @@ impl TapJobStatus {
 
 /// A single tap-run, tracked from spawn through completion.
 ///
-/// `cancel_tx` carries the abort signal — the running `run_tap_role` future
-/// holds a paired receiver and bails when the value flips to `true`. The
-/// receiver is also handed to the LLM call so cancellation aborts mid-tool.
+/// `cancel_tx` carries the abort signal — the ACP subprocess driver holds a
+/// paired receiver and kills the child when the value flips to `true`.
+/// Conversation state lives on disk in the named session file (`<id>.jsonl`),
+/// so resume is just a fresh subprocess with `--name <id>`.
 pub struct TapJob {
 	pub id: String,
 	/// Role tag — `category:variant`, e.g. `developer:general`.
@@ -69,9 +69,6 @@ pub struct TapJob {
 	pub workdir: String,
 	pub started_at: SystemTime,
 	pub status: Arc<RwLock<TapJobStatus>>,
-	/// Conversation history — system + user/assistant/tool messages.
-	/// Shared with the runner so resume sees prior turns.
-	pub history: Arc<RwLock<Vec<Message>>>,
 	pub cancel_tx: watch::Sender<bool>,
 }
 
@@ -219,52 +216,19 @@ pub fn cancel_job(id: &str) -> Option<TapJobStatus> {
 	Some(current)
 }
 
-/// Type alias for the complex return type of [`get_handles`].
-type TapHandles = (
-	Arc<RwLock<Vec<Message>>>,
-	Arc<RwLock<TapJobStatus>>,
-	watch::Receiver<bool>,
-);
-
-/// Borrow the runtime handles for a job — history, status, and a fresh
-/// cancellation receiver. Used by the runner to resume an existing job.
-#[allow(clippy::type_complexity)]
-pub fn get_handles(id: &str) -> Option<TapHandles> {
+/// Borrow the live status handle and a fresh cancellation receiver for a
+/// running job. Used by `tap run` when a caller resumes by id — we need the
+/// shared status cell (so the resumed turn flips it back to terminal) and
+/// a cancel receiver subscribed to the existing sender.
+pub fn get_status_and_cancel(
+	id: &str,
+) -> Option<(Arc<RwLock<TapJobStatus>>, watch::Receiver<bool>)> {
 	let session_id = crate::session::context::current_session_id()?;
 	let guard = REGISTRY.read().ok()?;
 	let reg = guard.as_ref()?;
 	let jobs = reg.jobs.get(&session_id)?;
 	let job = jobs.iter().find(|j| j.id == id)?;
-	Some((
-		Arc::clone(&job.history),
-		Arc::clone(&job.status),
-		job.cancel_tx.subscribe(),
-	))
-}
-
-/// Set a job's terminal status. Used by the runner to mark `Done`/`Failed`
-/// when the LLM loop completes.
-pub fn mark_status(id: &str, status: TapJobStatus) {
-	let session_id = match crate::session::context::current_session_id() {
-		Some(id) => id,
-		None => return,
-	};
-	let guard = match REGISTRY.read() {
-		Ok(g) => g,
-		Err(_) => return,
-	};
-	let Some(reg) = guard.as_ref() else { return };
-	let Some(jobs) = reg.jobs.get(&session_id) else {
-		return;
-	};
-	if let Some(job) = jobs.iter().find(|j| j.id == id) {
-		if let Ok(mut s) = job.status.write() {
-			// Don't overwrite a terminal status (e.g. Cancelled wins over Done).
-			if *s == TapJobStatus::Running {
-				*s = status;
-			}
-		}
-	}
+	Some((Arc::clone(&job.status), job.cancel_tx.subscribe()))
 }
 
 /// Generate a fresh tap-run id from a role tag — `tap-<role-with-dash>-<6hex>`.


### PR DESCRIPTION
- Split command strings into program and arguments before execution
- Replace in-process LLM loop with external octomind acp calls
- Use disk-based session persistence via --name for tap-runs
- Remove redundant in-memory history tracking and config merging
- Locate current executable to ensure consistent subprocess version
- Simplify job handle retrieval and task management logic
- Update tap-run lifecycle to support external process resumption
- Improve clarity of ACP command execution interface