### PR TITLE
feat(schedule): implement persistence and state restoration

### DIFF
--- a/src/acp/agent.rs
+++ b/src/acp/agent.rs
@@ -537,6 +537,7 @@ impl agent_client_protocol::Agent for OctomindAgent {
 		crate::session::context::with_session_id(session_id.clone(), async move {
 			crate::session::context::init_session_services(&role_for_pool);
 			crate::mcp::core::plan::core::restore_plan_for_session(&session_id_for_restore);
+			crate::mcp::core::schedule::core::restore_schedule_for_session(&session_id_for_restore);
 		})
 		.await;
 
@@ -1075,6 +1076,7 @@ impl agent_client_protocol::Agent for OctomindAgent {
 		crate::session::context::with_session_id(actual_session_id.clone(), async move {
 			crate::session::context::init_session_services(&role_for_pool);
 			crate::mcp::core::plan::core::restore_plan_for_session(&session_id_for_restore);
+			crate::mcp::core::schedule::core::restore_schedule_for_session(&session_id_for_restore);
 		})
 		.await;
 

--- a/src/mcp/core/schedule/core.rs
+++ b/src/mcp/core/schedule/core.rs
@@ -46,6 +46,7 @@ fn get_store() -> Arc<Mutex<ScheduleStore>> {
 /// so the inbox is the single source of truth for all injected messages.
 pub fn flush_due_to_inbox() {
 	let store = get_store();
+	let mut mutated = false;
 	// NOTE: must NOT use `while let Some(entry) = store.lock().unwrap().pop_due()`.
 	// The MutexGuard temporary in a `while let` scrutinee lives for the entire
 	// loop body, so re-locking inside the body (to reschedule) deadlocks.
@@ -54,6 +55,7 @@ pub fn flush_due_to_inbox() {
 			Some(e) => e,
 			None => break,
 		};
+		mutated = true;
 
 		// If this is a repeating entry, re-add it before pushing to inbox.
 		if entry.interval_secs.is_some() {
@@ -71,6 +73,92 @@ pub fn flush_due_to_inbox() {
 			content: entry.message,
 		});
 	}
+	if mutated {
+		persist_schedule_snapshot();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Persistence: write snapshot after every mutation, replay last on resume
+// ---------------------------------------------------------------------------
+
+/// Append the current schedule store to the session log (best-effort, no-op outside a session).
+/// Lock is held only long enough to clone the entries; file I/O happens after release.
+fn persist_schedule_snapshot() {
+	let Some(session_id) = crate::session::context::current_session_id() else {
+		return;
+	};
+	let entries_snapshot: Vec<ScheduleEntry> = {
+		let store = get_store();
+		let guard = store.lock().unwrap();
+		guard.entries().to_vec()
+	};
+	if let Err(e) = crate::session::logger::log_schedule_snapshot(&session_id, &entries_snapshot) {
+		crate::log_debug!("Failed to log schedule snapshot: {}", e);
+	}
+}
+
+/// Restore the schedule store (if any) from the session log into session-scoped storage.
+/// Called at session startup (all entry points) right after init_session_services.
+/// Safe no-op when the log file doesn't exist or contains no snapshot.
+pub fn restore_schedule_for_session(session_name: &str) {
+	let log_file = match crate::session::logger::get_session_log_path(session_name) {
+		Ok(p) => p,
+		Err(e) => {
+			crate::log_debug!(
+				"restore_schedule_for_session: cannot resolve log file: {}",
+				e
+			);
+			return;
+		}
+	};
+	if !log_file.exists() {
+		return;
+	}
+
+	let file = match std::fs::File::open(&log_file) {
+		Ok(f) => f,
+		Err(e) => {
+			crate::log_debug!("restore_schedule_for_session: open failed: {}", e);
+			return;
+		}
+	};
+
+	use std::io::{BufRead, BufReader};
+	let reader = BufReader::new(file);
+	let mut latest_entries: Option<Vec<ScheduleEntry>> = None;
+
+	for line in reader.lines().map_while(Result::ok) {
+		let Ok(val) = serde_json::from_str::<serde_json::Value>(&line) else {
+			continue;
+		};
+		let Some(t) = val.get("type").and_then(|t| t.as_str()) else {
+			continue;
+		};
+		if t != "SCHEDULE_SNAPSHOT" {
+			continue;
+		}
+		let Some(entries_val) = val.get("entries") else {
+			continue;
+		};
+		match serde_json::from_value::<Vec<ScheduleEntry>>(entries_val.clone()) {
+			Ok(entries) => latest_entries = Some(entries),
+			Err(e) => crate::log_debug!("restore_schedule_for_session: deserialize failed: {}", e),
+		}
+	}
+
+	let Some(entries) = latest_entries else {
+		return;
+	};
+	let count = entries.len();
+	let session_id = session_name.to_string();
+	let storage = crate::session::context::get_schedule_storage(&session_id);
+	storage.lock().unwrap().seed_entries(entries);
+	crate::log_debug!(
+		"Restored {} scheduled entries for session '{}'",
+		count,
+		session_name
+	);
 }
 
 /// Returns true if there are any pending scheduled entries.
@@ -307,6 +395,7 @@ fn handle_add(call: &McpToolCall) -> Result<McpToolResult> {
 	let trigger_fmt = entry.trigger_at.format("%Y-%m-%d %H:%M:%S").to_string();
 
 	get_store().lock().unwrap().add(entry);
+	persist_schedule_snapshot();
 
 	// Wake up the schedule monitor so it recalculates the next due time
 	if let Some(sid) = crate::session::context::current_session_id() {
@@ -407,6 +496,7 @@ fn handle_remove(call: &McpToolCall) -> Result<McpToolResult> {
 
 	let removed = get_store().lock().unwrap().remove(&id);
 	if removed {
+		persist_schedule_snapshot();
 		// Wake up the schedule monitor so it recalculates the next due time
 		if let Some(sid) = crate::session::context::current_session_id() {
 			crate::session::context::notify_schedule_change(&sid);
@@ -511,6 +601,7 @@ fn handle_edit(call: &McpToolCall) -> Result<McpToolResult> {
 			.edit(&id, new_description, new_message, new_when, new_interval);
 
 	if updated {
+		persist_schedule_snapshot();
 		// Wake up the schedule monitor so it recalculates the next due time
 		if let Some(sid) = crate::session::context::current_session_id() {
 			crate::session::context::notify_schedule_change(&sid);

--- a/src/mcp/core/schedule/storage.rs
+++ b/src/mcp/core/schedule/storage.rs
@@ -16,10 +16,11 @@
 
 use anyhow::{bail, Result};
 use chrono::{DateTime, Duration, Local, NaiveTime};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// A single scheduled task.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduleEntry {
 	/// Short unique ID (first 8 chars of UUID).
 	pub id: String,
@@ -185,6 +186,13 @@ impl ScheduleStore {
 
 	pub fn entries(&self) -> &[ScheduleEntry] {
 		&self.entries
+	}
+
+	/// Replace all entries with the given set, keeping the trigger-time ordering invariant.
+	/// Used by session restore to seed the store from a persisted snapshot.
+	pub fn seed_entries(&mut self, mut entries: Vec<ScheduleEntry>) {
+		entries.sort_by_key(|e| e.trigger_at);
+		self.entries = entries;
 	}
 }
 

--- a/src/session/chat/animation_manager.rs
+++ b/src/session/chat/animation_manager.rs
@@ -431,38 +431,26 @@ impl Default for AnimationManager {
 	}
 }
 
-/// Build the cost/context prefix shown before "Working …".
-fn build_base_message(cost_bits: u64, ctx: u64, thresh: u64) -> String {
+/// Build a spinner message: shared status body + label. The spinner tick
+/// character (`⠋⠙⠹⠸…`) is the left-edge marker for this line — drawn by
+/// indicatif's template — so the body has no `▍`. The prompt's input line
+/// owns `▍` as its own line-leader.
+fn build_spinner_message(cost_bits: u64, ctx: u64, thresh: u64, label: &str) -> String {
 	let cost = cost_bits as f64 / 10000.0;
-	if cost > 0.0 && thresh > 0 {
-		let pct = (ctx as f64 / thresh as f64 * 100.0).min(100.0);
-		format!("[${:.2}|{:.1}%] Working …", cost, pct)
-	} else if cost > 0.0 {
-		format!("[${:.2}|∞] Working …", cost)
-	} else if thresh > 0 {
-		let pct = (ctx as f64 / thresh as f64 * 100.0).min(100.0);
-		format!("[{:.1}%] Working …", pct)
+	let body = crate::session::chat::status_prefix::build_status_body(cost, ctx, thresh);
+	if body.is_empty() {
+		label.to_string()
 	} else {
-		"Working …".to_string()
+		format!("{} {}", body, label)
 	}
 }
 
-/// Build a phase-labelled message like `[$1.23|45%] Validating (rust)…`.
-/// Preserves the same cost/context prefix as `build_base_message` so the
-/// user's mental model (bracketed prefix = session state) stays intact.
+fn build_base_message(cost_bits: u64, ctx: u64, thresh: u64) -> String {
+	build_spinner_message(cost_bits, ctx, thresh, "Working …")
+}
+
 fn build_phase_message(cost_bits: u64, ctx: u64, thresh: u64, phase: &str) -> String {
-	let cost = cost_bits as f64 / 10000.0;
-	if cost > 0.0 && thresh > 0 {
-		let pct = (ctx as f64 / thresh as f64 * 100.0).min(100.0);
-		format!("[${:.2}|{:.1}%] {}", cost, pct, phase)
-	} else if cost > 0.0 {
-		format!("[${:.2}|∞] {}", cost, phase)
-	} else if thresh > 0 {
-		let pct = (ctx as f64 / thresh as f64 * 100.0).min(100.0);
-		format!("[{:.1}%] {}", pct, phase)
-	} else {
-		phase.to_string()
-	}
+	build_spinner_message(cost_bits, ctx, thresh, phase)
 }
 
 /// Global animation manager instance.

--- a/src/session/chat/animation_manager.rs
+++ b/src/session/chat/animation_manager.rs
@@ -431,13 +431,14 @@ impl Default for AnimationManager {
 	}
 }
 
-/// Build a spinner message: shared status body + label. The spinner tick
-/// character (`⠋⠙⠹⠸…`) is the left-edge marker for this line — drawn by
-/// indicatif's template — so the body has no `▍`. The prompt's input line
-/// owns `▍` as its own line-leader.
+/// Build a spinner message: status body (plain, no embedded ANSI) + label.
+/// The template's `{msg:.cyan}` directive paints the entire message cyan —
+/// matching the original spinner appearance. Inline ANSI in the body would
+/// locally override the cyan and break uniform line coloring, so we use the
+/// plain body here and rely on glyph contrast for the bar.
 fn build_spinner_message(cost_bits: u64, ctx: u64, thresh: u64, label: &str) -> String {
 	let cost = cost_bits as f64 / 10000.0;
-	let body = crate::session::chat::status_prefix::build_status_body(cost, ctx, thresh);
+	let body = crate::session::chat::status_prefix::build_status_body_plain(cost, ctx, thresh);
 	if body.is_empty() {
 		label.to_string()
 	} else {

--- a/src/session/chat/input.rs
+++ b/src/session/chat/input.rs
@@ -121,6 +121,120 @@ fn display_shortcuts_help() {
 	let _ = std::io::stdout().flush();
 }
 
+/// Strip ANSI CSI escape sequences from a string.
+fn strip_ansi(s: &str) -> String {
+	let mut out = String::with_capacity(s.len());
+	let mut in_esc = false;
+	for c in s.chars() {
+		if in_esc {
+			if c.is_ascii_alphabetic() {
+				in_esc = false;
+			}
+			continue;
+		}
+		if c == '\x1b' {
+			in_esc = true;
+			continue;
+		}
+		out.push(c);
+	}
+	out
+}
+
+/// Approximate display width: char count of ANSI-stripped string.
+/// Underestimates for wide chars (CJK, emoji), which is the safe direction —
+/// we only ever clear rows we know reedline rendered.
+fn display_cols(s: &str) -> usize {
+	strip_ansi(s).chars().count()
+}
+
+/// Number of terminal rows reedline used to render the prompt+input.
+/// Returns 0 if it couldn't be determined (callers should skip redraw).
+fn rendered_rows(
+	prompt_left: &str,
+	indicator: &str,
+	multiline: &str,
+	line: &str,
+	term_w: usize,
+) -> usize {
+	if term_w == 0 {
+		return 0;
+	}
+	let first_prefix = display_cols(prompt_left) + display_cols(indicator);
+	let cont_prefix = display_cols(multiline);
+	let mut rows = 0usize;
+	for (i, l) in line.split('\n').enumerate() {
+		let prefix = if i == 0 { first_prefix } else { cont_prefix };
+		let combined = (prefix + display_cols(l)).max(1);
+		rows += combined.div_ceil(term_w);
+	}
+	rows
+}
+
+/// Re-render a just-submitted user input as a styled history marker,
+/// replacing reedline's plain rendering. Call immediately after
+/// `Signal::Success` returns, while the cursor is on the line below the
+/// rendered prompt+input.
+///
+/// Style: bright-blue left bar (▌) + italic message text. No background,
+/// so it's resize-stable in scrollback and reads clearly on any terminal
+/// theme.
+///
+/// No-op for empty input. Best-effort: silently bails if terminal size or
+/// I/O fails.
+fn highlight_submitted_input(prompt_left: &str, indicator: &str, multiline: &str, line: &str) {
+	use crossterm::{cursor, queue, terminal};
+
+	if line.trim().is_empty() {
+		return;
+	}
+	let Ok((term_w_u16, _)) = crossterm::terminal::size() else {
+		return;
+	};
+	let term_w = term_w_u16 as usize;
+	if term_w < 4 {
+		return;
+	}
+
+	let rows = rendered_rows(prompt_left, indicator, multiline, line, term_w);
+	if rows == 0 {
+		return;
+	}
+
+	let mut out = std::io::stdout();
+	if queue!(
+		out,
+		cursor::MoveUp(rows as u16),
+		cursor::MoveToColumn(0),
+		terminal::Clear(terminal::ClearType::FromCursorDown),
+	)
+	.is_err()
+	{
+		return;
+	}
+	let _ = out.flush();
+
+	// Bright-blue left bar (▍) + italic message text. One marker at the start
+	// of the line is enough to make user messages stand out in history.
+	// No background, so it's resize-stable and works on any terminal theme.
+	let marker = "\x1b[94m▍\x1b[39m"; // bright blue ▍, then reset fg only
+	let italic_on = "\x1b[3m";
+	let reset = "\x1b[0m";
+
+	// Continuation prefix aligns under the message text (▍=1 cell + space).
+	let cont_pad = "  ";
+
+	for (i, raw_line) in line.split('\n').enumerate() {
+		let prefix = if i == 0 {
+			format!("{} {}", marker, italic_on)
+		} else {
+			format!("{}{}", cont_pad, italic_on)
+		};
+		println!("{}{}{}", prefix, raw_line, reset);
+	}
+	let _ = std::io::stdout().flush();
+}
+
 fn calculate_context_percentage(
 	current_context_tokens: u64,
 	max_session_tokens_threshold: usize,
@@ -382,7 +496,7 @@ pub fn read_user_input(
 		format!("{} ", prompt_text).bright_blue().to_string()
 	};
 	let prompt = crate::session::chat::ChatPrompt::new(
-		prompt_left,
+		prompt_left.clone(),
 		"〉".bright_blue().to_string(),
 		reverse_search_active,
 	);
@@ -402,6 +516,10 @@ pub fn read_user_input(
 					display_shortcuts_help();
 					continue;
 				}
+
+				// Replace reedline's plain echo of the submitted input with a
+				// dim-background highlight so it stands out as a history marker.
+				highlight_submitted_input(&prompt_left, "〉", "  ", &line);
 
 				// Check if this is an "add without sending" request (Ctrl+G)
 				// and drain any clipboard blobs auto-attached via Ctrl+V.

--- a/src/session/chat/input.rs
+++ b/src/session/chat/input.rs
@@ -235,20 +235,6 @@ fn highlight_submitted_input(prompt_left: &str, indicator: &str, multiline: &str
 	let _ = std::io::stdout().flush();
 }
 
-fn calculate_context_percentage(
-	current_context_tokens: u64,
-	max_session_tokens_threshold: usize,
-) -> Option<f64> {
-	if max_session_tokens_threshold > 0 {
-		Some(
-			(current_context_tokens as f64 / max_session_tokens_threshold as f64 * 100.0)
-				.min(100.0),
-		)
-	} else {
-		None
-	}
-}
-
 fn add_completion_menu_keybindings(keybindings: &mut Keybindings) {
 	keybindings.add_binding(
 		KeyModifiers::NONE,
@@ -468,32 +454,19 @@ pub fn read_user_input(
 		.with_external_printer(printer)
 		.with_poll_interval(std::time::Duration::from_millis(100));
 
-	// Set prompt with cost and context percentage
-	let prompt_text = if estimated_cost > 0.0 {
-		let context_pct =
-			calculate_context_percentage(current_context_tokens, max_session_tokens_threshold);
-
-		if let Some(pct) = context_pct {
-			format!("[${:.2}|{:.1}%]", estimated_cost, pct)
-		} else {
-			format!("[${:.2}|∞]", estimated_cost)
-		}
-	} else if max_session_tokens_threshold > 0 {
-		// No cost but still show context percentage
-		let context_pct =
-			calculate_context_percentage(current_context_tokens, max_session_tokens_threshold);
-		if let Some(pct) = context_pct {
-			format!("[{:.1}%]", pct)
-		} else {
-			String::new()
-		}
-	} else {
-		String::new()
-	};
+	// Build the session-status prefix (`▍ $cost  bar  pct%`) — same renderer
+	// the working spinner uses, so prompt line and spinner line share a
+	// visual identity. Chevron `〉` is appended separately by ChatPrompt's
+	// indicator and is intentionally NOT part of the shared prefix.
+	let prompt_text = crate::session::chat::status_prefix::build_prompt_prefix(
+		estimated_cost,
+		current_context_tokens,
+		max_session_tokens_threshold as u64,
+	);
 	let prompt_left = if prompt_text.is_empty() {
 		String::new()
 	} else {
-		format!("{} ", prompt_text).bright_blue().to_string()
+		format!("{} ", prompt_text)
 	};
 	let prompt = crate::session::chat::ChatPrompt::new(
 		prompt_left.clone(),

--- a/src/session/chat/mod.rs
+++ b/src/session/chat/mod.rs
@@ -31,6 +31,7 @@ mod prompt;
 mod reedline_adapter;
 pub(crate) mod response;
 pub mod session;
+mod status_prefix;
 mod syntax;
 mod thinking_display;
 mod tool_display;

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -175,6 +175,9 @@ pub async fn run_interactive_session<T: std::fmt::Debug>(args: &T, config: &Conf
 		crate::session::context::init_session_services(&role);
 
 		crate::mcp::core::plan::core::restore_plan_for_session(&chat_session.session.info.name);
+		crate::mcp::core::schedule::core::restore_schedule_for_session(
+			&chat_session.session.info.name,
+		);
 
 		let _inject_listener =
 			crate::session::inject_listener::start_inject_listener(&chat_session.session.info.name);
@@ -1382,6 +1385,7 @@ pub async fn run_interactive_session_with_input<T: std::fmt::Debug>(
 	crate::mcp::initialize_mcp_for_role(&role, config).await?;
 	crate::session::context::init_session_services(&role);
 	crate::mcp::core::plan::core::restore_plan_for_session(&chat_session.session.info.name);
+	crate::mcp::core::schedule::core::restore_schedule_for_session(&chat_session.session.info.name);
 	// Start inject listener so `octomind send` can push messages into this session
 	let _inject_listener = crate::session::inject_listener::start_inject_listener(&chat_session.session.info.name);
 	// Start webhook listeners for any --hook flags

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -115,6 +115,12 @@ async fn start_webhook_guards<T: std::fmt::Debug>(
 
 // Run an interactive session
 pub async fn run_interactive_session<T: std::fmt::Debug>(args: &T, config: &Config) -> Result<()> {
+	// Suppress the tty driver's `^C` echo for the lifetime of the session.
+	// Otherwise the spinner's last drawn row gets stranded in scrollback when
+	// the echoed `^C` auto-wraps off the indicatif-padded line and our clear
+	// lands on the wrong row. See utils::term_echo for the full rationale.
+	let _echo_guard = crate::utils::term_echo::CtrlCEchoGuard::install();
+
 	// Setup and initialize session using helper function
 
 	let (chat_session, config_for_role, role, first_message_processed, spinner) =

--- a/src/session/chat/status_prefix.rs
+++ b/src/session/chat/status_prefix.rs
@@ -1,0 +1,102 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared "session status" body used by the interactive prompt and the
+//! working-spinner message. Body format (no leading marker):
+//!
+//!   `$0.01 ▰▰▱▱▱ 13.8%`
+//!
+//! The prompt prepends `▍` as its line-leader marker; the spinner uses the
+//! tick character (`⠋⠙⠹⠸…`) as its leader instead, so the two share the
+//! body but each owns its own left-edge identity.
+//!
+//! - `▰`/`▱` cells (5 total, ~20% each, `ceil(pct/20)` filled) make context
+//!   usage scan-able without reading the number.
+//! - `· ∞` is shown in place of the bar when there is no max threshold.
+//!
+//! The chevron `〉` is the prompt's input indicator and is NOT part of this
+//! body — animation messages append their own label ("Working …",
+//! "Validating …", etc.) after it.
+
+use colored::Colorize;
+
+/// Render the 5-cell context-usage bar. Filled cells bright blue, empty cells
+/// dim. Glyphs: `▰` (filled) / `▱` (empty).
+fn build_context_bar(pct: f64) -> String {
+	const CELLS: usize = 5;
+	let filled = ((pct / 100.0) * CELLS as f64).ceil() as usize;
+	let filled = filled.min(CELLS);
+	let mut out = String::with_capacity(32);
+	out.push_str("\x1b[94m");
+	for _ in 0..filled {
+		out.push('▰');
+	}
+	out.push_str("\x1b[90m");
+	for _ in 0..(CELLS - filled) {
+		out.push('▱');
+	}
+	out.push_str("\x1b[39m");
+	out
+}
+
+/// Build the status body (no leading marker). Returns an empty string when
+/// neither cost nor a max threshold is set (callers should not add a
+/// separator in that case).
+///
+/// Layout matrix:
+/// - cost > 0,  threshold > 0:  `$0.01 ▰▰▱▱▱ 13.8%`
+/// - cost > 0,  threshold == 0: `$0.01 · ∞`
+/// - cost == 0, threshold > 0:  `▰▰▱▱▱ 13.8%`
+/// - cost == 0, threshold == 0: `` (empty)
+pub fn build_status_body(cost: f64, context_tokens: u64, max_threshold: u64) -> String {
+	let pct = if max_threshold > 0 {
+		Some((context_tokens as f64 / max_threshold as f64 * 100.0).min(100.0))
+	} else {
+		None
+	};
+
+	match (cost > 0.0, pct) {
+		(true, Some(pct)) => format!(
+			"{} {} {}",
+			format!("${:.2}", cost).bright_blue(),
+			build_context_bar(pct),
+			format!("{:.1}%", pct).bright_blue(),
+		),
+		(true, None) => format!(
+			"{} {} {}",
+			format!("${:.2}", cost).bright_blue(),
+			"·".bright_black(),
+			"∞".bright_blue(),
+		),
+		(false, Some(pct)) => format!(
+			"{} {}",
+			build_context_bar(pct),
+			format!("{:.1}%", pct).bright_blue(),
+		),
+		(false, None) => String::new(),
+	}
+}
+
+/// Build the prompt prefix: `▍`-marker + status body. Returns just `▍ ` if
+/// no cost/threshold data is available so the prompt always has its
+/// identifying marker.
+pub fn build_prompt_prefix(cost: f64, context_tokens: u64, max_threshold: u64) -> String {
+	let marker = "▍".bright_blue();
+	let body = build_status_body(cost, context_tokens, max_threshold);
+	if body.is_empty() {
+		String::new()
+	} else {
+		format!("{} {}", marker, body)
+	}
+}

--- a/src/session/chat/status_prefix.rs
+++ b/src/session/chat/status_prefix.rs
@@ -100,3 +100,36 @@ pub fn build_prompt_prefix(cost: f64, context_tokens: u64, max_threshold: u64) -
 		format!("{} {}", marker, body)
 	}
 }
+
+/// Same status body but with no embedded ANSI codes. Used by the spinner
+/// so indicatif's `{msg:.cyan}` template directive paints the whole line
+/// uniformly cyan (the original spinner color). Filled vs empty bar cells
+/// rely on glyph contrast (`▰` vs `▱`) alone, since any inline ANSI here
+/// would locally override the template's cyan.
+pub fn build_status_body_plain(cost: f64, context_tokens: u64, max_threshold: u64) -> String {
+	let pct = if max_threshold > 0 {
+		Some((context_tokens as f64 / max_threshold as f64 * 100.0).min(100.0))
+	} else {
+		None
+	};
+
+	let plain_bar = |pct: f64| -> String {
+		const CELLS: usize = 5;
+		let filled = (((pct / 100.0) * CELLS as f64).ceil() as usize).min(CELLS);
+		let mut out = String::with_capacity(CELLS * 3);
+		for _ in 0..filled {
+			out.push('▰');
+		}
+		for _ in 0..(CELLS - filled) {
+			out.push('▱');
+		}
+		out
+	};
+
+	match (cost > 0.0, pct) {
+		(true, Some(pct)) => format!("${:.2} {} {:.1}%", cost, plain_bar(pct), pct),
+		(true, None) => format!("${:.2} · ∞", cost),
+		(false, Some(pct)) => format!("{} {:.1}%", plain_bar(pct), pct),
+		(false, None) => String::new(),
+	}
+}

--- a/src/session/logger.rs
+++ b/src/session/logger.rs
@@ -24,6 +24,7 @@
 //! the loader needs to reconstruct session state.
 
 use crate::mcp::core::plan::storage::ExecutionPlan;
+use crate::mcp::core::schedule::storage::ScheduleEntry;
 use crate::session::Message;
 use anyhow::Result;
 use std::fs::OpenOptions;
@@ -135,6 +136,19 @@ pub fn log_plan_cleared(session_name: &str) -> Result<()> {
 	let entry = serde_json::json!({
 		"type": "PLAN_CLEARED",
 		"timestamp": get_timestamp(),
+	});
+	append_to_log(&log_file, &serde_json::to_string(&entry)?)
+}
+
+/// Log a full snapshot of the schedule store so it can be restored on session resume.
+/// Written on every mutation (add/remove/edit/flush). The most recent snapshot wins on replay;
+/// an empty `entries` vec is meaningful — it records that the store was cleared.
+pub fn log_schedule_snapshot(session_name: &str, entries: &[ScheduleEntry]) -> Result<()> {
+	let log_file = get_session_log_file(session_name)?;
+	let entry = serde_json::json!({
+		"type": "SCHEDULE_SNAPSHOT",
+		"timestamp": get_timestamp(),
+		"entries": entries,
 	});
 	append_to_log(&log_file, &serde_json::to_string(&entry)?)
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -17,6 +17,7 @@
 pub mod file_parser;
 pub mod file_renderer;
 pub mod glob;
+pub mod term_echo;
 pub mod terminal_output;
 pub mod time;
 pub mod truncation;

--- a/src/utils/term_echo.rs
+++ b/src/utils/term_echo.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Suppress the tty driver's `^C` echo on SIGINT for the lifetime of an
+//! interactive session.
+//!
+//! Why this is needed: when the user presses Ctrl+C in a cooked-mode terminal,
+//! the tty driver echoes the literal characters `^C` to stdout at the current
+//! cursor position *before* delivering SIGINT. indicatif's spinner pads its
+//! line to terminal width on each draw, leaving the cursor at the very last
+//! column. The `^` of the echo therefore auto-wraps to a new row, and the
+//! subsequent `finish_and_clear` (which clears `bar_count = 1` rows starting
+//! from the current cursor row) wipes the wrapped echo line — leaving the
+//! actual spinner content stuck in scrollback above.
+//!
+//! Disabling `ECHOCTL` removes the echo entirely; SIGINT still fires
+//! normally and the spinner is cleared from the row it was actually drawn on.
+
+#[cfg(unix)]
+pub struct CtrlCEchoGuard {
+	saved_lflag: libc::tcflag_t,
+}
+
+#[cfg(unix)]
+impl CtrlCEchoGuard {
+	/// Clear `ECHOCTL` on stdin and return a guard that restores the original
+	/// value on Drop. Returns `None` if stdin isn't a tty or the tcgetattr /
+	/// tcsetattr calls fail.
+	pub fn install() -> Option<Self> {
+		let fd = libc::STDIN_FILENO;
+		// SAFETY: passing a valid stack pointer to libc::tcgetattr.
+		let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+		if unsafe { libc::tcgetattr(fd, &mut termios) } != 0 {
+			return None;
+		}
+		let saved_lflag = termios.c_lflag;
+		termios.c_lflag &= !libc::ECHOCTL;
+		// SAFETY: termios is fully initialized by tcgetattr above.
+		if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &termios) } != 0 {
+			return None;
+		}
+		Some(Self { saved_lflag })
+	}
+}
+
+#[cfg(unix)]
+impl Drop for CtrlCEchoGuard {
+	fn drop(&mut self) {
+		let fd = libc::STDIN_FILENO;
+		// SAFETY: stack-allocated termios passed to libc.
+		let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+		if unsafe { libc::tcgetattr(fd, &mut termios) } == 0 {
+			termios.c_lflag = self.saved_lflag;
+			unsafe { libc::tcsetattr(fd, libc::TCSANOW, &termios) };
+		}
+	}
+}
+
+#[cfg(not(unix))]
+pub struct CtrlCEchoGuard;
+
+#[cfg(not(unix))]
+impl CtrlCEchoGuard {
+	pub fn install() -> Option<Self> {
+		// Windows console does not echo `^C` for Ctrl+C events; no-op.
+		None
+	}
+}

--- a/src/websocket/server.rs
+++ b/src/websocket/server.rs
@@ -623,6 +623,7 @@ async fn handle_session_message(
 		// schedule/inbox/skill storage is keyed to this session ID.
 		crate::session::context::init_session_services(&role_for_pool);
 		crate::mcp::core::plan::core::restore_plan_for_session(&session_id);
+		crate::mcp::core::schedule::core::restore_schedule_for_session(&session_id);
 		crate::mcp::core::skill_auto::load_env_skills(&mut chat_session).await;
 		crate::mcp::core::capability::load_env_capabilities(&config_for_role, None).await;
 


### PR DESCRIPTION
- Implement schedule snapshot logging to session event logs
- Restore schedule state when resuming interactive sessions
- Restore schedule state when initializing websocket sessions
- Trigger snapshot persistence on every schedule mutation
- Add seed_entries to ScheduleStore for state recovery
- Sort schedule entries by trigger time before storage