### PR TITLE
refactor(compression): remove first_prompt_idx tracking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,336 @@
+# Contributing to Octomind
+
+Thank you for your interest in contributing. This document covers everything you need to ship correct, maintainable code.
+
+---
+
+## Table of Contents
+
+- [Development Setup](#development-setup)
+- [Code Style](#code-style)
+- [Architecture Overview](#architecture-overview)
+- [Adding Features](#adding-features)
+  - [New MCP Tool](#new-mcp-tool)
+  - [New Session Command](#new-session-command)
+  - [New Config Field](#new-config-field)
+  - [New Session-Scoped State](#new-session-scoped-state)
+- [Rust Patterns](#rust-patterns)
+- [Error Handling](#error-handling)
+- [Logging](#logging)
+- [Testing](#testing)
+- [Pre-Commit Checks](#pre-commit-checks)
+- [Commit Messages](#commit-messages)
+- [Validation Checklist](#validation-checklist)
+
+---
+
+## Development Setup
+
+```bash
+# Clone and build
+git clone https://github.com/muvon/octomind
+cd octomind
+cargo build
+
+# Install pre-commit hooks (required)
+pip install pre-commit
+pre-commit install
+
+# Run checks manually
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo check --all-targets --all-features
+```
+
+**Minimum Rust version:** 1.95 (enforced by `rust-version` in `Cargo.toml`).
+
+---
+
+## Code Style
+
+### Formatting
+
+- **Tabs, not spaces** — `rustfmt.toml` sets `hard_tabs = true`
+- **LF line endings**, UTF-8, trailing newline on every file (`.editorconfig`)
+- **120-character line limit**
+- Run `cargo fmt --all` before committing; the pre-commit hook enforces this
+
+### Copyright header
+
+Every new `.rs` file **must** begin with:
+
+```rust
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+```
+
+### Print macros
+
+Use the crate-level macros (`println!`, `eprintln!`, `print!`, `eprint!`) defined in `src/lib.rs`. They suspend the animation spinner automatically.
+
+```rust
+// ✅ correct
+println!("output");
+eprintln!("error");
+
+// ❌ breaks the spinner and wrong output path
+std::println!("output");
+std::eprintln!("error");
+```
+
+---
+
+## Architecture Overview
+
+```
+Config::load()  →  get_merged_config_for_role(role)  →  initialize_mcp_for_role()
+                                                              └─ TOOL_MAP built
+
+User input  →  /command?  →  pipelines  →  workflows  →  layers
+                                                             └─  tool execution loop  →  response
+```
+
+Key files:
+
+| What | Where |
+|------|-------|
+| Tool routing | `src/mcp/mod.rs` → `try_execute_tool_call()` |
+| Tool map (name → server) | `src/mcp/tool_map.rs` |
+| Core tool definitions | `src/mcp/core/functions.rs` |
+| Runtime tool definitions | `src/mcp/runtime/mod.rs` |
+| Session main loop | `src/session/chat/session/main_loop.rs` |
+| Session commands | `src/session/chat/session/commands/` |
+| Config types | `src/config/` |
+| Config defaults | `config-templates/default.toml` |
+| Directory constants | `src/directories.rs` |
+
+### Config merge rules
+
+- All `*.toml` files in the config directory are merged alphabetically
+- Files matching `mcp-*.toml` are loaded **after** all base files — they always win for same-named servers
+- Arrays are concatenated and deduped by `name`; tables are deep-merged
+- `auto_bind` is **exact-match** — `"developer"` does not match `"developer:general"`
+- `allowed_tools` non-empty silently drops any unlisted tool — `get_merged_config_for_role` auto-appends `"<server>:*"` for auto-bind servers
+
+---
+
+## Adding Features
+
+### New MCP Tool
+
+1. **Define** the tool schema in `src/mcp/core/functions.rs` → `get_all_functions()` (core) **or** `src/mcp/runtime/mod.rs` → `get_all_functions()` (runtime)
+2. **Implement** the handler in the same file/module
+3. **Route** in `src/mcp/mod.rs` → `route_builtin_tool()` — add a match arm under `"core"` or `"runtime"`
+4. **Register** in `src/mcp/tool_map.rs` — map the tool name to its server config
+
+Rules:
+- All failures return `Ok(McpToolResult::error(...))` — never `Err()`
+- Validate parameters explicitly; return a descriptive error for missing/wrong-type params
+- If a more specific tool exists for a use-case, append a hint (but only when that tool is actually enabled — see `src/mcp/hint_accumulator.rs`)
+
+```rust
+// ✅ parameter extraction pattern
+let param = match call.parameters.get("key") {
+    Some(Value::String(s)) if !s.trim().is_empty() => s.clone(),
+    Some(_) => return Ok(McpToolResult::error(call.tool_name.clone(), call.tool_id.clone(), "must be a non-empty string".into())),
+    None    => return Ok(McpToolResult::error(call.tool_name.clone(), call.tool_id.clone(), "required parameter".into())),
+};
+
+// ✅ wrapping internal errors
+match tool::execute(call).await {
+    Ok(mut r) => { r.tool_id = call.tool_id.clone(); Ok(r) }
+    Err(e)    => Ok(McpToolResult::error(call.tool_name.clone(), call.tool_id.clone(), format!("{e}")))
+}
+```
+
+### New Session Command (`/name`)
+
+1. Create `src/session/chat/session/commands/<name>.rs` — implement the handler returning `CommandResult`
+2. Add `mod <name>;` in `commands/mod.rs` and a routing arm in `process_command()`
+3. If the command has a new result shape, add a `CommandOutput` variant to the enum in `commands/mod.rs`
+4. Add the constant to `src/session/chat/commands.rs` and the `COMMANDS` array
+
+Note: `/done` is intercepted in `main_loop.rs` before reaching `process_command()`. The `DONE_COMMAND` arm in `process_command` is `unreachable!()` — do not add code there.
+
+### New Config Field
+
+1. Add the field with its default value to `config-templates/default.toml` **first**
+2. Add the corresponding field to the matching Rust type in `src/config/`
+3. Never hardcode config values — all defaults belong in the template
+
+### New Session-Scoped State
+
+There are **five** session entry points that must all be updated together:
+
+| Mode | Location |
+|------|----------|
+| Interactive / non-interactive CLI | `src/session/chat/session/main_loop.rs` → `init_session_runtime()` |
+| ACP `new_session` | `src/acp/agent.rs` ~line 568 |
+| ACP `initialize` | `src/acp/agent.rs` ~line 1166 |
+| WebSocket | `src/websocket/server.rs` ~line 625 |
+
+All session-scoped services are initialized through a single call:
+
+```rust
+crate::session::context::init_session_services(&role);
+```
+
+Never call `init_inbox_for_session`, `init_job_manager`, or similar directly. If you add new session-scoped state, add it inside `init_session_services` and verify all five entry points call it.
+
+---
+
+## Rust Patterns
+
+### Ownership
+
+- Default to owned types in struct fields (`String`, `Vec<T>`, `PathBuf`) — borrowed fields force lifetime parameters that infect callers
+- Borrow in function signatures: `&str`, `&[T]`, `&Path`; return owned values
+- Reach for `Cow<'a, T>` only when benchmarks show real allocation pressure
+
+### Shared state
+
+- `Arc<Mutex<T>>` held across `.await` is a deadlock — use `tokio::sync::Mutex` or an actor with a channel
+- Interior mutability (`RefCell`, `Mutex`) signals shared-state design — prefer ownership transfer or message passing
+
+### Abstractions
+
+- Define a trait when there are two real implementations, not in anticipation
+- Static dispatch (`fn f<T: Trait>`) is the default; `dyn Trait` only for type erasure
+- Newtype pattern (`struct UserId(u64)`) for domain types — prevents mixing primitives
+
+### General
+
+- No wrapper methods (inline 1–3 line delegates instead)
+- No `unwrap_or_else(|_| default)` that swallows real errors
+- No speculative abstractions — YAGNI applies strictly
+- Comments explain **why**, not what — remove dead code rather than comment it out
+- Named constants, no magic numbers
+
+---
+
+## Error Handling
+
+```rust
+// ✅ fail fast — surfaces the real problem
+let config = load_config().expect("failed to load config");
+
+// ❌ hides real problems
+let config = load_config().unwrap_or_else(|_| default_config());
+```
+
+- One error enum per crate boundary using `thiserror`; use `#[non_exhaustive]` from day one
+- Convert foreign errors at the boundary with `#[from]` — don't let `std::io::Error` leak through layers
+- Validate at real boundaries (user input, external APIs), not at internal seams you control
+- MCP tool execution: **always** `Ok(McpToolResult::error(...))`, never `Err()`
+
+---
+
+## Logging
+
+Log macros are defined in `src/config/mod.rs`:
+
+```rust
+crate::log_debug!("detail");   // bright blue in CLI; tracing in ACP/WS
+crate::log_info!("status");    // cyan in CLI
+crate::log_error!("failure");  // always visible; ACP also writes JSONL sink
+```
+
+- Use these macros exclusively — raw `println!` bypasses the spinner and wrong output path
+- Log **decisions and state transitions**, not mechanical step-by-step tracing
+- Do not add logging to investigate a bug you can fix directly
+
+---
+
+## Testing
+
+- Unit tests live in `#[cfg(test)] mod tests` next to the code they test
+- Integration tests in `tests/` exercise the public API as an external consumer
+- Do not add tests speculatively — write them for real invariants
+- Do not run tests on behalf of contributors — they run `cargo test` themselves
+
+---
+
+## Pre-Commit Checks
+
+The pre-commit hooks run automatically on `git commit`:
+
+| Hook | Command |
+|------|---------|
+| Format | `cargo fmt --all` |
+| Lint | `cargo clippy --all-targets --all-features -- -D warnings` |
+| Compile | `cargo check --all-targets --all-features` |
+| Trailing whitespace | (general hook) |
+| File endings | (general hook) |
+
+Install once with `pre-commit install`. All hooks must pass before a commit lands.
+
+---
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`
+
+Scopes match top-level modules: `mcp`, `session`, `config`, `acp`, `websocket`, `agent`, `learning`, `chat`, `schedule`, `sandbox`
+
+Examples:
+```
+feat(mcp): add file_watch tool to core server
+fix(session): prevent race condition in spinner shutdown
+docs: add CONTRIBUTING.md
+refactor(config): consolidate merge logic into load()
+```
+
+---
+
+## Validation Checklist
+
+Before opening a pull request:
+
+- [ ] Apache 2.0 copyright header on every new `.rs` file
+- [ ] No `std::println!` / `std::eprintln!` — use crate macros
+- [ ] No `unwrap_or_else(|_| ...)` that swallows real errors
+- [ ] MCP tool failures return `Ok(McpToolResult::error(...))`, not `Err(...)`
+- [ ] New config fields added to `config-templates/default.toml` first, then the Rust type
+- [ ] Session-scoped state added to all five entry points (grep `init_session_services`)
+- [ ] `mcp-*.toml` override behavior considered if adding config loading logic
+- [ ] `auto_bind` strings are exact-match — full role tag in both places
+- [ ] No hardcoded config values
+- [ ] `cargo fmt --all` clean
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
+- [ ] Every changed line traces directly to the request — no opportunistic cleanups
+
+---
+
+## Never
+
+| Don't | Because |
+|-------|---------|
+| Return `Err()` from MCP tool execution | Callers expect `Ok(McpToolResult)` — always |
+| Use `std::println!` / `std::eprintln!` | Breaks the terminal spinner |
+| Use `unwrap_or_else(\|_\| default)` | Hides real failures silently |
+| Add session state to fewer than five entry points | Causes subtle mode-specific bugs |
+| Use `"stdin"` as MCP server type | Correct value is `"stdio"` |
+| Use `[role_name]` TOML sections for roles | Always `[[roles]]` with `name = "..."` |
+| Omit the copyright header | License compliance requirement |
+| Hardcode config values | All defaults belong in `config-templates/default.toml` |
+| Add unrequested features | YAGNI — scope creep slows review and introduces regressions |
+| Comment out dead code | Delete it; git history preserves it |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -1115,9 +1115,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "landlock"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
 dependencies = [
  "enumflags2",
  "libc",
@@ -4745,9 +4745,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4758,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4768,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4778,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4791,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4847,9 +4847,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ reqwest = { version = "0.13.3", features = ["json", "rustls", "gzip"], default-f
 rustls-webpki = ">=0.103.12"
 flate2 = "1.1"
 anyhow = "1.0.102"
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.5"
 toml = "1.1"

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -186,10 +186,6 @@ let hint = if crate::mcp::tool_map::get_server_for_tool("better_tool").is_some()
 ```
 See `src/mcp/hint_accumulator.rs` and `src/mcp/core/schedule/core.rs` for examples.
 
-### Formatting: hard tabs
-
-`rustfmt.toml` sets `hard_tabs = true`. Run `cargo fmt --all` before every commit.
-
 ## Adding a New MCP Tool
 
 1. **Define** in `src/mcp/core/functions.rs` → `get_all_functions()` (core server) **or** `src/mcp/runtime/mod.rs` → `get_all_functions()` (runtime server)
@@ -208,26 +204,9 @@ See `src/mcp/hint_accumulator.rs` and `src/mcp/core/schedule/core.rs` for exampl
 3. Add `CommandOutput` variant to the enum in `commands/mod.rs` if the command has a new result shape
 4. Add constant to `src/session/chat/commands.rs` and the `COMMANDS` array
 
-## Development Workflow
-
-```bash
-cargo build                                                  # dev build
-cargo build --release                                        # release build
-cargo fmt --all                                              # format (must pass CI)
-cargo clippy --all-targets --all-features -- -D warnings    # lint (must pass CI)
-cargo test --release                                         # tests
-make dev                                                     # fmt + clippy + test
-make pre-commit                                              # full pre-commit suite
-```
-
-CI checks (all must pass): `cargo check` → `fmt --check` → `clippy -D warnings` → `cargo test`.
-
 ## Validation Checklist
 
 Before any commit:
-- [ ] `cargo fmt --all` passes (hard tabs — zero diff)
-- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
-- [ ] `cargo test --release` — all pass
 - [ ] Apache 2.0 copyright header on every new `.rs` file
 - [ ] No `std::println!` / `std::eprintln!` — use crate macros
 - [ ] No `unwrap_or_else(|_| ...)` that swallows real errors

--- a/config-templates/default.toml
+++ b/config-templates/default.toml
@@ -689,7 +689,7 @@ knowledge_retention = 10
 # Use a fast, cheap model like Haiku for cost savings (10x cheaper than Sonnet)
 # Cost comparison: Haiku ~$0.0003 vs Sonnet ~$0.003 per compression decision
 [compression.decision]
-model = "anthropic:claude-haiku-4-5"
+model = "openai:gpt-5-mini"
 max_tokens = 16000  # Enough for decision + summary
 temperature = 0.3  # Lower temperature for consistent decisions
 top_p = 1.0

--- a/src/acp/agent.rs
+++ b/src/acp/agent.rs
@@ -704,6 +704,10 @@ impl agent_client_protocol::Agent for OctomindAgent {
 				// intercepts, so without this branch the panic aborts the agent
 				// process (panic = "abort" in release → SIGABRT). Handle it here
 				// directly, mirroring the websocket server pattern.
+				// Override text for /done so the client sees the actual compression
+				// outcome instead of the generic "Command executed.". Captured here
+				// and threaded through to the AgentMessageChunk send below.
+				let mut done_status_override: Option<String> = None;
 				let result = if input.trim() == crate::session::chat::DONE_COMMAND {
 					let config_for_role = config.get_merged_config_for_role(&self.role);
 					match crate::session::chat::session::commands::handle_done(
@@ -713,10 +717,21 @@ impl agent_client_protocol::Agent for OctomindAgent {
 					)
 					.await
 					{
-						Ok(_) => {
+						Ok(outcome) => {
 							if let Err(e) = chat_session.save() {
 								crate::log_debug!("session save failed: {}", e);
 							}
+							done_status_override = Some(match outcome {
+								crate::session::chat::session::commands::DoneOutcome::Compressed => {
+									"✅ Conversation compressed.".to_string()
+								}
+								crate::session::chat::session::commands::DoneOutcome::NothingToCompress => {
+									"ℹ️ Nothing to compress.".to_string()
+								}
+								crate::session::chat::session::commands::DoneOutcome::Failed(e) => {
+									format!("❌ Compression failed: {e}")
+								}
+							});
 							Ok(crate::session::chat::session::commands::CommandResult::Handled)
 						}
 						Err(e) => Err(e),
@@ -746,7 +761,9 @@ impl agent_client_protocol::Agent for OctomindAgent {
 					) => serde_json::to_string_pretty(&output.to_json())
 						.unwrap_or_else(|_| "Command executed.".to_string()),
 					Ok(crate::session::chat::session::commands::CommandResult::Handled) => {
-						"Command executed.".to_string()
+						done_status_override
+							.take()
+							.unwrap_or_else(|| "Command executed.".to_string())
 					}
 					Ok(crate::session::chat::session::commands::CommandResult::Exit) => {
 						"Session exit requested.".to_string()

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -43,23 +43,25 @@ impl Config {
 		// STRICT: Validate required fields are not empty
 		self.validate_required_fields()?;
 
-		// STRICT: The compression model must support structured output —
-		// the compression call attaches a strict JSON schema and parses
-		// `response.structured_output`. Failing here at config-load time
-		// makes the requirement visible up front rather than surfacing
-		// mid-session at the first compression event.
-		self.validate_compression_provider()?;
+		// Compression model: must resolve to a known provider, but EITHER
+		// structured-output support (JSON path) OR no support (XML path)
+		// is acceptable — `ask_ai_decision_and_summary` dispatches on the
+		// provider's capability at call time.
+		self.validate_compression_model()?;
 
 		Ok(())
 	}
 
-	/// Verify the configured compression model is served by a provider
-	/// that supports structured (JSON-schema) output. Required because the
-	/// compression call path is schema-driven with no markdown fallback.
+	/// Verify the configured compression model resolves to a known
+	/// provider. The runtime picks JSON or XML wire mode from the
+	/// provider's `supports_structured_output(model)` capability, so
+	/// either capability is acceptable — we only fail when the model
+	/// string itself is missing or unresolvable.
 	///
-	/// Skipped when compression is effectively disabled (no pressure levels
-	/// configured) — there is no compression call to validate against.
-	fn validate_compression_provider(&self) -> Result<()> {
+	/// Skipped when compression is effectively disabled (no pressure
+	/// levels configured) — there is no compression call to validate
+	/// against.
+	fn validate_compression_model(&self) -> Result<()> {
 		if self.compression.pressure_levels.is_empty() {
 			return Ok(());
 		}
@@ -67,23 +69,12 @@ impl Config {
 		let model = &self.compression.decision.model;
 		if model.is_empty() {
 			return Err(anyhow!(
-				"compression.decision.model is empty — set it to a model that supports structured output (e.g. anthropic:claude-sonnet-4-6, openai:gpt-4.1)"
+				"compression.decision.model is empty — set it to a model resolvable by a configured provider (e.g. anthropic:claude-sonnet-4-6, openai:gpt-4.1)"
 			));
 		}
 
-		let (provider, actual_model) =
-			crate::providers::ProviderFactory::get_provider_for_model(model)
-				.map_err(|e| anyhow!("compression.decision.model '{}' is invalid: {}", model, e))?;
-
-		if !provider.supports_structured_output(&actual_model) {
-			return Err(anyhow!(
-				"compression.decision.model '{}' (provider '{}') does not support structured output. \
-				 Compression requires strict JSON schema responses. \
-				 Pick a model whose provider supports structured output (e.g. anthropic:claude-sonnet-4-6, openai:gpt-4.1).",
-				model,
-				provider.name()
-			));
-		}
+		crate::providers::ProviderFactory::get_provider_for_model(model)
+			.map_err(|e| anyhow!("compression.decision.model '{}' is invalid: {}", model, e))?;
 
 		Ok(())
 	}

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -43,6 +43,48 @@ impl Config {
 		// STRICT: Validate required fields are not empty
 		self.validate_required_fields()?;
 
+		// STRICT: The compression model must support structured output —
+		// the compression call attaches a strict JSON schema and parses
+		// `response.structured_output`. Failing here at config-load time
+		// makes the requirement visible up front rather than surfacing
+		// mid-session at the first compression event.
+		self.validate_compression_provider()?;
+
+		Ok(())
+	}
+
+	/// Verify the configured compression model is served by a provider
+	/// that supports structured (JSON-schema) output. Required because the
+	/// compression call path is schema-driven with no markdown fallback.
+	///
+	/// Skipped when compression is effectively disabled (no pressure levels
+	/// configured) — there is no compression call to validate against.
+	fn validate_compression_provider(&self) -> Result<()> {
+		if self.compression.pressure_levels.is_empty() {
+			return Ok(());
+		}
+
+		let model = &self.compression.decision.model;
+		if model.is_empty() {
+			return Err(anyhow!(
+				"compression.decision.model is empty — set it to a model that supports structured output (e.g. anthropic:claude-sonnet-4-6, openai:gpt-4.1)"
+			));
+		}
+
+		let (provider, actual_model) =
+			crate::providers::ProviderFactory::get_provider_for_model(model)
+				.map_err(|e| anyhow!("compression.decision.model '{}' is invalid: {}", model, e))?;
+
+		if !provider.supports_structured_output(&actual_model) {
+			return Err(anyhow!(
+				"compression.decision.model '{}' (provider '{}') does not support structured output. \
+				 Compression requires strict JSON schema responses. \
+				 Pick a model whose provider supports structured output (e.g. anthropic:claude-sonnet-4-6, openai:gpt-4.1).",
+				model,
+				provider.name()
+			));
+		}
+
 		Ok(())
 	}
 

--- a/src/mcp/core/plan/compression.rs
+++ b/src/mcp/core/plan/compression.rs
@@ -659,9 +659,10 @@ fn format_compressed_summary(
 		.unwrap_or_else(|| "Unknown".to_string());
 
 	let mut output = format!(
-		"## Compressed Knowledge [COMPRESSED: {}]\n\n\
-		**Latest fold**: {} (completed {})\n\n",
-		compression_id, task.title, completed_at
+		"<task_compressed id=\"{}\" task=\"{}\" completed_at=\"{}\">\n",
+		compression_id,
+		escape_attr(&task.title),
+		escape_attr(&completed_at),
 	);
 
 	// Anchor is the primary content. It contains intent, decisions,
@@ -669,13 +670,15 @@ fn format_compressed_summary(
 	// before format runs), file_refs accumulated across compactions, and
 	// any errors / next_steps recorded so far.
 	if !anchor.is_empty() {
-		output.push_str(&anchor.to_markdown());
+		output.push_str("<anchor>\n");
+		output.push_str(&anchor.to_xml());
+		output.push_str("</anchor>\n");
 	} else {
 		// Defensive fallback — should not happen because the caller
 		// extends the anchor before calling format. Kept so the function
 		// is correct even if invoked out of band (e.g. tests).
 		output.push_str(&format!(
-			"**Task**: {}\n**Summary**: {}\n\n",
+			"<task>{}</task>\n<summary>{}</summary>\n",
 			task.title, summary
 		));
 	}
@@ -684,21 +687,28 @@ fn format_compressed_summary(
 	// still in progress and which task is current.
 	if let Some((plan_title, completed_count, total_tasks, current_task_title)) = plan_context {
 		output.push_str(&format!(
-			"\n🎯 **ACTIVE PLAN**: {}\n\
-			- Progress: {}/{} tasks completed\n\
-			- Current Task: {}\n\
-			- Status: IN PROGRESS (use plan commands to continue)\n\n",
-			plan_title, completed_count, total_tasks, current_task_title
+			"<active_plan title=\"{}\" progress=\"{}/{}\" status=\"in_progress\">\n\
+			<current_task>{}</current_task>\n\
+			</active_plan>\n",
+			escape_attr(plan_title),
+			completed_count,
+			total_tasks,
+			current_task_title,
 		));
 	}
 
-	output.push_str(&format!(
-		"---\n\
-		*Compressed [{}]. Decisions, file references, and changes are preserved above.*",
-		compression_id
-	));
-
+	output.push_str("</task_compressed>");
 	output
+}
+
+/// Escape characters that would break a double-quoted XML attribute value.
+/// Used only for attribute embedding (titles, ids, timestamps); body text
+/// stays unescaped since it's free-form prose the LLM tolerates as-is.
+fn escape_attr(s: &str) -> String {
+	s.replace('&', "&amp;")
+		.replace('"', "&quot;")
+		.replace('<', "&lt;")
+		.replace('>', "&gt;")
 }
 
 /// Calculate total tokens in message range using accurate token counting
@@ -768,7 +778,7 @@ async fn compress_phase(
 	// Look for task compressions that belong to this phase
 	for (i, msg) in session.session.messages.iter().enumerate() {
 		if let Some(name) = &msg.name {
-			if name == "plan_compression" && msg.content.contains("## Compressed Knowledge") {
+			if name == "plan_compression" && msg.content.contains("<task_compressed") {
 				// Check if this task belongs to the phase (by checking content or just take all recent ones)
 				task_summaries.push((i, msg.content.clone()));
 				if start_index.is_none() {
@@ -870,16 +880,13 @@ async fn compress_phase(
 fn format_phase_summary(phase_name: &str, summary: &str, task_count: usize) -> String {
 	let compression_id = get_compression_id().unwrap_or_else(|| "unknown".to_string());
 	format!(
-		"## Phase Completed: {} [COMPRESSED: {}]\n\n\
-		**Tasks Completed**: {}\n\n\
-		**Summary**: {}\n\n\
-		**Compression Info**:\n\
-		- ID: `{}`\n\
-		- Type: Phase-level compression\n\
-		- Retrievable: Use `/retrieve {}` to expand (future feature)\n\n\
-		---\n\
-		*Phase Compression - {} task summaries compressed into phase overview*",
-		phase_name, compression_id, task_count, summary, compression_id, compression_id, task_count
+		"<phase_compressed id=\"{}\" phase=\"{}\" task_count=\"{}\">\n\
+		<summary>{}</summary>\n\
+		</phase_compressed>",
+		compression_id,
+		escape_attr(phase_name),
+		task_count,
+		summary,
 	)
 }
 
@@ -1058,23 +1065,15 @@ fn format_project_summary(
 ) -> String {
 	let compression_id = get_compression_id().unwrap_or_else(|| "unknown".to_string());
 	format!(
-		"## Project Completed: {} [COMPRESSED: {}]\n\n\
-		**Scale**: {} tasks across {} phases\n\n\
-		**Summary**: {}\n\n\
-		**Compression Info**:\n\
-		- ID: `{}`\n\
-		- Type: Project-level compression\n\
-		- Retrievable: Use `/retrieve {}` to expand (future feature)\n\n\
-		---\n\
-		*Project Compression - {} summaries consolidated into final project overview*",
-		plan_title,
+		"<project_compressed id=\"{}\" plan=\"{}\" tasks=\"{}\" phases=\"{}\" summaries_folded=\"{}\">\n\
+		<summary>{}</summary>\n\
+		</project_compressed>",
 		compression_id,
+		escape_attr(plan_title),
 		total_tasks,
 		total_phases,
+		summaries_compressed,
 		summary,
-		compression_id,
-		compression_id,
-		summaries_compressed
 	)
 }
 
@@ -1123,10 +1122,11 @@ mod tests {
 			&[],
 			&empty_anchor,
 		);
-		assert!(formatted.contains("## Compressed Knowledge"));
-		assert!(formatted.contains("test_123"));
-		assert!(formatted.contains("Test Task"));
+		assert!(formatted.contains("<task_compressed"));
+		assert!(formatted.contains("id=\"test_123\""));
+		assert!(formatted.contains("task=\"Test Task\""));
 		assert!(formatted.contains("Task completed successfully"));
+		assert!(formatted.contains("</task_compressed>"));
 	}
 
 	#[test]
@@ -1152,11 +1152,14 @@ mod tests {
 			0,
 		);
 		let formatted = format_compressed_summary(&task, "ok", "id_xyz", None, &[], &anchor);
-		// Anchor content surfaces directly — no separate Session Anchor heading.
+		// Anchor content surfaces directly inside <anchor>…</anchor>.
+		assert!(formatted.contains("<anchor>"));
 		assert!(formatted.contains("Refactor auth layer"));
 		assert!(formatted.contains("use JWT not sessions"));
-		// The redundant per-task Summary block should be gone.
-		assert!(!formatted.contains("**Summary**: ok"));
+		assert!(formatted.contains("</anchor>"));
+		// The defensive per-task <summary> fallback must NOT appear when the
+		// anchor carries content (it's only used when the anchor is empty).
+		assert!(!formatted.contains("<summary>ok</summary>"));
 	}
 
 	#[test]

--- a/src/mcp/core/plan/compression.rs
+++ b/src/mcp/core/plan/compression.rs
@@ -409,22 +409,48 @@ fn adjusted_task_compression_start_index(
 	}
 
 	let anchor = messages.get(start_index)?;
-	if anchor.role != "assistant" || anchor.tool_calls.is_none() {
-		return Some(start_index);
+
+	// Case 1: start_index is an assistant with tool_calls — advance past its results.
+	if anchor.role == "assistant" && anchor.tool_calls.is_some() {
+		let mut next = start_index + 1;
+		while next <= end_index && messages[next].role == "tool" {
+			next += 1;
+		}
+
+		return if next == start_index + 1 {
+			Some(start_index)
+		} else if next <= end_index {
+			Some(next)
+		} else {
+			None
+		};
 	}
 
-	let mut next = start_index + 1;
-	while next <= end_index && messages[next].role == "tool" {
-		next += 1;
+	// Case 2: start_index is a tool_result whose parent assistant (somewhere
+	// before start_index, past any earlier tool_results) has tool_calls. The
+	// drain removes start_index+1..=end, which may include sibling tool_results
+	// for the same assistant. Walk back past consecutive tool messages to find
+	// the parent, then advance forward past ALL consecutive tool messages from
+	// start_index so no sibling results are split by the drain boundary.
+	if anchor.role == "tool" {
+		let mut parent_idx = start_index;
+		while parent_idx > 0 && messages[parent_idx - 1].role == "tool" {
+			parent_idx -= 1;
+		}
+		if parent_idx > 0 {
+			let parent = &messages[parent_idx - 1];
+			if parent.role == "assistant" && parent.tool_calls.is_some() {
+				let mut next = start_index + 1;
+				while next <= end_index && messages[next].role == "tool" {
+					next += 1;
+				}
+
+				return if next <= end_index { Some(next) } else { None };
+			}
+		}
 	}
 
-	if next == start_index + 1 {
-		Some(start_index)
-	} else if next <= end_index {
-		Some(next)
-	} else {
-		None
-	}
+	Some(start_index)
 }
 
 /// Compress session history for a completed task
@@ -1336,5 +1362,97 @@ mod tests {
 		messages.push(tool);
 
 		assert_eq!(adjusted_task_compression_start_index(&messages, 1, 2), None);
+	}
+
+	#[test]
+	fn task_compression_start_in_middle_of_tool_results_orphans_tool_use() {
+		use crate::session::Message;
+		use serde_json::json;
+
+		fn msg(role: &str) -> Message {
+			Message {
+				role: role.to_string(),
+				content: format!("{} message", role),
+				timestamp: 1000,
+				cached: false,
+				cache_ttl: None,
+				tool_call_id: None,
+				name: None,
+				tool_calls: None,
+				images: None,
+				videos: None,
+				thinking: None,
+				id: None,
+			}
+		}
+
+		// Scenario: start_index lands on a tool_result that is NOT the last
+		// result for its parent assistant. The assistant at start_index-1 has
+		// multiple tool_calls; some results fall before start_index, some after.
+		// After drain, the assistant retains tool_use blocks whose results were
+		// removed — Anthropic rejects this ("tool_use ids were found without
+		// tool_result blocks immediately after").
+		let mut messages = Vec::new();
+		messages.push(msg("system")); // 0
+
+		let mut assistant = msg("assistant"); // 1
+		assistant.tool_calls = Some(json!([
+			{"id": "toolu_AAA", "type": "function", "function": {"name": "view", "arguments": "{}"}},
+			{"id": "toolu_BBB", "type": "function", "function": {"name": "edit", "arguments": "{}"}},
+			{"id": "toolu_CCC", "type": "function", "function": {"name": "shell", "arguments": "{}"}}
+		]));
+		messages.push(assistant);
+
+		let mut tool_a = msg("tool"); // 2
+		tool_a.tool_call_id = Some("toolu_AAA".to_string());
+		messages.push(tool_a);
+
+		let mut tool_b = msg("tool"); // 3  ← start_index lands here
+		tool_b.tool_call_id = Some("toolu_BBB".to_string());
+		messages.push(tool_b);
+
+		let mut tool_c = msg("tool"); // 4  ← this result will be drained
+		tool_c.tool_call_id = Some("toolu_CCC".to_string());
+		messages.push(tool_c);
+
+		messages.push(msg("assistant")); // 5
+		messages.push(msg("user")); // 6
+		messages.push(msg("assistant")); // 7
+
+		let start_index = 3usize; // tool_result for toolu_BBB
+		let end_index = 7usize;
+
+		// Current behaviour: adjusted_start does NOT advance past tool_c
+		// because start_index is a tool message, not an assistant.
+		let adjusted_start =
+			adjusted_task_compression_start_index(&messages, start_index, end_index).unwrap();
+
+		// Simulate the drain that compress_completed_task would do
+		let drain_range = adjusted_start + 1..=end_index;
+		let drained: Vec<Message> = messages.drain(drain_range).collect();
+		let _ = drained;
+
+		// Collect surviving tool_call ids from the assistant at index 1
+		let tool_call_ids: Vec<&str> = messages[1]
+			.tool_calls
+			.as_ref()
+			.unwrap()
+			.as_array()
+			.unwrap()
+			.iter()
+			.map(|tc| tc["id"].as_str().unwrap())
+			.collect();
+
+		// For every surviving tool_call, there MUST be a matching tool_result
+		for tc_id in &tool_call_ids {
+			let has_result = messages
+				.iter()
+				.any(|m| m.role == "tool" && m.tool_call_id.as_deref() == Some(tc_id));
+			assert!(
+				has_result,
+				"BUG: tool_call {tc_id} has no matching tool_result after compression — \
+				 Anthropic will reject with 'tool_use ids were found without tool_result blocks'"
+			);
+		}
 	}
 }

--- a/src/mcp/core/tap.rs
+++ b/src/mcp/core/tap.rs
@@ -61,13 +61,15 @@ When to use:
 - You want a long-running side task while continuing other work — call `run` with `background=true`; the specialist's reply lands in your next turn.
 - You want to keep a focused dialog with one specialist across multiple turns — keep the returned `session` id and pass it back on subsequent `run` calls.
 
+Important: Every `run` call WITHOUT a `session` id starts a completely fresh agent with zero memory of prior work. If you are continuing, following up, or building on a previous tap call, you MUST pass `session=<id>` from that prior call. Omitting it is ALWAYS wrong when there is prior context to preserve.
+
 Discovery flow:
 - If you know the role: `tap(action="run", role="developer:general", prompt="…")`.
 - If you don't: `tap(action="discover", intent="<plain-English need>")` returns the closest 5 roles ranked by semantic match. Pick one, then `run`.
 - If needed tools, skills, or capabilities are missing: `tap(action="capability", prompt="<underlying capability need>")` triggers the same auto-activation checks used for user messages.
 
 Actions:
-- `run`        — launch a role. Required: `role` (for new runs) OR `session` (to resume), plus `prompt`. Optional: `workdir` (defaults to current cwd), `background` (default false; true = return immediately, reply injected later).
+- `run`        — launch a role. Required: `role` (for new runs) OR `session` (to resume), plus `prompt`. Optional: `workdir` (defaults to current cwd), `background` (default false; true = return immediately, reply injected later). **Always supply `session` when continuing an existing run — omitting it discards all prior context.**
 - `list`       — show every run in this session: id, role, status (running|done|failed|cancelled), start time, workdir.
 - `stop`       — cancel a running specialist. Required: `session` (the id).
 - `discover`   — find roles matching free-text intent. Required: `intent`. Returns top matches with title, description, and source tap.

--- a/src/mcp/core/tap.rs
+++ b/src/mcp/core/tap.rs
@@ -64,8 +64,8 @@ When to use:
 Important: Every `run` call WITHOUT a `session` id starts a completely fresh agent with zero memory of prior work. If you are continuing, following up, or building on a previous tap call, you MUST pass `session=<id>` from that prior call. Omitting it is ALWAYS wrong when there is prior context to preserve.
 
 Discovery flow:
-- If you know the role: `tap(action="run", role="developer:general", prompt="…")`.
-- If you don't: `tap(action="discover", intent="<plain-English need>")` returns the closest 5 roles ranked by semantic match. Pick one, then `run`.
+- ALWAYS start with `tap(action="discover", intent="<plain-English need>")` unless the role was already returned by a previous `discover` or `list` call in this session. Never guess a role name from context, documentation, or examples — role names are only valid after `discover` confirms they exist.
+- After `discover` returns matches, pick the best-fit role from the results, then call `run` with that exact role string.
 - If needed tools, skills, or capabilities are missing: `tap(action="capability", prompt="<underlying capability need>")` triggers the same auto-activation checks used for user messages.
 
 Actions:

--- a/src/mcp/process.rs
+++ b/src/mcp/process.rs
@@ -1519,11 +1519,62 @@ pub async fn communicate_with_stdin_server_extended_timeout(
 			std::time::Duration::from_secs(timeout_seconds),
 			handle_opt.take().unwrap(),
 		) => {
-			// Handle completed (or timed out) — clear in_flight since there's nothing to await.
-			*in_flight_arc.lock().unwrap() = None;
 			match result {
-				Ok(task_result) => task_result?,
-			Err(_) => Err(anyhow::anyhow!("Timeout ({} seconds) communicating with stdin server: {}", timeout_seconds, server_name_for_error))
+				Ok(task_result) => {
+					// Task completed within the timeout — clean in_flight slot.
+					*in_flight_arc.lock().unwrap() = None;
+					task_result?
+				}
+				Err(_) => {
+					// Timeout elapsed. The spawn_blocking thread is still alive,
+					// holding the std::sync::Mutex on the server process while it
+					// waits for a response that may never come (e.g. the server
+					// is itself blocked running a long shell command). Without
+					// the teardown below, the NEXT tool call deadlocks trying to
+					// lock the same mutex. Mirror the cancellation branch: tell
+					// the blocking loop to exit, kill the server's process group
+					// so its read pipe EOFs immediately, and mark the server
+					// dead so the next call restarts a fresh process.
+					cancel_flag.store(true, Ordering::Relaxed);
+
+					#[cfg(unix)]
+					{
+						let pgid = child_pid as libc::pid_t;
+						// SAFETY: libc::kill is always safe to call with valid arguments.
+						unsafe {
+							libc::kill(-pgid, libc::SIGTERM);
+						}
+						crate::log_debug!(
+							"Sent SIGTERM to process group {} (server '{}') on timeout",
+							pgid,
+							server_name_for_error
+						);
+						tokio::spawn(async move {
+							tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+							unsafe {
+								libc::kill(-pgid, libc::SIGKILL);
+							}
+						});
+					}
+
+					{
+						let mut restart_info_guard = SERVER_RESTART_INFO.write().unwrap();
+						let info = restart_info_guard
+							.entry(server_name_for_error.clone())
+							.or_default();
+						info.health_status = ServerHealth::Dead;
+					}
+
+					// in_flight already empty (handle_opt was consumed when the
+					// timeout future was constructed); clear defensively.
+					*in_flight_arc.lock().unwrap() = None;
+
+					Err(anyhow::anyhow!(
+						"Timeout ({} seconds) communicating with stdin server: {}",
+						timeout_seconds,
+						server_name_for_error
+					))
+				}
 			}
 		},
 		_ = cancellation_future => {

--- a/src/session/anchor.rs
+++ b/src/session/anchor.rs
@@ -137,22 +137,25 @@ impl Anchor {
 		self.last_compacted_at = now_unix;
 	}
 
-	/// Render the anchor as a compact markdown block suitable for
-	/// inclusion in compressed-knowledge messages.
-	pub fn to_markdown(&self) -> String {
+	/// Render the anchor as a compact XML block suitable for inclusion in
+	/// compressed-knowledge messages. XML over markdown: subsequent
+	/// compressions re-feed this body as transcript input, and Claude is
+	/// tuned to parse XML-delimited sections more reliably than markdown
+	/// headers across paraphrase cycles.
+	pub fn to_xml(&self) -> String {
 		let mut out = String::with_capacity(512);
 		if !self.intent.is_empty() {
-			out.push_str("**Intent**: ");
-			out.push_str(&self.intent);
-			out.push_str("\n\n");
+			out.push_str("<intent>");
+			out.push_str(self.intent.trim());
+			out.push_str("</intent>\n");
 		}
-		render_list(&mut out, "Decisions", &self.decisions);
-		render_list(&mut out, "Changes made", &self.changes_made);
-		render_list(&mut out, "Errors / resolutions", &self.errors_seen);
-		render_list(&mut out, "File references", &self.file_refs);
-		render_list(&mut out, "Next steps", &self.next_steps);
+		render_list(&mut out, "decisions", "decision", &self.decisions);
+		render_list(&mut out, "changes_made", "change", &self.changes_made);
+		render_list(&mut out, "errors_seen", "entry", &self.errors_seen);
+		render_list(&mut out, "file_references", "file", &self.file_refs);
+		render_list(&mut out, "next_steps", "step", &self.next_steps);
 		if self.compactions_folded > 0 {
-			out.push_str(&format!("_anchor folds: {}_\n", self.compactions_folded));
+			out.push_str(&format!("<folds>{}</folds>\n", self.compactions_folded));
 		}
 		out
 	}
@@ -170,19 +173,16 @@ fn extend_dedup(target: &mut Vec<String>, additions: Vec<String>) {
 	}
 }
 
-fn render_list(out: &mut String, heading: &str, items: &[String]) {
-	if items.is_empty() {
+fn render_list(out: &mut String, outer: &str, item: &str, items: &[String]) {
+	let non_empty: Vec<&String> = items.iter().filter(|s| !s.trim().is_empty()).collect();
+	if non_empty.is_empty() {
 		return;
 	}
-	out.push_str("**");
-	out.push_str(heading);
-	out.push_str("**:\n");
-	for item in items {
-		out.push_str("- ");
-		out.push_str(item);
-		out.push('\n');
+	out.push_str(&format!("<{outer}>\n"));
+	for v in non_empty {
+		out.push_str(&format!("<{item}>{}</{item}>\n", v.trim(), item = item));
 	}
-	out.push('\n');
+	out.push_str(&format!("</{outer}>\n"));
 }
 
 #[cfg(test)]
@@ -277,7 +277,7 @@ mod tests {
 	}
 
 	#[test]
-	fn to_markdown_renders_only_present_sections() {
+	fn to_xml_renders_only_present_sections() {
 		let mut a = Anchor::default();
 		a.extend(
 			AnchorUpdate {
@@ -287,20 +287,20 @@ mod tests {
 			},
 			0,
 		);
-		let md = a.to_markdown();
-		assert!(md.contains("**Intent**: Refactor auth"));
-		assert!(md.contains("**Decisions**"));
-		assert!(md.contains("- use JWT"));
+		let xml = a.to_xml();
+		assert!(xml.contains("<intent>Refactor auth</intent>"));
+		assert!(xml.contains("<decisions>"));
+		assert!(xml.contains("<decision>use JWT</decision>"));
 		// Empty sections are skipped.
-		assert!(!md.contains("**Errors"));
-		assert!(!md.contains("**Next steps"));
+		assert!(!xml.contains("<errors_seen"));
+		assert!(!xml.contains("<next_steps"));
 	}
 
 	#[test]
 	fn empty_anchor_renders_to_short_string() {
 		let a = Anchor::default();
-		let md = a.to_markdown();
-		assert!(md.is_empty() || md.len() < 50);
+		let xml = a.to_xml();
+		assert!(xml.is_empty() || xml.len() < 50);
 	}
 
 	#[test]

--- a/src/session/chat/assistant_output.rs
+++ b/src/session/chat/assistant_output.rs
@@ -18,6 +18,16 @@ use crate::config::Config;
 use crate::providers::ThinkingBlock;
 use crate::session::chat::markdown::{is_markdown_content, MarkdownRenderer};
 use colored::Colorize;
+use regex::Regex;
+
+/// Strip `<system>...</system>` blocks (and surrounding blank lines) from
+/// content intended for user-facing display. Used for welcome messages that
+/// embed AI-only context inside `<system>` tags.
+pub fn strip_system_tags(content: &str) -> String {
+	// Match <system>...</system> (multiline, lazy) including any trailing newline
+	let re = Regex::new(r"(?is)\s*<system>.*?</system>\s*").unwrap();
+	re.replace_all(content, "\n").trim().to_string()
+}
 
 /// Check if assistant content was already displayed in thinking block
 /// Returns the content to display (either full content or trimmed content)

--- a/src/session/chat/conversation_compression/ai.rs
+++ b/src/session/chat/conversation_compression/ai.rs
@@ -14,32 +14,48 @@
 
 // LLM I/O for compression decision + summary generation.
 //
-// `ask_ai_decision_and_summary` builds the prompt, invokes the model with a
-// strict JSON schema attached, deserialises the typed response, and applies
-// the substantive-content gate. Cost accounting and critical-knowledge
-// folding remain side-effects on the session.
+// `ask_ai_decision_and_summary` picks one of two equal paths up-front from
+// the provider's `supports_structured_output(model)` capability:
+//
+//   - JSON path: builds the JSON prompt + attaches the strict JSON schema;
+//     deserialises `response.structured_output` (with a small lenient
+//     recovery inside the JSON mode for providers that misroute valid JSON
+//     into `content` instead of `structured_output`).
+//   - XML path: builds the XML prompt (embedding the tag spec); parses the
+//     response with `parse_xml_summary`, which performs structural
+//     validation matching the JSON schema's bounds.
+//
+// Both paths return `CompressionSummary`; the substantive-content gate and
+// cost/knowledge side-effects are mode-agnostic.
 
-use super::prompt::build_compression_prompt;
-use super::schema::{build_compression_schema, is_summary_substantive, CompressionSummary};
+use super::prompt::{build_compression_prompt_json, build_compression_prompt_xml};
+use super::schema::{
+	build_compression_schema, is_summary_substantive, parse_xml_summary, CompressionSummary,
+};
 use crate::config::Config;
+use crate::providers::ProviderFactory;
 use crate::session::chat::session::ChatSession;
 use crate::{log_debug, log_info};
 use anyhow::Result;
 
-/// Invoke the compression model with the JSON schema attached, return the
-/// parsed structured response.
+/// Invoke the compression model and return the parsed summary.
 ///
-/// Cost tracking applies unless `decision.ignore_cost` is set.
+/// `schema` decides the wire-mode:
+///   - `Some(schema)` → JSON path. Schema is attached to the request,
+///     `response.structured_output` is preferred and falls back to a
+///     lenient text-content recovery for providers that misroute it.
+///   - `None` → XML path. No schema attached, the model's textual
+///     response is fed through `parse_xml_summary`.
 ///
-/// The system message is marked cached with 1h TTL so it's amortised across
-/// every compression call in a session — the schema + behaviour rules are
-/// byte-identical between calls and benefit from prompt caching.
-pub(super) async fn call_ai_for_decision(
+/// Cost tracking applies unless `decision.ignore_cost` is set. The system
+/// message is marked cached with 1h TTL so it's amortised across every
+/// compression call in a session.
+async fn call_ai_for_decision(
 	session: &mut ChatSession,
 	config: &Config,
 	system_content: String,
 	user_content: String,
-	schema: serde_json::Value,
+	schema: Option<serde_json::Value>,
 	operation_rx: tokio::sync::watch::Receiver<bool>,
 ) -> Result<CompressionSummary> {
 	let now = crate::utils::time::now_secs();
@@ -47,7 +63,7 @@ pub(super) async fn call_ai_for_decision(
 
 	// Cache the system prompt only if the compression model supports caching.
 	// The system content is stable across compression calls (only varies on
-	// `force`), so cache hits amortise the (still small) system tokens.
+	// `force` and mode), so cache hits amortise the system tokens.
 	let supports_caching = crate::session::model_supports_caching(&decision_config.model);
 
 	let messages = vec![
@@ -85,15 +101,17 @@ pub(super) async fn call_ai_for_decision(
 		},
 	];
 
-	crate::log_debug!(
-		"Using compression decision model '{}' (max_tokens={}, temp={}, ignore_cost={})",
+	let mode_label = if schema.is_some() { "json" } else { "xml" };
+	log_debug!(
+		"Using compression decision model '{}' mode={} (max_tokens={}, temp={}, ignore_cost={})",
 		decision_config.model,
+		mode_label,
 		decision_config.max_tokens,
 		decision_config.temperature,
 		decision_config.ignore_cost
 	);
 
-	let params = crate::session::ChatCompletionWithValidationParams::new(
+	let mut params = crate::session::ChatCompletionWithValidationParams::new(
 		&messages,
 		&decision_config.model,
 		decision_config.temperature,
@@ -104,8 +122,11 @@ pub(super) async fn call_ai_for_decision(
 	)
 	.with_max_retries(decision_config.max_retries)
 	.with_full_context_tokens(true)
-	.with_schema(schema)
 	.with_cancellation_token(operation_rx);
+
+	if let Some(s) = schema.clone() {
+		params = params.with_schema(s);
+	}
 
 	let response = crate::session::chat_completion_with_validation(params).await?;
 
@@ -123,39 +144,51 @@ pub(super) async fn call_ai_for_decision(
 		log_debug!("Compression decision cost ignored (ignore_cost=true)");
 	}
 
-	// Provider should return the validated JSON in `structured_output`. When
-	// it's absent, try a lenient recovery from `response.content` before
-	// erroring — some providers (notably OctoHub) ship a strict text-to-JSON
-	// extractor that misses valid JSON wrapped in markdown fences or with
-	// a chatty preamble, even when the model genuinely followed the schema.
-	// Native-structured-output models (GPT, Claude, Gemini direct) hit the
-	// happy path; the fallback covers cross-routing quirks for DeepSeek,
-	// Kimi, OctoHub-routed models, etc.
-	let raw = match response.structured_output {
+	if schema.is_some() {
+		parse_json_response(&response, &decision_config.model)
+	} else {
+		parse_xml_summary(&response.content).map_err(|e| {
+			anyhow::anyhow!(
+				"Compression model '{}' (XML mode) produced an unparseable response: {}",
+				decision_config.model,
+				e
+			)
+		})
+	}
+}
+
+/// JSON-path response parser. Prefers `response.structured_output`; falls
+/// back to lenient extraction from `response.content` so providers that
+/// misroute valid JSON into the text body (notably some OctoHub-routed
+/// models) still succeed. The recovered value is then deserialized into
+/// the typed `CompressionSummary`.
+fn parse_json_response(
+	response: &crate::providers::ProviderResponse,
+	model: &str,
+) -> Result<CompressionSummary> {
+	let raw = match response.structured_output.clone() {
 		Some(v) => v,
 		None => {
 			let recovered = extract_json_lenient(&response.content).ok_or_else(|| {
 				anyhow::anyhow!(
 					"Compression model '{}' returned no structured_output and no recoverable JSON in text content",
-					decision_config.model
+					model
 				)
 			})?;
 			log_debug!(
 				"Compression model '{}' omitted structured_output; recovered JSON from text content",
-				decision_config.model
+				model
 			);
 			recovered
 		}
 	};
 
-	let summary: CompressionSummary = serde_json::from_value(raw).map_err(|e| {
+	serde_json::from_value(raw).map_err(|e| {
 		anyhow::anyhow!(
 			"Failed to deserialize compression schema response: {}. The provider returned JSON that does not match the expected shape.",
 			e
 		)
-	})?;
-
-	Ok(summary)
+	})
 }
 
 /// Best-effort JSON extraction from a text response when the provider didn't
@@ -253,8 +286,9 @@ fn find_first_balanced_json(s: &str) -> Option<serde_json::Value> {
 	None
 }
 
-/// Orchestration entrypoint: build prompt + schema, invoke model, apply
-/// substantive-content gate, return whether to compress and the typed summary.
+/// Orchestration entrypoint: pick the wire mode from the provider's
+/// `supports_structured_output(model)` capability, build the matching
+/// prompt, invoke the model, apply the substantive-content gate.
 ///
 /// Returns `(should_compress, summary)`:
 /// - `should_compress = false` → caller skips compression entirely; the
@@ -273,9 +307,28 @@ pub(super) async fn ask_ai_decision_and_summary(
 	force: bool,
 	target_ratio: f64,
 ) -> Result<(bool, CompressionSummary)> {
-	let (system_content, user_content) =
-		build_compression_prompt(session, messages_to_compress, force, target_ratio);
-	let schema = build_compression_schema(force);
+	let model = &config.compression.decision.model;
+	let (provider, actual_model) = ProviderFactory::get_provider_for_model(model)?;
+	let use_json = provider.supports_structured_output(&actual_model);
+
+	let (system_content, user_content) = if use_json {
+		build_compression_prompt_json(session, messages_to_compress, force, target_ratio)
+	} else {
+		build_compression_prompt_xml(session, messages_to_compress, force, target_ratio)
+	};
+
+	let schema = if use_json {
+		Some(build_compression_schema(force))
+	} else {
+		None
+	};
+
+	log_debug!(
+		"Compression wire mode: {} (provider='{}', model='{}')",
+		if use_json { "json" } else { "xml" },
+		provider.name(),
+		actual_model
+	);
 
 	let summary = call_ai_for_decision(
 		session,

--- a/src/session/chat/conversation_compression/ai.rs
+++ b/src/session/chat/conversation_compression/ai.rs
@@ -14,39 +14,53 @@
 
 // LLM I/O for compression decision + summary generation.
 //
-// This submodule owns the request → response → parse cycle:
-// `ask_ai_decision_and_summary` is the orchestration entrypoint that builds
-// the prompt (via the `prompt` submodule), invokes the model
-// (`call_ai_for_decision`), parses the body (`parse_ai_response`), and
-// validates it (`is_summary_valid`). Side-effects on the session: cost
-// tracking and `<knowledge>` extraction routed through the `knowledge`
-// submodule.
+// `ask_ai_decision_and_summary` builds the prompt, invokes the model with a
+// strict JSON schema attached, deserialises the typed response, and applies
+// the substantive-content gate. Cost accounting and critical-knowledge
+// folding remain side-effects on the session.
 
-use super::knowledge::{extract_and_store_knowledge, strip_knowledge_tags};
 use super::prompt::build_compression_prompt;
+use super::schema::{build_compression_schema, is_summary_substantive, CompressionSummary};
 use crate::config::Config;
 use crate::session::chat::session::ChatSession;
 use crate::{log_debug, log_info};
 use anyhow::Result;
 
-/// Call the AI compression model and return the raw response content.
+/// Invoke the compression model with the JSON schema attached, return the
+/// parsed structured response.
 ///
-/// Tracks cost against the session unless `ignore_cost` is set in config.
+/// Cost tracking applies unless `decision.ignore_cost` is set.
+///
+/// The system message is marked cached with 1h TTL so it's amortised across
+/// every compression call in a session — the schema + behaviour rules are
+/// byte-identical between calls and benefit from prompt caching.
 pub(super) async fn call_ai_for_decision(
 	session: &mut ChatSession,
 	config: &Config,
 	system_content: String,
 	user_content: String,
+	schema: serde_json::Value,
 	operation_rx: tokio::sync::watch::Receiver<bool>,
-) -> Result<String> {
+) -> Result<CompressionSummary> {
 	let now = crate::utils::time::now_secs();
+	let decision_config = &config.compression.decision;
+
+	// Cache the system prompt only if the compression model supports caching.
+	// The system content is stable across compression calls (only varies on
+	// `force`), so cache hits amortise the (still small) system tokens.
+	let supports_caching = crate::session::model_supports_caching(&decision_config.model);
+
 	let messages = vec![
 		crate::session::Message {
 			role: "system".to_string(),
 			content: system_content,
 			timestamp: now,
-			cached: false,
-			cache_ttl: None,
+			cached: supports_caching,
+			cache_ttl: if supports_caching {
+				Some("1h".to_string())
+			} else {
+				None
+			},
 			tool_call_id: None,
 			name: None,
 			tool_calls: None,
@@ -71,8 +85,6 @@ pub(super) async fn call_ai_for_decision(
 		},
 	];
 
-	let decision_config = &config.compression.decision;
-
 	crate::log_debug!(
 		"Using compression decision model '{}' (max_tokens={}, temp={}, ignore_cost={})",
 		decision_config.model,
@@ -92,6 +104,7 @@ pub(super) async fn call_ai_for_decision(
 	)
 	.with_max_retries(decision_config.max_retries)
 	.with_full_context_tokens(true)
+	.with_schema(schema)
 	.with_cancellation_token(operation_rx);
 
 	let response = crate::session::chat_completion_with_validation(params).await?;
@@ -110,102 +123,40 @@ pub(super) async fn call_ai_for_decision(
 		log_debug!("Compression decision cost ignored (ignore_cost=true)");
 	}
 
-	Ok(response.content)
+	// Provider returns the validated JSON in `structured_output`. If absent
+	// the provider didn't honour the schema — treat as a hard error rather
+	// than silently falling back to text parsing. `completion.rs:233`
+	// already pre-validates that the model supports structured output, so
+	// reaching this branch means a runtime provider misbehaviour.
+	let raw = response.structured_output.ok_or_else(|| {
+		anyhow::anyhow!(
+			"Compression model '{}' returned no structured_output despite schema being attached",
+			decision_config.model
+		)
+	})?;
+
+	let summary: CompressionSummary = serde_json::from_value(raw).map_err(|e| {
+		anyhow::anyhow!(
+			"Failed to deserialize compression schema response: {}. The provider returned JSON that does not match the expected shape.",
+			e
+		)
+	})?;
+
+	Ok(summary)
 }
 
-/// Minimum acceptable length (after trim + knowledge-tag strip) for a compression summary.
+/// Orchestration entrypoint: build prompt + schema, invoke model, apply
+/// substantive-content gate, return whether to compress and the typed summary.
 ///
-/// A 200-OK response from the AI is no guarantee the body is usable. The model can
-/// return:
-/// - bare `"YES"` with no summary line,
-/// - `"YES\n<knowledge>...</knowledge>"` (knowledge stripped → empty),
-/// - `force=true` response that is ONLY knowledge tags (also strips to empty),
-/// - whitespace, a stray punctuation, or other near-empty noise.
+/// Returns `(should_compress, summary)`:
+/// - `should_compress = false` → caller skips compression entirely; the
+///   returned `summary` is meaningless and must not be applied.
+/// - `should_compress = true` → caller proceeds with `apply_compression`
+///   using the returned typed summary.
 ///
-/// If we accept any of those, `apply_compression` would drain dozens of messages and
-/// insert a header-only "## Conversation Summary" block — wiping the entire context.
-/// This guard refuses to compress in that case so the caller sets a cooldown and the
-/// session keeps its real history.
-pub(super) const MIN_SUMMARY_LEN: usize = 20;
-
-/// True if a candidate summary is substantive enough to replace compressed messages.
-pub(super) fn is_summary_valid(summary: &str) -> bool {
-	summary.trim().chars().count() >= MIN_SUMMARY_LEN
-}
-
-/// Parse the AI response into a compression decision and optional summary text.
-///
-/// `force=true`: entire response is the summary (no YES/NO gate).
-/// `force=false`: first line must be YES to proceed; NO means skip compression.
-///
-/// SAFETY: A response that yields a too-short summary (after trim + knowledge-tag
-/// strip) is treated as a compression failure and returns `(false, "")` — even on
-/// the `force` path. Better to skip compression than to wipe the conversation with
-/// an empty summary. See `MIN_SUMMARY_LEN`.
-pub(super) fn parse_ai_response(
-	session: &mut ChatSession,
-	config: &Config,
-	content: &str,
-	force: bool,
-) -> Result<(bool, String)> {
-	let content = content.trim();
-	let lines: Vec<&str> = content.lines().collect();
-
-	if lines.is_empty() {
-		if force {
-			return Err(anyhow::anyhow!(
-				"AI returned empty summary during forced compression"
-			));
-		}
-		log_debug!("AI compression decision: NO (empty response)");
-		return Ok((false, String::new()));
-	}
-
-	// Extract and store critical knowledge from <knowledge> tags before returning summary
-	extract_and_store_knowledge(session, config, content);
-
-	if force {
-		// Entire response is the summary — no YES/NO prefix expected.
-		let summary = strip_knowledge_tags(content);
-		if !is_summary_valid(&summary) {
-			log_info!(
-				"Compression aborted: AI returned too-short summary ({} chars, force=true). Skipping compression to avoid context loss.",
-				summary.trim().chars().count()
-			);
-			return Ok((false, String::new()));
-		}
-		log_debug!("AI forced compression summary ({} chars)", summary.len());
-		return Ok((true, summary));
-	}
-
-	let first_line = lines[0].trim().to_uppercase();
-	let decision = first_line.contains("YES");
-
-	if decision {
-		let summary = if lines.len() > 1 {
-			let raw = lines[1..].join("\n").trim().to_string();
-			strip_knowledge_tags(&raw)
-		} else {
-			String::new()
-		};
-		if !is_summary_valid(&summary) {
-			log_info!(
-				"Compression aborted: AI said YES but summary is too short ({} chars). Skipping compression to avoid context loss.",
-				summary.trim().chars().count()
-			);
-			return Ok((false, String::new()));
-		}
-		log_debug!(
-			"AI compression decision: YES with summary ({} chars)",
-			summary.len()
-		);
-		Ok((true, summary))
-	} else {
-		log_debug!("AI compression decision: NO");
-		Ok((false, String::new()))
-	}
-}
-
+/// Substantive-content gate: if the model emits `should_compress: true` but
+/// every narrative field is empty, we refuse to compress. Better to skip
+/// than to wipe the session with a header-only summary.
 pub(super) async fn ask_ai_decision_and_summary(
 	session: &mut ChatSession,
 	config: &Config,
@@ -213,10 +164,40 @@ pub(super) async fn ask_ai_decision_and_summary(
 	operation_rx: tokio::sync::watch::Receiver<bool>,
 	force: bool,
 	target_ratio: f64,
-) -> Result<(bool, String)> {
+) -> Result<(bool, CompressionSummary)> {
 	let (system_content, user_content) =
 		build_compression_prompt(session, messages_to_compress, force, target_ratio);
-	let response_content =
-		call_ai_for_decision(session, config, system_content, user_content, operation_rx).await?;
-	parse_ai_response(session, config, &response_content, force)
+	let schema = build_compression_schema(force);
+
+	let summary = call_ai_for_decision(
+		session,
+		config,
+		system_content,
+		user_content,
+		schema,
+		operation_rx,
+	)
+	.await?;
+
+	if !summary.should_compress {
+		log_debug!("AI compression decision: should_compress=false");
+		return Ok((false, summary));
+	}
+
+	if !is_summary_substantive(&summary) {
+		log_info!(
+			"Compression aborted: AI set should_compress=true but every narrative field is empty. Skipping compression to avoid context loss."
+		);
+		return Ok((false, summary));
+	}
+
+	log_debug!(
+		"AI compression decision: should_compress=true (findings={}, recent={}, knowledge={}, files={})",
+		summary.analysis_findings.len(),
+		summary.recent_exchanges.len(),
+		summary.critical_knowledge.len(),
+		summary.file_context.len()
+	);
+
+	Ok((true, summary))
 }

--- a/src/session/chat/conversation_compression/ai.rs
+++ b/src/session/chat/conversation_compression/ai.rs
@@ -123,17 +123,30 @@ pub(super) async fn call_ai_for_decision(
 		log_debug!("Compression decision cost ignored (ignore_cost=true)");
 	}
 
-	// Provider returns the validated JSON in `structured_output`. If absent
-	// the provider didn't honour the schema — treat as a hard error rather
-	// than silently falling back to text parsing. `completion.rs:233`
-	// already pre-validates that the model supports structured output, so
-	// reaching this branch means a runtime provider misbehaviour.
-	let raw = response.structured_output.ok_or_else(|| {
-		anyhow::anyhow!(
-			"Compression model '{}' returned no structured_output despite schema being attached",
-			decision_config.model
-		)
-	})?;
+	// Provider should return the validated JSON in `structured_output`. When
+	// it's absent, try a lenient recovery from `response.content` before
+	// erroring — some providers (notably OctoHub) ship a strict text-to-JSON
+	// extractor that misses valid JSON wrapped in markdown fences or with
+	// a chatty preamble, even when the model genuinely followed the schema.
+	// Native-structured-output models (GPT, Claude, Gemini direct) hit the
+	// happy path; the fallback covers cross-routing quirks for DeepSeek,
+	// Kimi, OctoHub-routed models, etc.
+	let raw = match response.structured_output {
+		Some(v) => v,
+		None => {
+			let recovered = extract_json_lenient(&response.content).ok_or_else(|| {
+				anyhow::anyhow!(
+					"Compression model '{}' returned no structured_output and no recoverable JSON in text content",
+					decision_config.model
+				)
+			})?;
+			log_debug!(
+				"Compression model '{}' omitted structured_output; recovered JSON from text content",
+				decision_config.model
+			);
+			recovered
+		}
+	};
 
 	let summary: CompressionSummary = serde_json::from_value(raw).map_err(|e| {
 		anyhow::anyhow!(
@@ -143,6 +156,101 @@ pub(super) async fn call_ai_for_decision(
 	})?;
 
 	Ok(summary)
+}
+
+/// Best-effort JSON extraction from a text response when the provider didn't
+/// populate `structured_output`. Handles three common provider patterns:
+///
+///   1. Bare JSON: `{"…": …}`
+///   2. Fenced JSON: <code>```json\n{…}\n```</code> or unlabeled fences
+///   3. Prose preamble: `"Here is the analysis: {…}"`
+///
+/// Returns `None` if no parseable JSON object/array can be located.
+fn extract_json_lenient(content: &str) -> Option<serde_json::Value> {
+	let trimmed = content.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+
+	// Direct parse — bare JSON or JSON-with-only-whitespace-padding.
+	if matches!(trimmed.as_bytes().first(), Some(b'{') | Some(b'[')) {
+		if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+			return Some(v);
+		}
+	}
+
+	// Strip a single surrounding markdown fence (```json … ``` or ``` … ```)
+	// and retry direct parse on the inner body.
+	if let Some(inner) = strip_markdown_fence(trimmed) {
+		if let Ok(v) = serde_json::from_str::<serde_json::Value>(inner.trim()) {
+			return Some(v);
+		}
+	}
+
+	// Last resort: scan for the first balanced JSON object or array anywhere
+	// in the text, respecting string literals so brackets inside strings
+	// don't fool the counter.
+	find_first_balanced_json(trimmed)
+}
+
+/// Strip an outer markdown code fence if the content is wrapped in one.
+/// Accepts ` ```json … ``` `, ` ```JSON … ``` `, or bare ` ``` … ``` `.
+/// Returns the inner body without the fence markers, or `None` if no fence
+/// envelope is present.
+fn strip_markdown_fence(s: &str) -> Option<&str> {
+	let s = s.trim();
+	let after_open = s.strip_prefix("```")?;
+	// Optional language tag on the opening fence — accept any letters then \n.
+	let body = match after_open.find('\n') {
+		Some(nl) => &after_open[nl + 1..],
+		None => after_open,
+	};
+	body.strip_suffix("```").map(str::trim)
+}
+
+/// Scan `s` for the first balanced JSON object (`{…}`) or array (`[…]`).
+/// Tracks bracket depth while skipping over string literals (with `\"` escape
+/// handling) so punctuation inside strings doesn't unbalance the counter.
+fn find_first_balanced_json(s: &str) -> Option<serde_json::Value> {
+	let bytes = s.as_bytes();
+	for start in 0..bytes.len() {
+		let open = bytes[start];
+		if open != b'{' && open != b'[' {
+			continue;
+		}
+		let close = if open == b'{' { b'}' } else { b']' };
+		let mut depth: i32 = 0;
+		let mut in_string = false;
+		let mut escape = false;
+		for (i, &b) in bytes.iter().enumerate().skip(start) {
+			if in_string {
+				if escape {
+					escape = false;
+				} else if b == b'\\' {
+					escape = true;
+				} else if b == b'"' {
+					in_string = false;
+				}
+				continue;
+			}
+			if b == b'"' {
+				in_string = true;
+			} else if b == open {
+				depth += 1;
+			} else if b == close {
+				depth -= 1;
+				if depth == 0 {
+					let candidate = &s[start..=i];
+					if let Ok(v) = serde_json::from_str::<serde_json::Value>(candidate) {
+						return Some(v);
+					}
+					// Balanced but invalid — abandon this opener, outer loop continues.
+					break;
+				}
+			}
+		}
+	}
+	None
 }
 
 /// Orchestration entrypoint: build prompt + schema, invoke model, apply
@@ -200,4 +308,93 @@ pub(super) async fn ask_ai_decision_and_summary(
 	);
 
 	Ok((true, summary))
+}
+
+#[cfg(test)]
+mod extract_json_lenient_tests {
+	use super::extract_json_lenient;
+
+	#[test]
+	fn parses_bare_object() {
+		let v = extract_json_lenient(r#"{"should_compress": true, "x": 1}"#).unwrap();
+		assert_eq!(v["should_compress"], true);
+		assert_eq!(v["x"], 1);
+	}
+
+	#[test]
+	fn parses_bare_array() {
+		let v = extract_json_lenient(r#"[1, 2, 3]"#).unwrap();
+		assert_eq!(v.as_array().unwrap().len(), 3);
+	}
+
+	#[test]
+	fn strips_json_labeled_markdown_fence() {
+		let input = "```json\n{\"should_compress\": false}\n```";
+		let v = extract_json_lenient(input).unwrap();
+		assert_eq!(v["should_compress"], false);
+	}
+
+	#[test]
+	fn strips_unlabeled_markdown_fence() {
+		let input = "```\n{\"k\": \"v\"}\n```";
+		let v = extract_json_lenient(input).unwrap();
+		assert_eq!(v["k"], "v");
+	}
+
+	#[test]
+	fn recovers_from_chatty_preamble() {
+		let input = "Here is the analysis:\n{\"should_compress\": true, \"target\": 2.0}";
+		let v = extract_json_lenient(input).unwrap();
+		assert_eq!(v["should_compress"], true);
+		assert_eq!(v["target"], 2.0);
+	}
+
+	#[test]
+	fn recovers_from_preamble_with_fence() {
+		let input = "Sure, here you go:\n```json\n{\"a\": 1}\n```\nDone!";
+		let v = extract_json_lenient(input).unwrap();
+		assert_eq!(v["a"], 1);
+	}
+
+	#[test]
+	fn respects_braces_inside_strings() {
+		// Naive brace-counting would balance early on the `{` inside the string;
+		// the scanner must skip string contents.
+		let input = r#"text {"label": "value with } brace", "n": 7}"#;
+		let v = extract_json_lenient(input).unwrap();
+		assert_eq!(v["label"], "value with } brace");
+		assert_eq!(v["n"], 7);
+	}
+
+	#[test]
+	fn handles_escaped_quotes_in_strings() {
+		let input = r#"prefix {"msg": "she said \"hi\""}"#;
+		let v = extract_json_lenient(input).unwrap();
+		assert_eq!(v["msg"], "she said \"hi\"");
+	}
+
+	#[test]
+	fn returns_none_for_empty_input() {
+		assert!(extract_json_lenient("").is_none());
+		assert!(extract_json_lenient("   \n\t  ").is_none());
+	}
+
+	#[test]
+	fn returns_none_for_no_json() {
+		assert!(extract_json_lenient("just a plain text response with no JSON").is_none());
+	}
+
+	#[test]
+	fn returns_none_for_truncated_json() {
+		// Opener with no matching close — provider got cut off.
+		assert!(extract_json_lenient(r#"{"incomplete": "no closing brace"#).is_none());
+	}
+
+	#[test]
+	fn skips_invalid_object_finds_later_valid_one() {
+		// First {…} has a syntax error; scanner must keep going and find the second.
+		let input = r#"garbage {not valid json} more text {"ok": true}"#;
+		let v = extract_json_lenient(input).unwrap();
+		assert_eq!(v["ok"], true);
+	}
 }

--- a/src/session/chat/conversation_compression/apply.rs
+++ b/src/session/chat/conversation_compression/apply.rs
@@ -18,7 +18,8 @@
 // update anchor + token bookkeeping. Pure side-effects on `ChatSession`.
 
 use super::decision::estimate_future_turns;
-use super::knowledge::format_compressed_entry_with_context;
+use super::knowledge::{fold_critical_knowledge, format_compressed_entry_with_context};
+use super::schema::{render_summary, CompressionSummary};
 use crate::log_debug;
 use crate::session::chat::file_context;
 use crate::session::chat::session::ChatSession;
@@ -67,23 +68,41 @@ fn build_continuation_content(intent: Option<&str>) -> String {
 }
 
 /// Apply compression: drain all messages, insert summary, re-inject recent user messages.
-/// Also parses and injects file contexts if given by AI.
+/// Pulls structured file contexts and critical knowledge directly from the
+/// typed summary — no markdown re-parsing.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn apply_compression(
 	session: &mut ChatSession,
 	start_idx: usize,
 	end_idx: usize,
-	context_summary: &str,
+	summary: &CompressionSummary,
 	tokens_before: u64,
 	current_context_tokens: u64,
 	user_tasks_msgs: Vec<String>,
 	last_user_message: Option<crate::session::Message>,
 	preserved_skills: Vec<crate::session::Message>,
+	config: &crate::config::Config,
 ) -> Result<()> {
-	// Parse file contexts from AI summary (AI may request specific file ranges to re-inject)
-	let file_contexts = file_context::parse_file_contexts(context_summary);
+	// Fold critical knowledge from the typed summary into the session.
+	// Done up-front so the session reflects the new knowledge before we
+	// insert the rendered markdown that omits the (already-folded) entries.
+	fold_critical_knowledge(session, config, &summary.critical_knowledge);
 
-	// Generate file context content if any contexts found
+	// Render the typed summary to the markdown body that gets inserted into
+	// the session as the compressed turn. Sections appear only when they
+	// carry signal so the body stays terse on early or sparse compressions.
+	let summary_body = render_summary(summary);
+
+	// File context: structured array → tuple form expected by the legacy
+	// renderer. Validate line ranges (start <= end, both > 0); drop invalid
+	// entries silently rather than failing compression.
+	let file_contexts: Vec<(String, usize, usize)> = summary
+		.file_context
+		.iter()
+		.filter(|fc| fc.start_line > 0 && fc.start_line <= fc.end_line)
+		.map(|fc| (fc.filepath.clone(), fc.start_line, fc.end_line))
+		.collect();
+
 	let file_context_content = if !file_contexts.is_empty() {
 		crate::log_debug!(
 			"Compression: AI requested {} file context(s) for continuation",
@@ -97,15 +116,11 @@ pub(super) async fn apply_compression(
 		String::new()
 	};
 
-	// Format compressed entry with file context
 	let compression_id = crate::mcp::core::plan::compression::get_compression_id()
 		.unwrap_or_else(|| "unknown".to_string());
 
-	let base_entry = format_compressed_entry_with_context(
-		context_summary,
-		&file_context_content,
-		compression_id,
-	);
+	let base_entry =
+		format_compressed_entry_with_context(&summary_body, &file_context_content, compression_id);
 
 	// Prepend USER TASKS section (last 4 user requests, excluding the appended one).
 	// These are raw user messages — not AI-rephrased — so intent is never lost.

--- a/src/session/chat/conversation_compression/apply.rs
+++ b/src/session/chat/conversation_compression/apply.rs
@@ -288,9 +288,6 @@ pub(super) async fn apply_compression(
 		}
 	);
 
-	// Update first_prompt_idx to the actual anchor used for this compression.
-	session.first_prompt_idx = Some(start_idx);
-
 	// Calculate metrics
 	let tokens_saved = tokens_before.saturating_sub(tokens_after);
 

--- a/src/session/chat/conversation_compression/knowledge.rs
+++ b/src/session/chat/conversation_compression/knowledge.rs
@@ -12,80 +12,109 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Compression-summary formatting and <knowledge> tag handling.
+// XML wrapper around the rendered summary + folding of critical knowledge
+// into the session.
 //
-// Extracted from the main compression module to keep this cluster of pure
-// text-manipulation helpers in one focused place. Visibility is `pub(super)`
-// so both the parent `conversation_compression` module and its `tests`
-// submodule can reach these helpers without exposing them crate-wide.
+// The XML/regex parsers that used to live here for `<knowledge>` and
+// `<context>` tags are gone — the model now returns a typed JSON object
+// (`schema::CompressionSummary`) and we render it deterministically as XML.
+//
+// Why XML for the wrapper too: Claude is tuned to attend to XML-delimited
+// sections. A summary is the largest *re-fed* block in subsequent
+// compressions, so structuring it as XML (instead of `## H2 markdown`)
+// makes the model's section detection more reliable across paraphrase
+// cycles.
 
 use crate::config::Config;
 use crate::session::chat::session::ChatSession;
 use crate::{log_debug, log_info};
 
+/// Open tag of the conversation-summary wrapper. Used as the prior-summary
+/// sentinel when re-feeding a prior summary into the next compression
+/// transcript (`prompt.rs`) and as the file-context strip boundary below.
+pub(super) const SUMMARY_TAG_OPEN_PREFIX: &str = "<conversation_summary";
+
 pub(super) fn format_compressed_entry_with_context(
-	context: &str,
+	body: &str,
 	file_context: &str,
 	compression_id: String,
 ) -> String {
-	let mut sections = Vec::new();
+	let mut sections = String::new();
 
-	if !context.is_empty() {
-		sections.push(context.to_string());
+	if !body.is_empty() {
+		sections.push_str(body);
+		sections.push('\n');
 	}
 
-	// Add file context if provided (automatically expanded from AI's <context> tags)
 	if !file_context.is_empty() {
-		sections.push(format!(
-			"**FILE CONTEXT** (auto-expanded):\n{}",
-			file_context
-		));
+		sections.push_str("<file_context>\n");
+		sections.push_str(file_context);
+		if !file_context.ends_with('\n') {
+			sections.push('\n');
+		}
+		sections.push_str("</file_context>\n");
 	}
 
 	format!(
-		"## Conversation Summary [COMPRESSED: {}]\n\n{}",
-		compression_id,
-		sections.join("\n\n"),
+		"<conversation_summary id=\"{}\">\n{}</conversation_summary>",
+		compression_id, sections
 	)
 }
 
-/// Strip the FILE CONTEXT section from a prior compressed summary before re-feeding it
-/// to the next compression pass.
-///
-/// When a summary is re-compressed, the embedded file bytes are stale and bloat the
-/// prompt. The AI will re-request any files it still needs via <context> tags.
-/// Returns the summary text with the FILE CONTEXT block removed, trimmed.
+/// Strip the `<file_context>` block from a prior compressed summary before
+/// re-feeding it to the next compression pass. When a summary is
+/// re-compressed, the embedded file bytes are stale and bloat the prompt —
+/// the AI will re-request whatever it still needs via the structured
+/// `file_context` field of the new summary.
 pub(super) fn strip_file_context_from_summary(summary: &str) -> String {
-	const SENTINEL: &str = "\n\n**FILE CONTEXT** (auto-expanded):";
-	if let Some(pos) = summary.find(SENTINEL) {
-		summary[..pos].trim().to_string()
+	const OPEN: &str = "<file_context>";
+	const CLOSE: &str = "</file_context>";
+	let bytes = summary.as_bytes();
+	if let Some(open) = summary.find(OPEN) {
+		// Locate the matching close tag; if absent, drop everything from the
+		// open onward (defensive — a malformed summary should still
+		// strip cleanly rather than re-embed half the file dump).
+		let close_end = summary[open + OPEN.len()..]
+			.find(CLOSE)
+			.map(|i| open + OPEN.len() + i + CLOSE.len())
+			.unwrap_or(bytes.len());
+		let mut head = summary[..open].trim_end().to_string();
+		let tail = summary[close_end..].trim_start().to_string();
+		if !tail.is_empty() {
+			head.push('\n');
+			head.push_str(&tail);
+		}
+		head.trim().to_string()
 	} else {
 		summary.trim().to_string()
 	}
 }
 
-/// Extract <knowledge> tags from AI compression response, store in session, and log.
-/// Trims to the configured knowledge_retention limit (keeps most recent entries).
-pub(super) fn extract_and_store_knowledge(
+/// Persist `critical_knowledge` entries from the typed summary onto the
+/// session and log them. Trims to the configured `knowledge_retention`
+/// limit (keeping the most recent entries).
+///
+/// Replaces the old `<knowledge>` tag extractor — entries now arrive
+/// pre-structured as `Vec<String>` from the schema response.
+pub(super) fn fold_critical_knowledge(
 	session: &mut ChatSession,
 	config: &Config,
-	content: &str,
+	entries: &[String],
 ) {
-	let knowledge_entries = parse_knowledge_tags(content);
-	if knowledge_entries.is_empty() {
+	let new_entries: Vec<&String> = entries.iter().filter(|e| !e.trim().is_empty()).collect();
+	if new_entries.is_empty() {
 		return;
 	}
 
 	let retention_limit = config.compression.knowledge_retention;
-	for entry in &knowledge_entries {
+	let added = new_entries.len();
+
+	for entry in new_entries {
 		log_debug!("Extracted critical knowledge: {}", entry);
 		session.critical_knowledge.push(entry.clone());
-
-		// Persist to session log
 		let _ = crate::session::logger::log_knowledge_entry(&session.session.info.name, entry);
 	}
 
-	// Trim to retention limit (keep most recent)
 	if retention_limit > 0 && session.critical_knowledge.len() > retention_limit {
 		let drain_count = session.critical_knowledge.len() - retention_limit;
 		session.critical_knowledge.drain(..drain_count);
@@ -97,43 +126,7 @@ pub(super) fn extract_and_store_knowledge(
 
 	log_info!(
 		"Stored {} new critical knowledge entries ({} total)",
-		knowledge_entries.len(),
+		added,
 		session.critical_knowledge.len()
 	);
-}
-
-/// Parse all <knowledge>...</knowledge> tags from text.
-/// Returns the trimmed content of each tag.
-pub(super) fn parse_knowledge_tags(content: &str) -> Vec<String> {
-	let mut entries = Vec::new();
-	let mut search_from = 0;
-	while let Some(start) = content[search_from..].find("<knowledge>") {
-		let abs_start = search_from + start + "<knowledge>".len();
-		if let Some(end) = content[abs_start..].find("</knowledge>") {
-			let abs_end = abs_start + end;
-			let entry = content[abs_start..abs_end].trim().to_string();
-			if !entry.is_empty() {
-				entries.push(entry);
-			}
-			search_from = abs_end + "</knowledge>".len();
-		} else {
-			break;
-		}
-	}
-	entries
-}
-
-/// Strip <knowledge>...</knowledge> tags from summary text.
-/// The knowledge is already extracted and stored separately — no need to keep it in the summary.
-pub(super) fn strip_knowledge_tags(content: &str) -> String {
-	let mut result = content.to_string();
-	while let Some(start) = result.find("<knowledge>") {
-		if let Some(end) = result[start..].find("</knowledge>") {
-			let abs_end = start + end + "</knowledge>".len();
-			result = format!("{}{}", &result[..start], &result[abs_end..]);
-		} else {
-			break;
-		}
-	}
-	result.trim().to_string()
 }

--- a/src/session/chat/conversation_compression/mod.rs
+++ b/src/session/chat/conversation_compression/mod.rs
@@ -29,6 +29,7 @@ mod decision;
 mod knowledge;
 mod prompt;
 mod range;
+mod schema;
 
 // Submodule entrypoints used by this orchestrator file:
 // - `ai::ask_ai_decision_and_summary` runs the LLM round-trip (it builds the
@@ -473,7 +474,8 @@ pub async fn check_and_compress_conversation(
 		.collect();
 
 	// OPTIMIZATION: Single API call for decision + summary (1-hop instead of 2-hop)
-	let (should_compress, context_summary) = ask_ai_decision_and_summary(
+	// Response is schema-validated and arrives as a typed struct.
+	let (should_compress, summary) = ask_ai_decision_and_summary(
 		session,
 		config,
 		&messages_to_compress,
@@ -490,17 +492,18 @@ pub async fn check_and_compress_conversation(
 
 	log_info!("AI decided to compress older conversation exchanges");
 
-	// Apply compression with the summary we got from AI
+	// Apply compression with the typed summary
 	apply_compression(
 		session,
 		start_idx,
 		end_idx,
-		&context_summary,
+		&summary,
 		tokens_before,
 		current_context_tokens,
 		user_tasks_msgs,
 		last_user_message,
 		preserved_skills,
+		config,
 	)
 	.await?;
 

--- a/src/session/chat/conversation_compression/mod.rs
+++ b/src/session/chat/conversation_compression/mod.rs
@@ -195,11 +195,7 @@ pub async fn should_check_compression(session: &mut ChatSession, config: &Config
 
 	if net_benefit > 0.0 {
 		// Verify compression will actually reduce context meaningfully
-		let (start_idx, end_idx) = match find_compression_range(
-			&session.session.messages,
-			session.first_prompt_idx,
-			false,
-		) {
+		let (start_idx, end_idx) = match find_compression_range(&session.session.messages, false) {
 			Ok(range) => range,
 			Err(e) => {
 				log_debug!("Failed to find compression range: {}", e);
@@ -344,8 +340,7 @@ pub async fn check_and_compress_conversation(
 
 	// OPTIMIZATION: Do semantic chunking BEFORE AI call (local, no API cost)
 	// This allows us to send context chunks to AI in the same call as decision
-	let (start_idx, end_idx) =
-		find_compression_range(&session.session.messages, session.first_prompt_idx, force)?;
+	let (start_idx, end_idx) = find_compression_range(&session.session.messages, force)?;
 
 	// end_idx is already safe from find_compression_range
 

--- a/src/session/chat/conversation_compression/prompt.rs
+++ b/src/session/chat/conversation_compression/prompt.rs
@@ -17,43 +17,111 @@
 // AI invocation in `ai.rs` so prompt tuning and AI orchestration can evolve
 // independently.
 //
-// Output shape is enforced by JSON schema (see `schema::build_compression_schema`),
-// not by markdown templates embedded in the prompt. As a result this prompt
-// is dramatically shorter than the old free-form version — it only carries
-// *behavioural guidance* the schema cannot express (priorities, scaffold
-// rules, recency semantics).
+// Two prompt modes mirror the two AI-call modes in `ai.rs`:
+//   - JSON mode (`build_compression_prompt_json`): output shape is enforced
+//     by JSON schema (see `schema::build_compression_schema`); the prompt
+//     carries only behavioural guidance.
+//   - XML mode (`build_compression_prompt_xml`): for providers without
+//     structured-output support; the prompt additionally embeds the XML
+//     output specification (`schema::XML_OUTPUT_SPEC`) so the model knows
+//     the exact tag shape `schema::parse_xml_summary` will validate against.
+//
+// The user content (transcript + prior knowledge + file refs) is identical
+// across modes — only the system content and the closing task instruction
+// differ.
 
 use super::knowledge::{strip_file_context_from_summary, SUMMARY_TAG_OPEN_PREFIX};
+use super::schema::XML_OUTPUT_SPEC;
 use crate::session::chat::file_context;
 use crate::session::chat::session::ChatSession;
 
-/// Build the system and user prompt for the compression AI call.
+/// Output mode for the compression call. Decided up-front from the
+/// provider's `supports_structured_output(model)` capability in `ai.rs`.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum OutputMode {
+	/// Schema-driven JSON path (preferred). Provider receives the
+	/// `build_compression_schema(..)` value as `structured_output`.
+	Json,
+	/// XML path. No schema attached; the model is told to emit XML matching
+	/// `XML_OUTPUT_SPEC` and the response is parsed by `parse_xml_summary`.
+	Xml,
+}
+
+/// Build the system and user prompt for the JSON-mode compression call.
 ///
-/// Returns `(system_content, user_content)`.
-///
-/// The system content is byte-identical across every compression call that
-/// shares the same `force` value. `ai.rs` flags it as cached so the provider
-/// can amortise it across calls — a small but real cost win for sessions
-/// that compress multiple times.
-pub(super) fn build_compression_prompt(
+/// Output shape is governed by the JSON schema attached to the request; the
+/// prompt only carries behavioural guidance.
+pub(super) fn build_compression_prompt_json(
 	session: &ChatSession,
 	messages_to_compress: &[crate::session::Message],
 	force: bool,
 	target_ratio: f64,
 ) -> (String, String) {
-	// The response shape is defined by the JSON schema attached to the call.
-	// What this prompt provides is *behaviour*: how to choose what to put in
-	// each field, what to carry forward, what to drop. Field-level descriptions
-	// live in the schema; cross-field rules and priorities live here.
+	build_compression_prompt(
+		session,
+		messages_to_compress,
+		force,
+		target_ratio,
+		OutputMode::Json,
+	)
+}
+
+/// Build the system and user prompt for the XML-mode compression call.
+///
+/// Used when the provider does not support structured output. The system
+/// prompt embeds the XML output specification so the model knows the
+/// exact tag contract; the user-side task instruction directs raw-XML
+/// output (no fences, no prose).
+pub(super) fn build_compression_prompt_xml(
+	session: &ChatSession,
+	messages_to_compress: &[crate::session::Message],
+	force: bool,
+	target_ratio: f64,
+) -> (String, String) {
+	build_compression_prompt(
+		session,
+		messages_to_compress,
+		force,
+		target_ratio,
+		OutputMode::Xml,
+	)
+}
+
+/// Shared implementation. Returns `(system_content, user_content)`.
+///
+/// The system content is byte-identical across every compression call that
+/// shares the same `(force, mode)` pair. `ai.rs` flags it as cached so the
+/// provider can amortise it across calls — a small but real cost win for
+/// sessions that compress multiple times.
+fn build_compression_prompt(
+	session: &ChatSession,
+	messages_to_compress: &[crate::session::Message],
+	force: bool,
+	target_ratio: f64,
+	mode: OutputMode,
+) -> (String, String) {
+	// Behavioural guidance shared by both modes: how to choose what to put
+	// where, what to carry forward, what to drop. Mode-specific output
+	// contract is appended (schema reference for JSON, XML spec for XML).
 	let force_directive = if force {
 		"\n<forced>\nThe user has explicitly requested compression. Set should_compress to true and fill every field. Refusal is not an option.\n</forced>"
 	} else {
 		""
 	};
 
+	let role_line = match mode {
+		OutputMode::Json => "You are a conversation compressor. Read a conversation transcript and emit a faithful structured summary so the session can continue with full working context. Your output is validated against a strict JSON schema — field shapes and constraints are documented there.",
+		OutputMode::Xml => "You are a conversation compressor. Read a conversation transcript and emit a faithful structured summary so the session can continue with full working context. Your output is an XML document — the exact tag contract is specified in <output_format> below and is parsed by tag boundaries.",
+	};
+
+	let mode_appendix = match mode {
+		OutputMode::Json => String::new(),
+		OutputMode::Xml => format!("\n\n{XML_OUTPUT_SPEC}"),
+	};
+
 	let system_content = format!(
 		"<role>
-You are a conversation compressor. Read a conversation transcript and emit a faithful structured summary so the session can continue with full working context. Your output is validated against a strict JSON schema — field shapes and constraints are documented there.
+{role_line}
 </role>
 
 <priorities>
@@ -74,7 +142,7 @@ If the transcript contains a prior <conversation_summary id=\"…\">…</convers
 
 <recency>
 Messages tagged [RECENT] are the most recent and most important — preserve them with highest fidelity. [USER] and [ASSISTANT] turns are primary signal. [TOOL CALL] and [TOOL RESULT] entries are secondary context.
-</recency>{force_directive}",
+</recency>{force_directive}{mode_appendix}",
 	);
 
 	// USER message: longform transcript first, task instruction at the bottom
@@ -278,15 +346,26 @@ Messages tagged [RECENT] are the most recent and most important — preserve the
 	}
 
 	// 4. Task instruction — at the BOTTOM (Anthropic long-context guidance:
-	//    query-at-end lifts quality on complex inputs).
+	//    query-at-end lifts quality on complex inputs). The output-contract
+	//    line differs per mode: JSON cites the attached schema, XML cites
+	//    the <output_format> block embedded in the system prompt.
+	let output_directive = match mode {
+		OutputMode::Json => {
+			"Emit a single JSON object conforming to the structured-output schema attached to this request."
+		}
+		OutputMode::Xml => {
+			"Emit a single XML document with the exact tags defined in <output_format>. Output ONLY raw XML — no prose, no code fences."
+		}
+	};
 	user_content.push_str(&format!(
 		"\n<task>\n\
 Compress the transcript above to roughly {pct}% of its original size ({ratio:.1}x compression). Be {agg} in what you preserve.\n\
-Emit a single JSON object conforming to the structured-output schema attached to this request.\n\
+{out}\n\
 </task>",
 		pct = reduction_pct,
 		ratio = target_ratio,
 		agg = aggressiveness,
+		out = output_directive,
 	));
 
 	(system_content, user_content)

--- a/src/session/chat/conversation_compression/prompt.rs
+++ b/src/session/chat/conversation_compression/prompt.rs
@@ -16,168 +16,114 @@
 // string assembly — no LLM call, no session mutation. Kept apart from the
 // AI invocation in `mod.rs` so prompt tuning and AI orchestration can evolve
 // independently.
+//
+// Prompt design follows three proven techniques:
+//   1. XML-tag structure for the system prompt (Anthropic: Claude is tuned
+//      to attend to XML-delimited sections; reduces section drift).
+//   2. Longform-at-top, query-at-bottom layout in the user message
+//      (Anthropic: queries at the end can lift quality up to 30% on
+//      large/complex inputs).
+//   3. Positive phrasing throughout (multiple 2024–2026 studies on the
+//      "Pink Elephant" problem: "do not X" routinely degrades performance
+//      versus the equivalent "do Y").
+// Sentence/paragraph caps are kept (not word caps): models can plan to a
+// sentence but cannot reliably count tokens/words.
 
 use super::knowledge::strip_file_context_from_summary;
 use crate::session::chat::file_context;
 use crate::session::chat::session::ChatSession;
 
-/// This combines decision + summarization to reduce latency and cost by 50%
-/// Ask AI: should we compress AND get summary in ONE call (1-hop optimization)
-/// This combines decision + summarization to reduce latency and cost by 50%.
-/// When `force=true` the AI is only asked to summarize — it has no right to say NO.
 /// Build the system and user prompt for the compression AI call.
 ///
 /// Returns `(system_content, user_content)`.
-/// `force=true` produces a direct-summary prompt (no YES/NO gate).
+///
+/// Single prompt path — `force` only swaps the trailing `<response_directive>`
+/// line (direct summary vs. YES/NO gate). Everything else is identical, so
+/// prompt drift between the two paths is impossible.
 pub(super) fn build_compression_prompt(
 	session: &ChatSession,
 	messages_to_compress: &[crate::session::Message],
 	force: bool,
 	target_ratio: f64,
 ) -> (String, String) {
-	// SYSTEM: role identity + instructions (what the model must do and how to respond).
-	// Kept separate from the data so the model acts as a compressor, not a session participant.
-	//
-	// SINGLE PATH: always produce a full summary when compressing — no silent YES/NO-only fallback.
-	// The prompt encodes three priorities:
-	//   1. CURRENT TASK — the user's most recent request dominates; older tasks compress aggressively.
-	//   2. RECENCY — messages marked [RECENT] are preserved with highest fidelity.
-	//   3. TOOL CALLS — secondary context, reduced to one-liners.
-	let system_content = if force {
-		"You are a conversation compressor. \
-The user has explicitly requested compression. You MUST produce a summary — do NOT refuse. \
-Do not start with YES or NO. Just write the summary directly using the format below.\n\n\
-## CRITICAL PRIORITIES\n\n\
-**Priority 1 — CURRENT TASK**: The user's MOST RECENT task/request is what matters most. \
-If the user pivoted to a new topic mid-conversation, the new topic IS the current intent. \
-Older completed/abandoned tasks can be compressed to a single line each.\n\n\
-**Priority 2 — RECENCY**: Messages marked [RECENT] represent the current state of work. \
-Preserve them with the highest fidelity — quote or closely paraphrase. \
-Older messages can be compressed aggressively.\n\n\
-**Priority 3 — TOOL CALLS are secondary**: Summarize what was done in one line each.\n\n\
-## SUMMARY FORMAT\n\n\
-**SESSION CONTEXT** (1 sentence):\n\
-Brief overview of the session — what brought us here. Keep it short.\n\n\
-**CURRENT TASK** (1-2 sentences):\n\
-What is the user working on RIGHT NOW? This is the most recent request — highlight it as the primary focus.\n\n\
-**PROGRESS** (2-4 sentences):\n\
-What was completed for the current task? What is in progress? What was the outcome?\n\n\
-**ANALYSIS FINDINGS** (preserve conclusions — this prevents re-doing work):\n\
-Capture key findings from code analysis, debugging, or investigation. Include:\n\
-- What was discovered (root causes, patterns, behaviors)\n\
-- Specific code locations and what was found there\n\
-- Conclusions drawn from tool results\n\
-This section is CRITICAL — without it, the AI will re-read the same files to rediscover the same things.\n\n\
-**RECENT EXCHANGES** (preserve with high fidelity — the most recent [RECENT] messages):\n\
-For each recent user/assistant pair: quote or closely paraphrase.\n\n\
-**KEY ENTITIES** (preserve exactly — copy values verbatim):\n\
-- Files/paths: exact file paths, line numbers, code locations\n\
-- Names: identifiers, function names, variable names, config keys\n\
-- Errors/issues: problems encountered and their status\n\
-- Decisions: choices made with reasoning\n\n\
-**NEXT STEPS** (1-2 sentences):\n\
-What needs to happen next to continue the current task?\n\n\
-**FILE CONTEXT — files to auto-inject after compression (IMPORTANT):**\n\
-Files listed in <context> tags will be AUTO-READ from disk and injected verbatim into the compressed summary. \
-This is how the session retains real file content across compressions without re-reading. \
-Include any file the session is actively working on or needs to continue.\n\
-<context>\n\
-filepath:startline:endline\n\
-</context>\n\
-Rules: <context> tags required; one entry per line as filepath:N:N (no spaces); \
-paths from project root; line numbers 1–10000; max 5 ranges; prioritize files being edited or analyzed.\n\n\
-**CRITICAL KNOWLEDGE — survives all future compressions:**\n\
-If there is critical knowledge that MUST survive future compressions \
-(e.g., a key architectural decision, a non-obvious constraint, a user preference, \
-analysis conclusions, root cause findings), write it in a <knowledge> tag. \
-2-3 sentences MAX. Only include if truly critical — not routine progress.\n\
-<knowledge>\n\
-Your critical insight here (2-3 sentences max).\n\
-</knowledge>\n\n\
-"
+	// Response directive — the only branch between force / non-force.
+	// Phrased positively: state the desired action, not the forbidden one.
+	let response_directive = if force {
+		"Write the summary directly. Start your response with the SESSION CONTEXT section."
 	} else {
-		"You are a conversation compressor. \
-Your job is to produce a lossless summary of a conversation transcript so the session can continue \
-without losing any important context.\n\n\
-## CRITICAL PRIORITIES (read carefully before summarizing)\n\n\
-**Priority 1 — CURRENT TASK**: The user's MOST RECENT task/request is what matters most. \
-If the user pivoted to a new topic mid-conversation, the new topic IS the current intent. \
-Older completed/abandoned tasks can be compressed to a single line each.\n\n\
-**Priority 2 — RECENCY**: Messages marked [RECENT] represent the current state of work. \
-Preserve them with the highest fidelity — quote or closely paraphrase. \
-Older messages without [RECENT] can be compressed aggressively.\n\n\
-**Priority 3 — TOOL CALLS are secondary**: Summarize what was done in one line each \
-(e.g. 'read file X', 'ran shell command Y, got Z'). Never reproduce full tool output.\n\n\
-## WHEN TO ANSWER YES vs NO\n\n\
-Answer YES if there are older exchanges that can be compressed without losing information needed \
-to continue. Answer NO only if the transcript is already minimal and nothing can be safely reduced.\n\n\
-## SUMMARY FORMAT (use when answering YES)\n\n\
-**SESSION CONTEXT** (1 sentence):\n\
-Brief overview of the session — what brought us here. Keep it short.\n\n\
-**CURRENT TASK** (1-2 sentences):\n\
-What is the user working on RIGHT NOW? This is the most recent request — highlight it as the primary focus.\n\n\
-**PROGRESS** (2-4 sentences):\n\
-What was completed for the current task? What is in progress? What was the outcome?\n\n\
-**ANALYSIS FINDINGS** (preserve conclusions — this prevents re-doing work):\n\
-Capture key findings from code analysis, debugging, or investigation. Include:\n\
-- What was discovered (root causes, patterns, behaviors)\n\
-- Specific code locations and what was found there\n\
-- Conclusions drawn from tool results\n\
-This section is CRITICAL — without it, the AI will re-read the same files to rediscover the same things.\n\n\
-**RECENT EXCHANGES** (preserve with high fidelity — the most recent [RECENT] messages):\n\
-For each recent user/assistant pair: quote or closely paraphrase. Do not compress these.\n\n\
-**KEY ENTITIES** (preserve exactly — copy values verbatim):\n\
-- Files/paths: exact file paths, line numbers, code locations\n\
-- Names: identifiers, function names, variable names, config keys\n\
-- Errors/issues: problems encountered and their status\n\
-- Decisions: choices made with reasoning\n\n\
-**NEXT STEPS** (1-2 sentences):\n\
-What needs to happen next to continue the current task?\n\n\
-## RESPONSE FORMAT\n\n\
-Start with YES or NO on the first line.\n\
-If YES, follow immediately with the summary using the sections above:\n\n\
-YES\n\
-**SESSION CONTEXT**: ...\n\
-**CURRENT TASK**: ...\n\
-**PROGRESS**: ...\n\
-**ANALYSIS FINDINGS**:\n\
-- [finding 1]\n\
-- [finding 2]\n\
-**RECENT EXCHANGES**:\n\
-- User: [question] → Assistant: [answer]\n\
-**KEY ENTITIES**:\n\
-- Files/paths: ...\n\
-- Errors/issues: ...\n\
-- Decisions: ...\n\
-**NEXT STEPS**: ...\n\n\
-**FILE CONTEXT — files to auto-inject after compression (IMPORTANT):**\n\
-Files listed in <context> tags will be AUTO-READ from disk and injected verbatim into the compressed summary. \
-This is how the session retains real file content across compressions without re-reading. \
-Include any file the session is actively working on or needs to continue.\n\
-<context>\n\
-filepath:startline:endline\n\
-</context>\n\
-Rules: <context> tags required; one entry per line as filepath:N:N (no spaces); \
-paths from project root; line numbers 1–10000; max 5 ranges; prioritize files being edited or analyzed.\n\n\
-**CRITICAL KNOWLEDGE — survives all future compressions:**\n\
-If there is critical knowledge that MUST survive future compressions \
-(e.g., a key architectural decision, a non-obvious constraint, a user preference, \
-analysis conclusions, root cause findings), write it in a <knowledge> tag. \
-2-3 sentences MAX. Only include if truly critical — not routine progress.\n\
-<knowledge>\n\
-Your critical insight here (2-3 sentences max).\n\
-</knowledge>\n\n\
-If NO, respond with just: NO"
-	}
-	.to_string();
+		"If older exchanges can be compressed without losing information needed to continue, write YES on the first line, then the summary. \
+If the transcript is already minimal, respond with the single line: NO"
+	};
 
-	// USER: plain-text transcript of the range being compressed + semantic chunk hints.
-	// Building a transcript (not raw messages) prevents the model from continuing the
-	// tool-calling loop — it sees text to analyze, not a live conversation to participate in.
+	let system_content = format!(
+		"<role>
+You are a conversation compressor. Your job: read a conversation transcript and produce a faithful summary so the session can continue with full working context.
+</role>
+
+<priorities>
+1. The user's MOST RECENT request is the active task — preserve it precisely.
+2. Messages tagged [RECENT] reflect current state — paraphrase closely, keep concrete details.
+3. Older exchanges and tool activity are secondary — compress them aggressively into one-liners.
+4. Copy file paths, line numbers, identifiers, and error strings verbatim from the transcript.
+</priorities>
+
+<output_format>
+Write a document with these sections, in this order:
+
+SESSION CONTEXT (1 sentence): what brought the session to this point.
+
+CURRENT TASK (1–2 sentences): the user's most recent active request — highlight it as the primary focus.
+
+PROGRESS (2–4 sentences): what was completed for the current task, what is in progress, what was the outcome.
+
+ANALYSIS FINDINGS (3–6 bullets): conclusions from code analysis, debugging, or investigation. Cover what was discovered (root causes, patterns, behaviors), the specific code locations involved, and the conclusions drawn from tool results. Capture these so the next turn skips re-deriving them.
+
+RECENT EXCHANGES (one bullet per [RECENT] turn): closely paraphrase each [RECENT] user/assistant pair. Keep concrete details and decisions intact.
+
+KEY ENTITIES (copy values verbatim from the transcript):
+- Files/paths: exact paths with line numbers
+- Names: identifiers, function names, variable names, config keys
+- Errors/issues: error strings and current status
+- Decisions: choices made with their reasoning
+
+NEXT STEPS (1–2 sentences): the concrete action that advances the current task.
+</output_format>
+
+<file_context_rules>
+List the files the next turn will need to read. These are auto-loaded from disk and re-injected after the summary, so the session retains real file content across compressions.
+
+Format: one entry per line as filepath:startline:endline. Paths from project root. Line numbers between 1 and 10000. Maximum 5 ranges. Prioritize files actively being edited or analyzed.
+
+<context>
+filepath:N:N
+</context>
+</file_context_rules>
+
+<critical_knowledge_rules>
+Record insights that must survive future compressions — an architectural decision, a hidden constraint, a user preference, a root-cause finding. Include only truly critical knowledge (not routine progress). 2–3 sentences each.
+
+<knowledge>
+Critical insight here (2–3 sentences max).
+</knowledge>
+</critical_knowledge_rules>
+
+<response_directive>
+{response_directive}
+</response_directive>"
+	);
+
+	// USER: longform transcript first, task instruction last (Anthropic
+	// long-context best practice: query-at-bottom gains up to 30% on
+	// complex inputs).
 	//
-	// RECENCY MARKER: the last 8 messages (min 4, max 8) are tagged [RECENT] so the AI
-	// knows to preserve them with the highest fidelity. Capped at 8 to prevent the
-	// RECENT window from growing so large it defeats compression on long sessions.
+	// Building a transcript (not raw messages) prevents the model from
+	// continuing the tool-calling loop — it sees text to analyze, not a
+	// live conversation to participate in.
+	//
+	// RECENCY MARKER: the last 8 messages (min 4, max 8) are tagged [RECENT]
+	// so the AI knows to preserve them with the highest fidelity. Capped at
+	// 8 to prevent the RECENT window from growing so large it defeats
+	// compression on long sessions.
 	let total_msgs = messages_to_compress.len();
 	let recent_count = (total_msgs / 4).clamp(4, 8);
 	let recent_start = total_msgs.saturating_sub(recent_count);
@@ -190,25 +136,30 @@ If NO, respond with just: NO"
 	} else {
 		"gentle"
 	};
-	let mut user_content = format!(
-		"**COMPRESSION TARGET**: Reduce this transcript to ~{}% of its original size ({:.1}x compression). \
-Be {} in what you preserve.\n\n\
-**Conversation transcript to compress:**\n\
-NOTE: Messages marked [RECENT] are the most recent and most important — preserve them with \
-highest fidelity. [USER]/[ASSISTANT] pairs are primary signal; [TOOL CALL]/[TOOL RESULT] are \
-secondary context.\n\n",
-		reduction_pct, target_ratio, aggressiveness,
-	);
 
-	// Inject accumulated critical knowledge from prior compressions
+	let mut user_content = String::new();
+
+	// 1. Prior critical knowledge — short meta-context, placed before the
+	//    transcript so the model reads the transcript already aware of
+	//    must-preserve facts.
 	if !session.critical_knowledge.is_empty() {
+		user_content.push_str("<prior_knowledge>\n");
 		user_content
-			.push_str("**CRITICAL KNOWLEDGE (from prior compressions — MUST be preserved):**\n");
+			.push_str("From earlier compressions of this session — these facts must survive into the new summary:\n");
 		for (i, knowledge) in session.critical_knowledge.iter().enumerate() {
 			user_content.push_str(&format!("{}. {}\n", i + 1, knowledge));
 		}
-		user_content.push('\n');
+		user_content.push_str("</prior_knowledge>\n\n");
 	}
+
+	// 2. Transcript — the longform data, opens with a short reader hint then
+	//    the labelled exchanges. Wrapped in <transcript> so the model knows
+	//    exactly which span is the input to summarize.
+	user_content.push_str("<transcript>\n");
+	user_content.push_str(
+		"Messages tagged [RECENT] are the most recent and most important — preserve them with highest fidelity. \
+[USER] and [ASSISTANT] turns are primary signal. [TOOL CALL] and [TOOL RESULT] entries are secondary context.\n\n",
+	);
 
 	// Collect file references from tool calls for context preservation
 	// These can be re-read on demand after compression
@@ -354,19 +305,38 @@ secondary context.\n\n",
 		}
 	}
 
-	// Append file references extracted from tool calls
-	// These allow the model to re-read critical files after compression
+	// Close the <transcript> block.
+	user_content.push_str("</transcript>\n");
+
+	// 3. File references extracted from tool calls — candidate ranges the
+	//    next turn can re-read on demand. Placed between the transcript and
+	//    the task so the model sees them while deciding which files to
+	//    include under <file_context_rules>.
 	if !file_refs.is_empty() {
-		// Merge overlapping ranges and dedupe
 		let merged_refs = file_context::merge_file_refs(&file_refs);
 		if !merged_refs.is_empty() {
-			user_content.push_str("\n**File references (can be re-read on demand):**\n");
-			// Limit to prevent bloat
+			user_content.push_str("\n<file_references>\n");
+			user_content
+				.push_str("Files touched by tool calls in this transcript (candidates for the <context> tag in your output):\n");
 			for ref_str in merged_refs.iter().take(10) {
 				user_content.push_str(&format!("- {}\n", ref_str));
 			}
+			user_content.push_str("</file_references>\n");
 		}
 	}
+
+	// 4. Task instruction — placed at the BOTTOM of the user message
+	//    (Anthropic long-context guidance: query-at-end lifts quality on
+	//    complex inputs). Concrete compression target and writing posture.
+	user_content.push_str(&format!(
+		"\n<task>\n\
+Compress the transcript above to roughly {pct}% of its original size ({ratio:.1}x compression). Be {agg} in what you preserve.\n\
+Follow the output format from your instructions exactly. Apply the response directive verbatim.\n\
+</task>",
+		pct = reduction_pct,
+		ratio = target_ratio,
+		agg = aggressiveness,
+	));
 
 	(system_content, user_content)
 }

--- a/src/session/chat/conversation_compression/prompt.rs
+++ b/src/session/chat/conversation_compression/prompt.rs
@@ -14,22 +14,16 @@
 
 // Build the (system, user) prompt pair sent to the compression LLM. Pure
 // string assembly — no LLM call, no session mutation. Kept apart from the
-// AI invocation in `mod.rs` so prompt tuning and AI orchestration can evolve
+// AI invocation in `ai.rs` so prompt tuning and AI orchestration can evolve
 // independently.
 //
-// Prompt design follows three proven techniques:
-//   1. XML-tag structure for the system prompt (Anthropic: Claude is tuned
-//      to attend to XML-delimited sections; reduces section drift).
-//   2. Longform-at-top, query-at-bottom layout in the user message
-//      (Anthropic: queries at the end can lift quality up to 30% on
-//      large/complex inputs).
-//   3. Positive phrasing throughout (multiple 2024–2026 studies on the
-//      "Pink Elephant" problem: "do not X" routinely degrades performance
-//      versus the equivalent "do Y").
-// Sentence/paragraph caps are kept (not word caps): models can plan to a
-// sentence but cannot reliably count tokens/words.
+// Output shape is enforced by JSON schema (see `schema::build_compression_schema`),
+// not by markdown templates embedded in the prompt. As a result this prompt
+// is dramatically shorter than the old free-form version — it only carries
+// *behavioural guidance* the schema cannot express (priorities, scaffold
+// rules, recency semantics).
 
-use super::knowledge::strip_file_context_from_summary;
+use super::knowledge::{strip_file_context_from_summary, SUMMARY_TAG_OPEN_PREFIX};
 use crate::session::chat::file_context;
 use crate::session::chat::session::ChatSession;
 
@@ -37,93 +31,60 @@ use crate::session::chat::session::ChatSession;
 ///
 /// Returns `(system_content, user_content)`.
 ///
-/// Single prompt path — `force` only swaps the trailing `<response_directive>`
-/// line (direct summary vs. YES/NO gate). Everything else is identical, so
-/// prompt drift between the two paths is impossible.
+/// The system content is byte-identical across every compression call that
+/// shares the same `force` value. `ai.rs` flags it as cached so the provider
+/// can amortise it across calls — a small but real cost win for sessions
+/// that compress multiple times.
 pub(super) fn build_compression_prompt(
 	session: &ChatSession,
 	messages_to_compress: &[crate::session::Message],
 	force: bool,
 	target_ratio: f64,
 ) -> (String, String) {
-	// Response directive — the only branch between force / non-force.
-	// Phrased positively: state the desired action, not the forbidden one.
-	let response_directive = if force {
-		"Write the summary directly. Start your response with the SESSION CONTEXT section."
+	// The response shape is defined by the JSON schema attached to the call.
+	// What this prompt provides is *behaviour*: how to choose what to put in
+	// each field, what to carry forward, what to drop. Field-level descriptions
+	// live in the schema; cross-field rules and priorities live here.
+	let force_directive = if force {
+		"\n<forced>\nThe user has explicitly requested compression. Set should_compress to true and fill every field. Refusal is not an option.\n</forced>"
 	} else {
-		"If older exchanges can be compressed without losing information needed to continue, write YES on the first line, then the summary. \
-If the transcript is already minimal, respond with the single line: NO"
+		""
 	};
 
 	let system_content = format!(
 		"<role>
-You are a conversation compressor. Your job: read a conversation transcript and produce a faithful summary so the session can continue with full working context.
+You are a conversation compressor. Read a conversation transcript and emit a faithful structured summary so the session can continue with full working context. Your output is validated against a strict JSON schema — field shapes and constraints are documented there.
 </role>
 
 <priorities>
 1. The user's MOST RECENT request is the active task — preserve it precisely.
 2. Messages tagged [RECENT] reflect current state — paraphrase closely, keep concrete details.
-3. Older exchanges and tool activity are secondary — compress them aggressively into one-liners.
-4. Copy file paths, line numbers, identifiers, and error strings verbatim from the transcript.
+3. Older exchanges and tool activity are secondary — compress them aggressively.
+4. File paths, line numbers, identifiers, and error strings — copy verbatim from the transcript.
+5. User negative feedback (\"don't do X\", \"stop doing Y\") is the HIGHEST preservation priority — never lose a correction.
 </priorities>
 
-<output_format>
-Write a document with these sections, in this order:
+<scaffold_rules>
+If the transcript contains a prior <conversation_summary id=\"…\">…</conversation_summary> block, treat its content as established facts that must carry forward:
+- original_request: copy from the prior summary unchanged. Otherwise quote verbatim from the very first user turn.
+- analysis_findings, errors_and_corrections, critical_knowledge: carry forward all prior entries, append new ones.
+- progress: extend (do not replace) the prior progress narrative.
+- current_task, next_steps: replace based on the most recent transcript.
+</scaffold_rules>
 
-SESSION CONTEXT (1 sentence): what brought the session to this point.
-
-CURRENT TASK (1–2 sentences): the user's most recent active request — highlight it as the primary focus.
-
-PROGRESS (2–4 sentences): what was completed for the current task, what is in progress, what was the outcome.
-
-ANALYSIS FINDINGS (3–6 bullets): conclusions from code analysis, debugging, or investigation. Cover what was discovered (root causes, patterns, behaviors), the specific code locations involved, and the conclusions drawn from tool results. Capture these so the next turn skips re-deriving them.
-
-RECENT EXCHANGES (one bullet per [RECENT] turn): closely paraphrase each [RECENT] user/assistant pair. Keep concrete details and decisions intact.
-
-KEY ENTITIES (copy values verbatim from the transcript):
-- Files/paths: exact paths with line numbers
-- Names: identifiers, function names, variable names, config keys
-- Errors/issues: error strings and current status
-- Decisions: choices made with their reasoning
-
-NEXT STEPS (1–2 sentences): the concrete action that advances the current task.
-</output_format>
-
-<file_context_rules>
-List the files the next turn will need to read. These are auto-loaded from disk and re-injected after the summary, so the session retains real file content across compressions.
-
-Format: one entry per line as filepath:startline:endline. Paths from project root. Line numbers between 1 and 10000. Maximum 5 ranges. Prioritize files actively being edited or analyzed.
-
-<context>
-filepath:N:N
-</context>
-</file_context_rules>
-
-<critical_knowledge_rules>
-Record insights that must survive future compressions — an architectural decision, a hidden constraint, a user preference, a root-cause finding. Include only truly critical knowledge (not routine progress). 2–3 sentences each.
-
-<knowledge>
-Critical insight here (2–3 sentences max).
-</knowledge>
-</critical_knowledge_rules>
-
-<response_directive>
-{response_directive}
-</response_directive>"
+<recency>
+Messages tagged [RECENT] are the most recent and most important — preserve them with highest fidelity. [USER] and [ASSISTANT] turns are primary signal. [TOOL CALL] and [TOOL RESULT] entries are secondary context.
+</recency>{force_directive}",
 	);
 
-	// USER: longform transcript first, task instruction last (Anthropic
-	// long-context best practice: query-at-bottom gains up to 30% on
-	// complex inputs).
-	//
-	// Building a transcript (not raw messages) prevents the model from
-	// continuing the tool-calling loop — it sees text to analyze, not a
-	// live conversation to participate in.
+	// USER message: longform transcript first, task instruction at the bottom
+	// (Anthropic long-context best practice: query-at-end can lift quality up
+	// to 30% on complex inputs).
 	//
 	// RECENCY MARKER: the last 8 messages (min 4, max 8) are tagged [RECENT]
-	// so the AI knows to preserve them with the highest fidelity. Capped at
-	// 8 to prevent the RECENT window from growing so large it defeats
-	// compression on long sessions.
+	// so the AI knows which span to preserve with highest fidelity. Capped at
+	// 8 so the RECENT window can't grow to swallow the whole transcript on
+	// long sessions and defeat compression.
 	let total_msgs = messages_to_compress.len();
 	let recent_count = (total_msgs / 4).clamp(4, 8);
 	let recent_start = total_msgs.saturating_sub(recent_count);
@@ -139,30 +100,25 @@ Critical insight here (2–3 sentences max).
 
 	let mut user_content = String::new();
 
-	// 1. Prior critical knowledge — short meta-context, placed before the
-	//    transcript so the model reads the transcript already aware of
-	//    must-preserve facts.
+	// 1. Prior critical knowledge — short meta-context that must persist across
+	//    compressions. Placed before the transcript so the model reads the
+	//    transcript already aware of must-preserve facts. These facts must
+	//    appear in the emitted `critical_knowledge` array verbatim.
 	if !session.critical_knowledge.is_empty() {
 		user_content.push_str("<prior_knowledge>\n");
 		user_content
-			.push_str("From earlier compressions of this session — these facts must survive into the new summary:\n");
+			.push_str("From earlier compressions of this session — these facts must survive into the new summary's critical_knowledge:\n");
 		for (i, knowledge) in session.critical_knowledge.iter().enumerate() {
 			user_content.push_str(&format!("{}. {}\n", i + 1, knowledge));
 		}
 		user_content.push_str("</prior_knowledge>\n\n");
 	}
 
-	// 2. Transcript — the longform data, opens with a short reader hint then
-	//    the labelled exchanges. Wrapped in <transcript> so the model knows
-	//    exactly which span is the input to summarize.
+	// 2. Transcript — the longform data. Building a labelled text transcript
+	//    (not raw messages) keeps the model from continuing the tool-calling
+	//    loop — it sees text to analyse, not a live conversation to join.
 	user_content.push_str("<transcript>\n");
-	user_content.push_str(
-		"Messages tagged [RECENT] are the most recent and most important — preserve them with highest fidelity. \
-[USER] and [ASSISTANT] turns are primary signal. [TOOL CALL] and [TOOL RESULT] entries are secondary context.\n\n",
-	);
 
-	// Collect file references from tool calls for context preservation
-	// These can be re-read on demand after compression
 	let mut file_refs: Vec<String> = Vec::new();
 
 	for (idx, msg) in messages_to_compress.iter().enumerate() {
@@ -170,14 +126,16 @@ Critical insight here (2–3 sentences max).
 		match msg.role.as_str() {
 			"system" => {} // skip system — already in our system message
 			"assistant" => {
-				// Include text content; summarize tool calls as one-liners with key arg.
-				// CRITICAL: If this is a prior compressed summary, strip the FILE CONTEXT
-				// section before including it — file content will be re-read fresh by the
-				// new compression. Including stale XML bloats the prompt and causes the AI
-				// to re-embed the same file bytes in every subsequent summary.
+				// If this is a prior compressed summary, drop its <file_context>
+				// block before re-feeding. The file bytes are stale; the new
+				// compression cycle will re-request whatever it still needs via
+				// the structured `file_context` field. Re-embedding the old
+				// content would bloat the prompt and recursively grow each
+				// summary.
 				let assistant_text = if msg
 					.content
-					.starts_with("## Conversation Summary [COMPRESSED:")
+					.trim_start()
+					.starts_with(SUMMARY_TAG_OPEN_PREFIX)
 				{
 					strip_file_context_from_summary(&msg.content)
 				} else {
@@ -194,8 +152,6 @@ Critical insight here (2–3 sentences max).
 							.and_then(|n| n.as_str())
 							.unwrap_or("unknown");
 
-						// Extract a short key-arg hint (first path/query/command arg) so the
-						// AI understands what the tool was operating on, not just its name.
 						let key_arg = call
 							.get("function")
 							.and_then(|f| f.get("arguments"))
@@ -206,7 +162,6 @@ Critical insight here (2–3 sentences max).
 									Some(a.clone())
 								};
 								obj.and_then(|o| {
-									// Try common key-arg field names in priority order
 									for key in &[
 										"path", "paths", "query", "command", "pattern", "content",
 										"task",
@@ -252,8 +207,6 @@ Critical insight here (2–3 sentences max).
 							));
 						}
 
-						// Extract file references from tool arguments
-						// These allow the model to re-read files after compression
 						if let Some(args) = call.get("function").and_then(|f| f.get("arguments")) {
 							file_context::extract_file_refs_from_args(name, args, &mut file_refs);
 						}
@@ -263,8 +216,9 @@ Critical insight here (2–3 sentences max).
 			"tool" => {
 				let name = msg.name.as_deref().unwrap_or("tool");
 				let content = msg.content.trim();
-				// Preserve both the start (tool name/context) and the end (errors/results).
-				// Errors typically appear at the tail — head-only truncation hides them.
+				// Preserve both the start (tool name/context) and the end
+				// (errors/results). Errors typically appear at the tail —
+				// head-only truncation hides them.
 				let truncated = if content.len() > 1500 {
 					let head_end = content
 						.char_indices()
@@ -297,7 +251,6 @@ Critical insight here (2–3 sentences max).
 				));
 			}
 			_ => {
-				// user messages — always include, never drop
 				if !msg.content.trim().is_empty() {
 					user_content.push_str(&format!("{}[USER]: {}\n", recent, msg.content.trim()));
 				}
@@ -305,19 +258,18 @@ Critical insight here (2–3 sentences max).
 		}
 	}
 
-	// Close the <transcript> block.
 	user_content.push_str("</transcript>\n");
 
 	// 3. File references extracted from tool calls — candidate ranges the
 	//    next turn can re-read on demand. Placed between the transcript and
-	//    the task so the model sees them while deciding which files to
-	//    include under <file_context_rules>.
+	//    the task so the model sees them while populating `file_context`.
 	if !file_refs.is_empty() {
 		let merged_refs = file_context::merge_file_refs(&file_refs);
 		if !merged_refs.is_empty() {
 			user_content.push_str("\n<file_references>\n");
-			user_content
-				.push_str("Files touched by tool calls in this transcript (candidates for the <context> tag in your output):\n");
+			user_content.push_str(
+				"Files touched by tool calls in this transcript (candidates for file_context):\n",
+			);
 			for ref_str in merged_refs.iter().take(10) {
 				user_content.push_str(&format!("- {}\n", ref_str));
 			}
@@ -325,13 +277,12 @@ Critical insight here (2–3 sentences max).
 		}
 	}
 
-	// 4. Task instruction — placed at the BOTTOM of the user message
-	//    (Anthropic long-context guidance: query-at-end lifts quality on
-	//    complex inputs). Concrete compression target and writing posture.
+	// 4. Task instruction — at the BOTTOM (Anthropic long-context guidance:
+	//    query-at-end lifts quality on complex inputs).
 	user_content.push_str(&format!(
 		"\n<task>\n\
 Compress the transcript above to roughly {pct}% of its original size ({ratio:.1}x compression). Be {agg} in what you preserve.\n\
-Follow the output format from your instructions exactly. Apply the response directive verbatim.\n\
+Emit a single JSON object conforming to the structured-output schema attached to this request.\n\
 </task>",
 		pct = reduction_pct,
 		ratio = target_ratio,

--- a/src/session/chat/conversation_compression/range.rs
+++ b/src/session/chat/conversation_compression/range.rs
@@ -13,103 +13,55 @@
 // limitations under the License.
 
 // Range determination for compression: pick which message indices get drained,
-// and price the chosen range in tokens. Kept apart from the AI decision logic
-// in `mod.rs` because these are pure functions over `&[Message]` / `ChatSession`
-// with no LLM call or config dependency beyond the session itself.
+// and price the chosen range in tokens. Pure functions over `&[Message]` /
+// `ChatSession`; no LLM call, no persisted state.
+//
+// Anchor selection is purely structural and re-derived on every call — no
+// `first_prompt_idx` cache, no resume-time bootstrap detection, no Some/None
+// branching. Two-rule deterministic ladder:
+//
+//   1. If a `<instructions>` user message exists, anchor = its LATEST index.
+//   2. Else, anchor = first user message index.
+//
+// No tool-skip dance: under this rule the anchor is always a user-role
+// message, never an assistant-with-tool_calls, so its tool results can't
+// orphan in the drain range.
 
 use crate::session::chat::session::ChatSession;
 use anyhow::Result;
 
-/// Find the compression range: anchor to last message (compress-all approach).
+/// User-role messages wrap the instructions file in this tag at injection
+/// time (see `prompt_setup.rs`). Detect by literal prefix on trimmed content.
+const INSTRUCTIONS_TAG_OPEN: &str = "<instructions>";
+
+/// Find the compression range deterministically from message structure.
 ///
-/// CRITICAL: Must not cut between assistant with tool_calls and its tool results
-/// CRITICAL: Compression NEVER goes below first_prompt_idx (INCLUSIVE boundary)
+/// Returns `(anchor_idx, end_idx)` where:
+/// - `anchor_idx` is KEPT (compression drains `anchor_idx+1..=end_idx`)
+/// - `end_idx = messages.len() - 1`
+///
+/// Returns `(0, 0)` when there is nothing meaningful to compress (no anchor,
+/// too few conversational messages, or anchor already at the tail).
 pub(super) fn find_compression_range(
 	messages: &[crate::session::Message],
-	first_prompt_idx: Option<usize>,
 	force: bool,
 ) -> Result<(usize, usize)> {
-	// Find system message index
-	let system_idx = messages
+	// Anchor: latest <instructions> user message, else first user message.
+	let anchor = messages
 		.iter()
-		.position(|m| m.role == "system")
-		.unwrap_or(0);
+		.enumerate()
+		.rev()
+		.find(|(_, m)| {
+			m.role == "user" && m.content.trim_start().starts_with(INSTRUCTIONS_TAG_OPEN)
+		})
+		.map(|(i, _)| i)
+		.or_else(|| messages.iter().position(|m| m.role == "user"));
 
-	// Start boundary: try to move anchor BEFORE first_prompt_idx so the first user
-	// message gets compressed. Without this, the first user message persists raw
-	// across all compression cycles — even after the user moved on to new tasks.
-	//
-	// If instructions file exists at idx-1 (user role), use it as anchor.
-	// The first user message then falls into drain range (start_idx+1..=end_idx).
-	// Keep old behavior for tool-loops (single user message — it's still active).
-	//
-	// If not set (e.g. resumed sessions), detect bootstrap messages and skip past them.
-	// Bootstrap pattern: system[0] → assistant(welcome)[1] → optional user(instructions)[2]
-	// We must NEVER compress the system prompt, welcome message, or instructions file.
-	let mut start_idx = match first_prompt_idx {
-		Some(idx) => {
-			// Check if user sent additional messages after the first prompt.
-			// If yes, the first prompt is no longer active and should be compressed.
-			let has_subsequent_user = messages.iter().skip(idx + 1).any(|m| m.role == "user");
-
-			if has_subsequent_user
-				&& idx > 0 && messages.get(idx - 1).is_some_and(|m| m.role == "user")
-			{
-				// Instructions file at idx-1 becomes anchor.
-				// First user message at idx is now in drain range.
-				idx - 1
-			} else {
-				idx
-			}
-		}
-		None => {
-			let mut idx = system_idx + 1;
-			// Skip welcome message (assistant immediately after system, WITHOUT tool_calls).
-			// A welcome is a simple greeting — if it has tool_calls, it's a working response.
-			let has_welcome = idx < messages.len()
-				&& messages[idx].role == "assistant"
-				&& messages[idx].tool_calls.is_none();
-			if has_welcome {
-				idx += 1;
-			}
-			// Skip instructions file ONLY if welcome was present.
-			// Bootstrap pattern: system → assistant(welcome) → user(instructions).
-			// Without a welcome message, the first user message is a real prompt, not instructions.
-			if has_welcome
-				&& idx < messages.len()
-				&& messages[idx].role == "user"
-				&& (idx + 1 >= messages.len() || messages[idx + 1].role == "assistant")
-			{
-				idx += 1;
-			}
-			idx
-		}
+	let start_idx = match anchor {
+		Some(i) => i,
+		None => return Ok((0, 0)),
 	};
 
-	// CRITICAL: If the anchor message has tool_calls, its tool results immediately follow it.
-	// remove_messages_in_range drains start_idx+1..=end_idx — if tool results are in that
-	// range they get removed, leaving orphaned tool_use blocks without tool_result.
-	// The API then rejects the sequence with "tool_use ids were found without tool_result".
-	// Fix: advance start_idx past all tool results that belong to the anchor's tool_calls.
-	if let Some(anchor) = messages.get(start_idx) {
-		if anchor.role == "assistant" && anchor.tool_calls.is_some() {
-			// Skip past consecutive tool messages that follow the anchor
-			let mut next = start_idx + 1;
-			while next < messages.len() && messages[next].role == "tool" {
-				next += 1;
-			}
-			// next now points to the first non-tool message after the anchor's tool results.
-			// That becomes the new anchor (the drain will start at new_start_idx+1).
-			if next > start_idx + 1 && next < messages.len() {
-				start_idx = next;
-			}
-		}
-	}
-
-	// COMPRESS-ALL APPROACH: Compress everything from start_idx+1 to the last message.
-	// Recent user messages are extracted and re-injected after the summary by the caller.
-	// This eliminates the old preserve_count / boundary-search complexity and ensures
-	// no user messages persist as stale raw artifacts across compression cycles.
 	let end_idx = messages.len() - 1;
 
 	// Minimum conversation messages to justify compression.
@@ -131,8 +83,8 @@ pub(super) fn find_compression_range(
 	Ok((start_idx, end_idx))
 }
 
-/// Calculate tokens in message range using accurate token counting
-/// This now counts ALL message fields: content, tool_calls, thinking, images, etc.
+/// Calculate tokens in message range using accurate token counting.
+/// Counts ALL message fields: content, tool_calls, thinking, images, etc.
 ///
 /// CRITICAL: The range [start_idx, end_idx] must match the messages that will
 /// actually be removed. In compression, remove_messages_in_range drains
@@ -144,7 +96,6 @@ pub(super) fn calculate_range_tokens(
 ) -> Result<u64> {
 	let mut total_tokens = 0u64;
 
-	// Validate range
 	if start_idx >= session.session.messages.len() {
 		return Err(anyhow::anyhow!("Invalid start_index in range"));
 	}
@@ -153,7 +104,6 @@ pub(super) fn calculate_range_tokens(
 		return Err(anyhow::anyhow!("Invalid end_index in range"));
 	}
 
-	// Count tokens in range [start_idx, end_idx] inclusive
 	for i in start_idx..=end_idx {
 		if let Some(message) = session.session.messages.get(i) {
 			let tokens = crate::session::estimate_message_tokens(message) as u64;

--- a/src/session/chat/conversation_compression/schema.rs
+++ b/src/session/chat/conversation_compression/schema.rs
@@ -1,0 +1,291 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Schema + typed view of the compression response.
+//!
+//! The compression LLM call is invoked with a strict JSON schema (octolib
+//! `StructuredOutputRequest::json_schema(..).with_strict_mode()`). The model
+//! returns one well-typed object; we deserialize it into `CompressionSummary`
+//! and render it deterministically to markdown for insertion into the session
+//! and re-feed into the next compression cycle.
+//!
+//! Rationale (vs. free-form markdown):
+//!   - Zero format drift: schema validation guarantees every required field
+//!     is present and correctly typed.
+//!   - YES/NO gate becomes a `should_compress: bool` field — no first-line
+//!     parsing, no "AI said YES but summary is empty" failure mode.
+//!   - `file_context` line numbers validated at schema level (1..=10000).
+//!   - System prompt shrinks ~65% (no more long format spec embedded in it),
+//!     which is cached and amortised across every compression call.
+
+use serde::Deserialize;
+
+/// Typed deserialization target for the model's structured response.
+///
+/// `#[serde(default)]` on every field is defensive — the schema is strict, so
+/// in practice every field is always present, but we never want a stray
+/// deserialization error to abort compression. A near-empty summary is caught
+/// downstream by the substantive-length check in `is_summary_substantive`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct CompressionSummary {
+	pub should_compress: bool,
+	pub original_request: String,
+	pub session_context: String,
+	pub current_task: String,
+	pub progress: String,
+	pub analysis_findings: Vec<String>,
+	pub errors_and_corrections: Vec<String>,
+	pub recent_exchanges: Vec<String>,
+	pub key_entities: KeyEntities,
+	pub next_steps: String,
+	pub file_context: Vec<FileContextEntry>,
+	pub critical_knowledge: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct KeyEntities {
+	pub files: Vec<String>,
+	pub names: Vec<String>,
+	pub decisions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FileContextEntry {
+	pub filepath: String,
+	pub start_line: usize,
+	pub end_line: usize,
+}
+
+/// Heuristic substantive-content check.
+///
+/// Replaces the old `MIN_SUMMARY_LEN` byte-count gate. With schema validation
+/// the *shape* is guaranteed; what we still need to defend against is the
+/// model emitting `should_compress: true` with all string fields empty — that
+/// would wipe the session with a header-only summary. Require at least one
+/// of the core narrative sections to carry signal.
+pub fn is_summary_substantive(summary: &CompressionSummary) -> bool {
+	!summary.current_task.trim().is_empty()
+		|| !summary.progress.trim().is_empty()
+		|| !summary.session_context.trim().is_empty()
+		|| !summary.analysis_findings.is_empty()
+		|| !summary.recent_exchanges.is_empty()
+}
+
+/// Render a structured summary to the XML body that will be inserted into
+/// the session as the compressed assistant turn and re-fed into the next
+/// compression cycle as transcript input.
+///
+/// XML over markdown: Claude is tuned to attend to XML-delimited sections
+/// (`<finding>…</finding>` is parsed more reliably than `- finding`), and
+/// `**HEADER**:` text is just bytes to the model whereas `<header>…</header>`
+/// is a structural boundary. The structured tags survive paraphrase decay
+/// across compressions; markdown headers don't.
+///
+/// Sections appear only when they carry signal — the body stays terse on
+/// early or sparse compressions. Order matches priority (original request
+/// first → next steps last).
+pub fn render_summary(summary: &CompressionSummary) -> String {
+	let mut out = String::new();
+
+	let push_text = |out: &mut String, tag: &str, value: &str| {
+		if !value.trim().is_empty() {
+			out.push_str(&format!("<{tag}>{}</{tag}>\n", value.trim(), tag = tag));
+		}
+	};
+
+	let push_list = |out: &mut String, outer: &str, item: &str, values: &[String]| {
+		let non_empty: Vec<&String> = values.iter().filter(|s| !s.trim().is_empty()).collect();
+		if non_empty.is_empty() {
+			return;
+		}
+		out.push_str(&format!("<{outer}>\n"));
+		for v in non_empty {
+			out.push_str(&format!("<{item}>{}</{item}>\n", v.trim(), item = item));
+		}
+		out.push_str(&format!("</{outer}>\n"));
+	};
+
+	push_text(&mut out, "original_request", &summary.original_request);
+	push_text(&mut out, "session_context", &summary.session_context);
+	push_text(&mut out, "current_task", &summary.current_task);
+	push_text(&mut out, "progress", &summary.progress);
+	push_list(
+		&mut out,
+		"analysis_findings",
+		"finding",
+		&summary.analysis_findings,
+	);
+	push_list(
+		&mut out,
+		"errors_and_corrections",
+		"entry",
+		&summary.errors_and_corrections,
+	);
+	push_list(
+		&mut out,
+		"recent_exchanges",
+		"exchange",
+		&summary.recent_exchanges,
+	);
+
+	let ke = &summary.key_entities;
+	if !ke.files.is_empty() || !ke.names.is_empty() || !ke.decisions.is_empty() {
+		out.push_str("<key_entities>\n");
+		push_list(&mut out, "files", "file", &ke.files);
+		push_list(&mut out, "names", "name", &ke.names);
+		push_list(&mut out, "decisions", "decision", &ke.decisions);
+		out.push_str("</key_entities>\n");
+	}
+
+	push_text(&mut out, "next_steps", &summary.next_steps);
+
+	out.trim_end().to_string()
+}
+
+/// Build the JSON Schema sent to the provider via `with_schema(..)`.
+///
+/// `force=true`: model has no veto. `should_compress` MUST be `true`; the
+/// schema description nails it down so the model doesn't return `false` and
+/// stall a forced compression.
+///
+/// `force=false`: model may return `should_compress: false` when the
+/// transcript is already minimal. Other fields are still required by the
+/// schema (strict mode); they're expected to be empty strings / empty arrays
+/// when `should_compress` is false.
+pub fn build_compression_schema(force: bool) -> serde_json::Value {
+	let should_compress_desc = if force {
+		"Compression has been forced by the user. MUST be true."
+	} else {
+		"True if the transcript contains older exchanges that can be safely compressed without losing information needed to continue. False only if the transcript is already minimal."
+	};
+
+	serde_json::json!({
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"should_compress": {
+				"type": "boolean",
+				"description": should_compress_desc
+			},
+			"original_request": {
+				"type": "string",
+				"description": "The user's original task statement. Quote verbatim from the very first user turn in the transcript; OR, if a prior **ORIGINAL REQUEST** exists in a previous summary inside the transcript, carry it forward unchanged. Never paraphrase."
+			},
+			"session_context": {
+				"type": "string",
+				"description": "One sentence describing what brought the session to this point."
+			},
+			"current_task": {
+				"type": "string",
+				"description": "1–2 sentences: the user's most recent active request. If the user pivoted, the new topic IS the current task."
+			},
+			"progress": {
+				"type": "string",
+				"description": "2–4 sentences: what was completed, what is in progress, the outcome so far. If a prior summary exists in the transcript, extend (do not replace) its progress narrative."
+			},
+			"analysis_findings": {
+				"type": "array",
+				"items": { "type": "string" },
+				"maxItems": 8,
+				"description": "3–6 bullets: conclusions from investigation — root causes, behaviours, code-location-specific discoveries. If a prior summary exists, carry its findings forward and append new ones."
+			},
+			"errors_and_corrections": {
+				"type": "array",
+				"items": { "type": "string" },
+				"maxItems": 10,
+				"description": "Highest-priority preservation. Verbatim user negative feedback ('don't do X', 'stop doing Y'), error strings encountered, and failed approaches with why they failed. Carry forward across compressions."
+			},
+			"recent_exchanges": {
+				"type": "array",
+				"items": { "type": "string" },
+				"maxItems": 10,
+				"description": "One short paraphrase per [RECENT]-tagged turn. Keep concrete details and decisions intact."
+			},
+			"key_entities": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"files": {
+						"type": "array",
+						"items": { "type": "string" },
+						"description": "Exact file paths with line numbers, verbatim."
+					},
+					"names": {
+						"type": "array",
+						"items": { "type": "string" },
+						"description": "Identifiers, function names, variable names, config keys, verbatim."
+					},
+					"decisions": {
+						"type": "array",
+						"items": { "type": "string" },
+						"description": "Choices made with their reasoning."
+					}
+				},
+				"required": ["files", "names", "decisions"]
+			},
+			"next_steps": {
+				"type": "string",
+				"description": "1–2 sentences: the concrete action that advances the current task next."
+			},
+			"file_context": {
+				"type": "array",
+				"maxItems": 5,
+				"items": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"filepath": {
+							"type": "string",
+							"description": "Path from project root."
+						},
+						"start_line": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 10000
+						},
+						"end_line": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 10000
+						}
+					},
+					"required": ["filepath", "start_line", "end_line"]
+				},
+				"description": "Up to 5 file ranges the next turn will need. Auto-loaded from disk and re-injected after the summary. Prioritise files being actively edited or analysed."
+			},
+			"critical_knowledge": {
+				"type": "array",
+				"items": { "type": "string" },
+				"maxItems": 5,
+				"description": "Survives ALL future compressions. Architectural decisions, hidden constraints, user preferences, root-cause findings. 2–3 sentences each. Include only when truly critical — not routine progress."
+			}
+		},
+		"required": [
+			"should_compress",
+			"original_request",
+			"session_context",
+			"current_task",
+			"progress",
+			"analysis_findings",
+			"errors_and_corrections",
+			"recent_exchanges",
+			"key_entities",
+			"next_steps",
+			"file_context",
+			"critical_knowledge"
+		]
+	})
+}

--- a/src/session/chat/conversation_compression/schema.rs
+++ b/src/session/chat/conversation_compression/schema.rs
@@ -29,7 +29,12 @@
 //!   - System prompt shrinks ~65% (no more long format spec embedded in it),
 //!     which is cached and amortised across every compression call.
 
+use anyhow::{anyhow, Result};
 use serde::Deserialize;
+
+/// Maximum allowed value for `start_line` / `end_line` in `file_context`.
+/// Mirrors the JSON schema bound so JSON and XML paths validate identically.
+const FILE_CONTEXT_LINE_MAX: usize = 10_000;
 
 /// Typed deserialization target for the model's structured response.
 ///
@@ -288,4 +293,343 @@ pub fn build_compression_schema(force: bool) -> serde_json::Value {
 			"critical_knowledge"
 		]
 	})
+}
+
+/// Parse the XML-formatted compression response (used when the provider
+/// does not support structured output) into a `CompressionSummary`.
+///
+/// Tag shape mirrors the rendered summary plus the meta fields the JSON
+/// schema carries on the wire — see `XML_OUTPUT_SPEC` in `prompt.rs` for
+/// the exact contract sent to the model.
+///
+/// Tolerant of surrounding prose, code fences, and partial truncation —
+/// extracts known tag bodies anywhere in the text. Unknown tags are
+/// ignored. Missing tags map to defaults (empty string / empty vec).
+///
+/// Validation: structural sanity only (filepath non-empty, line bounds,
+/// start <= end). The substantive-content gate runs downstream against
+/// the parsed struct, matching the JSON path.
+pub fn parse_xml_summary(text: &str) -> Result<CompressionSummary> {
+	let body = strip_optional_envelope(text);
+
+	let should_compress = extract_text(body, "should_compress")
+		.map(|s| parse_bool(&s))
+		.ok_or_else(|| anyhow!("compression XML response missing <should_compress> tag"))??;
+
+	let key_entities = extract_text(body, "key_entities")
+		.map(|inner| KeyEntities {
+			files: extract_items(&inner, "files", "file"),
+			names: extract_items(&inner, "names", "name"),
+			decisions: extract_items(&inner, "decisions", "decision"),
+		})
+		.unwrap_or_default();
+
+	let file_context = extract_file_context(body)?;
+
+	Ok(CompressionSummary {
+		should_compress,
+		original_request: extract_text(body, "original_request").unwrap_or_default(),
+		session_context: extract_text(body, "session_context").unwrap_or_default(),
+		current_task: extract_text(body, "current_task").unwrap_or_default(),
+		progress: extract_text(body, "progress").unwrap_or_default(),
+		analysis_findings: extract_items(body, "analysis_findings", "finding"),
+		errors_and_corrections: extract_items(body, "errors_and_corrections", "entry"),
+		recent_exchanges: extract_items(body, "recent_exchanges", "exchange"),
+		key_entities,
+		next_steps: extract_text(body, "next_steps").unwrap_or_default(),
+		file_context,
+		critical_knowledge: extract_items(body, "critical_knowledge", "knowledge"),
+	})
+}
+
+/// Strip an outer markdown code fence if the whole payload is wrapped in
+/// one. The model is told to emit raw XML, but some chat providers will
+/// re-wrap any tag-heavy response in ```xml … ``` regardless.
+fn strip_optional_envelope(text: &str) -> &str {
+	let trimmed = text.trim();
+	if let Some(after_open) = trimmed.strip_prefix("```") {
+		let body = match after_open.find('\n') {
+			Some(nl) => &after_open[nl + 1..],
+			None => after_open,
+		};
+		if let Some(inner) = body.strip_suffix("```") {
+			return inner.trim();
+		}
+	}
+	trimmed
+}
+
+/// Extract the inner text of the first `<tag>…</tag>` occurrence.
+/// Whitespace around the body is trimmed. Returns `None` when the tag
+/// is absent or unbalanced.
+fn extract_text(body: &str, tag: &str) -> Option<String> {
+	let open = format!("<{tag}>");
+	let close = format!("</{tag}>");
+	let start = body.find(&open)? + open.len();
+	let end = body[start..].find(&close)? + start;
+	Some(body[start..end].trim().to_string())
+}
+
+/// Extract repeated `<item>` bodies from inside `<container>…</container>`.
+/// Empty items are dropped. Returns an empty vec when the container is
+/// absent — callers treat that as "no entries", matching the JSON-schema
+/// default of an empty array.
+fn extract_items(body: &str, container: &str, item: &str) -> Vec<String> {
+	let Some(inner) = extract_text(body, container) else {
+		return Vec::new();
+	};
+	let open = format!("<{item}>");
+	let close = format!("</{item}>");
+	let mut out = Vec::new();
+	let mut cursor = 0usize;
+	while let Some(start_rel) = inner[cursor..].find(&open) {
+		let start = cursor + start_rel + open.len();
+		let Some(end_rel) = inner[start..].find(&close) else {
+			break;
+		};
+		let end = start + end_rel;
+		let value = inner[start..end].trim();
+		if !value.is_empty() {
+			out.push(value.to_string());
+		}
+		cursor = end + close.len();
+	}
+	out
+}
+
+/// Extract `<range filepath="…" start_line="N" end_line="M"/>` entries
+/// from the `<file_context>` block and validate them.
+///
+/// Validation rules (mirror the JSON schema):
+///   - `filepath` non-empty after trimming
+///   - `start_line` and `end_line` in `1..=FILE_CONTEXT_LINE_MAX`
+///   - `start_line <= end_line`
+///
+/// An invalid entry fails the whole parse — same strictness as the JSON
+/// path's `additionalProperties: false` + range bounds.
+fn extract_file_context(body: &str) -> Result<Vec<FileContextEntry>> {
+	let Some(inner) = extract_text(body, "file_context") else {
+		return Ok(Vec::new());
+	};
+
+	let re = regex::Regex::new(
+		r#"(?s)<range\s+filepath="([^"]*)"\s+start_line="(\d+)"\s+end_line="(\d+)"\s*/?>"#,
+	)
+	.expect("static regex compiles");
+
+	let mut entries = Vec::new();
+	for caps in re.captures_iter(&inner) {
+		let filepath = caps[1].trim().to_string();
+		if filepath.is_empty() {
+			return Err(anyhow!("compression XML: <range> entry has empty filepath"));
+		}
+		let start_line: usize = caps[2]
+			.parse()
+			.map_err(|e| anyhow!("compression XML: invalid start_line: {e}"))?;
+		let end_line: usize = caps[3]
+			.parse()
+			.map_err(|e| anyhow!("compression XML: invalid end_line: {e}"))?;
+		if !(1..=FILE_CONTEXT_LINE_MAX).contains(&start_line)
+			|| !(1..=FILE_CONTEXT_LINE_MAX).contains(&end_line)
+		{
+			return Err(anyhow!(
+				"compression XML: line numbers out of range (1..={FILE_CONTEXT_LINE_MAX}) for {filepath}: {start_line}-{end_line}"
+			));
+		}
+		if start_line > end_line {
+			return Err(anyhow!(
+				"compression XML: start_line > end_line for {filepath}: {start_line}-{end_line}"
+			));
+		}
+		entries.push(FileContextEntry {
+			filepath,
+			start_line,
+			end_line,
+		});
+	}
+	Ok(entries)
+}
+
+fn parse_bool(s: &str) -> Result<bool> {
+	match s.trim().to_ascii_lowercase().as_str() {
+		"true" | "yes" | "1" => Ok(true),
+		"false" | "no" | "0" => Ok(false),
+		other => Err(anyhow!(
+			"compression XML: <should_compress> must be true/false, got '{other}'"
+		)),
+	}
+}
+
+/// Inline XML output specification embedded in the system prompt when the
+/// provider does not support structured output. The exact tag shape that
+/// `parse_xml_summary` understands. Keep this in sync with the parser.
+pub const XML_OUTPUT_SPEC: &str = r#"<output_format>
+Emit ONE single XML document with the following tags, in this order. Every required tag MUST be present. Use the exact tag names below. Do not add additional tags or attributes.
+
+<should_compress>true|false</should_compress>             (required, exactly true or false)
+<original_request>verbatim first user request</original_request>   (required, may be empty when should_compress is false)
+<session_context>one sentence</session_context>           (required, may be empty when should_compress is false)
+<current_task>1-2 sentences</current_task>                (required, may be empty when should_compress is false)
+<progress>2-4 sentences</progress>                        (required, may be empty when should_compress is false)
+<analysis_findings>                                       (required container; 0-8 <finding> items)
+  <finding>...</finding>
+</analysis_findings>
+<errors_and_corrections>                                  (required container; 0-10 <entry> items, verbatim feedback/errors)
+  <entry>...</entry>
+</errors_and_corrections>
+<recent_exchanges>                                        (required container; 0-10 <exchange> items, one per [RECENT] turn)
+  <exchange>...</exchange>
+</recent_exchanges>
+<key_entities>                                            (required container)
+  <files>
+    <file>path/to/file.rs:42-58</file>
+  </files>
+  <names>
+    <name>identifier_or_symbol</name>
+  </names>
+  <decisions>
+    <decision>choice with reasoning</decision>
+  </decisions>
+</key_entities>
+<next_steps>1-2 sentences</next_steps>                    (required, may be empty when should_compress is false)
+<file_context>                                            (required container; 0-5 entries, self-closing)
+  <range filepath="path/from/project/root.rs" start_line="N" end_line="M"/>
+</file_context>
+<critical_knowledge>                                      (required container; 0-5 <knowledge> items, 2-3 sentences each)
+  <knowledge>survives all future compressions</knowledge>
+</critical_knowledge>
+
+Output ONLY the XML. No prose, no code fences, no markdown headers — the response is parsed by exact tag boundaries.
+</output_format>"#;
+
+#[cfg(test)]
+mod xml_parser_tests {
+	use super::*;
+
+	fn minimal_ok_xml() -> String {
+		r#"<should_compress>true</should_compress>
+<original_request>do the thing</original_request>
+<session_context>session brought to here</session_context>
+<current_task>finish the thing</current_task>
+<progress>started it</progress>
+<analysis_findings><finding>root cause is X</finding></analysis_findings>
+<errors_and_corrections><entry>don't do Y</entry></errors_and_corrections>
+<recent_exchanges><exchange>user asked Z</exchange></recent_exchanges>
+<key_entities>
+  <files><file>a.rs:1-10</file></files>
+  <names><name>foo_fn</name></names>
+  <decisions><decision>chose A over B</decision></decisions>
+</key_entities>
+<next_steps>do the next thing</next_steps>
+<file_context><range filepath="a.rs" start_line="1" end_line="10"/></file_context>
+<critical_knowledge><knowledge>arch decision: X</knowledge></critical_knowledge>"#
+			.to_string()
+	}
+
+	#[test]
+	fn parses_full_happy_path() {
+		let s = parse_xml_summary(&minimal_ok_xml()).unwrap();
+		assert!(s.should_compress);
+		assert_eq!(s.original_request, "do the thing");
+		assert_eq!(s.current_task, "finish the thing");
+		assert_eq!(s.analysis_findings, vec!["root cause is X"]);
+		assert_eq!(s.errors_and_corrections, vec!["don't do Y"]);
+		assert_eq!(s.recent_exchanges, vec!["user asked Z"]);
+		assert_eq!(s.key_entities.files, vec!["a.rs:1-10"]);
+		assert_eq!(s.key_entities.names, vec!["foo_fn"]);
+		assert_eq!(s.key_entities.decisions, vec!["chose A over B"]);
+		assert_eq!(s.next_steps, "do the next thing");
+		assert_eq!(s.file_context.len(), 1);
+		assert_eq!(s.file_context[0].filepath, "a.rs");
+		assert_eq!(s.file_context[0].start_line, 1);
+		assert_eq!(s.file_context[0].end_line, 10);
+		assert_eq!(s.critical_knowledge, vec!["arch decision: X"]);
+	}
+
+	#[test]
+	fn parses_should_compress_false_with_empty_fields() {
+		let xml = r#"<should_compress>false</should_compress>
+<original_request></original_request>
+<session_context></session_context>
+<current_task></current_task>
+<progress></progress>
+<analysis_findings></analysis_findings>
+<errors_and_corrections></errors_and_corrections>
+<recent_exchanges></recent_exchanges>
+<key_entities><files></files><names></names><decisions></decisions></key_entities>
+<next_steps></next_steps>
+<file_context></file_context>
+<critical_knowledge></critical_knowledge>"#;
+		let s = parse_xml_summary(xml).unwrap();
+		assert!(!s.should_compress);
+		assert!(s.analysis_findings.is_empty());
+		assert!(s.file_context.is_empty());
+	}
+
+	#[test]
+	fn strips_code_fence_envelope() {
+		let xml = format!("```xml\n{}\n```", minimal_ok_xml());
+		let s = parse_xml_summary(&xml).unwrap();
+		assert!(s.should_compress);
+	}
+
+	#[test]
+	fn rejects_missing_should_compress() {
+		let xml = "<original_request>x</original_request>";
+		let err = parse_xml_summary(xml).unwrap_err().to_string();
+		assert!(err.contains("should_compress"), "got: {err}");
+	}
+
+	#[test]
+	fn rejects_invalid_bool() {
+		let xml = "<should_compress>maybe</should_compress>";
+		let err = parse_xml_summary(xml).unwrap_err().to_string();
+		assert!(err.contains("true/false"), "got: {err}");
+	}
+
+	#[test]
+	fn rejects_inverted_line_range() {
+		let xml = r#"<should_compress>true</should_compress>
+<file_context><range filepath="a.rs" start_line="20" end_line="10"/></file_context>"#;
+		let err = parse_xml_summary(xml).unwrap_err().to_string();
+		assert!(err.contains("start_line > end_line"), "got: {err}");
+	}
+
+	#[test]
+	fn rejects_out_of_range_line() {
+		let xml = r#"<should_compress>true</should_compress>
+<file_context><range filepath="a.rs" start_line="0" end_line="10"/></file_context>"#;
+		let err = parse_xml_summary(xml).unwrap_err().to_string();
+		assert!(err.contains("out of range"), "got: {err}");
+	}
+
+	#[test]
+	fn rejects_empty_filepath() {
+		let xml = r#"<should_compress>true</should_compress>
+<file_context><range filepath="" start_line="1" end_line="10"/></file_context>"#;
+		let err = parse_xml_summary(xml).unwrap_err().to_string();
+		assert!(err.contains("empty filepath"), "got: {err}");
+	}
+
+	#[test]
+	fn parses_multiple_items_and_drops_empties() {
+		let xml = r#"<should_compress>true</should_compress>
+<analysis_findings>
+  <finding>a</finding>
+  <finding>  </finding>
+  <finding>b</finding>
+</analysis_findings>"#;
+		let s = parse_xml_summary(xml).unwrap();
+		assert_eq!(s.analysis_findings, vec!["a", "b"]);
+	}
+
+	#[test]
+	fn tolerates_prose_before_and_after() {
+		let xml = format!(
+			"Sure, here is the output:\n\n{}\n\nLet me know if you need more.",
+			minimal_ok_xml()
+		);
+		let s = parse_xml_summary(&xml).unwrap();
+		assert!(s.should_compress);
+	}
 }

--- a/src/session/chat/conversation_compression/tests.rs
+++ b/src/session/chat/conversation_compression/tests.rs
@@ -1,9 +1,7 @@
-use super::ai::{is_summary_valid, MIN_SUMMARY_LEN};
 use super::collect_preserved_skills;
-use super::knowledge::{
-	format_compressed_entry_with_context, strip_file_context_from_summary, strip_knowledge_tags,
-};
+use super::knowledge::{format_compressed_entry_with_context, strip_file_context_from_summary};
 use super::range::find_compression_range;
+use super::schema::{is_summary_substantive, render_summary, CompressionSummary, KeyEntities};
 use crate::session::Message;
 use serde_json::json;
 
@@ -1513,18 +1511,20 @@ fn calculate_range_tokens_matches_actual_removal() {
 
 #[test]
 fn test_file_context_stripped_from_recompression_input() {
-	// strip_file_context_from_summary must remove everything from the sentinel onward.
-	// This prevents stale file bytes from accumulating in every subsequent summary.
-	let summary_with_context = "## Conversation Summary [COMPRESSED: abc]\n\
-			Some important history here.\n\n\
-			**FILE CONTEXT** (auto-expanded):\n\
-			<content path=\"src/main.rs\">\nfn main() {}\n</content>";
+	// strip_file_context_from_summary must remove the entire <file_context>…</file_context>
+	// block. This prevents stale file bytes from accumulating in every subsequent summary.
+	let summary_with_context = "<conversation_summary id=\"abc\">\n\
+			<progress>Some important history here.</progress>\n\
+			<file_context>\n\
+			<content path=\"src/main.rs\">\nfn main() {}\n</content>\n\
+			</file_context>\n\
+			</conversation_summary>";
 
 	let stripped = strip_file_context_from_summary(summary_with_context);
 
 	assert!(
-		!stripped.contains("FILE CONTEXT"),
-		"FILE CONTEXT sentinel must be stripped"
+		!stripped.contains("<file_context>"),
+		"file_context tag must be stripped"
 	);
 	assert!(
 		!stripped.contains("fn main()"),
@@ -1532,14 +1532,14 @@ fn test_file_context_stripped_from_recompression_input() {
 	);
 	assert!(
 		stripped.contains("Some important history here."),
-		"Summary text before sentinel must be preserved"
+		"Summary text before file_context must be preserved"
 	);
 }
 
 #[test]
 fn test_file_context_stripped_when_no_sentinel() {
-	// When there is no FILE CONTEXT block, the function must return the text unchanged.
-	let plain = "## Conversation Summary [COMPRESSED: abc]\nJust a summary.";
+	// When there is no file_context block, the function returns the text unchanged.
+	let plain = "<conversation_summary id=\"abc\">\n<progress>Just a summary.</progress>\n</conversation_summary>";
 	let stripped = strip_file_context_from_summary(plain);
 	assert_eq!(stripped, plain.trim());
 }
@@ -1577,7 +1577,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 	let drained: Vec<Message> = messages.drain(s1 + 1..=e1).collect();
 	assert!(!drained.is_empty(), "Cycle 1: must drain something");
 	let mut summary1 = msg("assistant");
-	summary1.content = "## Conversation Summary [COMPRESSED: c1]\nCycle 1 summary.".to_string();
+	summary1.content = "<conversation_summary id=\"c1\"><progress>Cycle 1 summary.</progress></conversation_summary>".to_string();
 	messages.insert(s1 + 1, summary1);
 
 	// ── Cycle 2: grow then compress again ────────────────────────────────
@@ -1592,7 +1592,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 	let drained2: Vec<Message> = messages.drain(s2 + 1..=e2).collect();
 	assert!(!drained2.is_empty(), "Cycle 2: must drain something");
 	let mut summary2 = msg("assistant");
-	summary2.content = "## Conversation Summary [COMPRESSED: c2]\nCycle 2 summary.".to_string();
+	summary2.content = "<conversation_summary id=\"c2\"><progress>Cycle 2 summary.</progress></conversation_summary>".to_string();
 	messages.insert(s2 + 1, summary2);
 
 	// ── Cycle 3: grow then compress again ────────────────────────────────
@@ -1709,7 +1709,7 @@ fn compress_all_with_tool_cycles() {
 	let mut after = messages.clone();
 	after.drain(start_idx + 1..=end_idx);
 	let mut summary = msg("assistant");
-	summary.content = "## Conversation Summary [COMPRESSED: test]".to_string();
+	summary.content = "<conversation_summary id=\"test\"></conversation_summary>".to_string();
 	after.insert(start_idx + 1, summary);
 	// Re-inject recent user messages
 	for (i, user_msg) in recent_users.iter().enumerate() {
@@ -1800,10 +1800,7 @@ fn test_triple_compression_only_one_summary_in_drain() {
 		// Count compressed summaries in the drain range (s+1..=e)
 		let summaries_in_drain = messages[s + 1..=e]
 			.iter()
-			.filter(|m| {
-				m.content
-					.starts_with("## Conversation Summary [COMPRESSED:")
-			})
+			.filter(|m| m.content.starts_with("<conversation_summary"))
 			.count();
 
 		if cycle > 1 {
@@ -1818,7 +1815,7 @@ fn test_triple_compression_only_one_summary_in_drain() {
 		let _drained: Vec<Message> = messages.drain(s + 1..=e).collect();
 		let mut summary = msg("assistant");
 		summary.content =
-			format!("## Conversation Summary [COMPRESSED: c{cycle}]\nCycle {cycle} summary.");
+			format!("<conversation_summary id=\"c{cycle}\"><progress>Cycle {cycle} summary.</progress></conversation_summary>");
 		messages.insert(s + 1, summary);
 	}
 }
@@ -1994,106 +1991,127 @@ fn knowledge_log_entry_uses_content_key() {
 }
 
 // ───────────────────────────────────────────────────────────────────────
-// Empty-summary safety guard
+// Empty-summary safety guard (schema era)
 //
-// Background: AI responses can pass HTTP-200 yet yield a useless summary —
-// `"YES"` with no second line, `"YES\n<knowledge>...</knowledge>"` (knowledge
-// stripped → empty), or whitespace. Without a guard, `apply_compression`
-// drains all messages and replaces them with a header-only summary block.
-// `is_summary_valid` is the gate that prevents catastrophic context loss.
+// Background: schema validation guarantees the *shape* of the response,
+// but the model could still return `should_compress: true` with every
+// narrative field empty. Without a guard, `apply_compression` would drain
+// every message and replace them with a header-only block.
+// `is_summary_substantive` rejects that case. These tests pin the gate.
 // ───────────────────────────────────────────────────────────────────────
 
-#[test]
-fn is_summary_valid_rejects_empty_string() {
-	assert!(!is_summary_valid(""));
+fn empty_summary() -> CompressionSummary {
+	CompressionSummary::default()
+}
+
+fn summary_with_progress() -> CompressionSummary {
+	let mut s = empty_summary();
+	s.should_compress = true;
+	s.progress = "User asked about config loading, AI explained the merge order.".to_string();
+	s
 }
 
 #[test]
-fn is_summary_valid_rejects_whitespace_only() {
-	assert!(!is_summary_valid("   \n\t  "));
+fn substantive_rejects_default_summary() {
+	assert!(!is_summary_substantive(&empty_summary()));
 }
 
 #[test]
-fn is_summary_valid_rejects_below_min_length() {
-	// 19 chars = below the 20-char floor
-	let short = "a".repeat(MIN_SUMMARY_LEN - 1);
-	assert!(!is_summary_valid(&short));
+fn substantive_rejects_whitespace_narrative_fields() {
+	let mut s = empty_summary();
+	s.current_task = "   ".to_string();
+	s.progress = "\n\t".to_string();
+	s.session_context = "  ".to_string();
+	assert!(!is_summary_substantive(&s));
 }
 
 #[test]
-fn is_summary_valid_accepts_at_min_length() {
-	let exact = "a".repeat(MIN_SUMMARY_LEN);
-	assert!(is_summary_valid(&exact));
+fn substantive_accepts_progress_only() {
+	assert!(is_summary_substantive(&summary_with_progress()));
 }
 
 #[test]
-fn is_summary_valid_accepts_real_summary() {
-	assert!(is_summary_valid(
-		"User asked about config loading, AI explained the merge order."
-	));
+fn substantive_accepts_single_finding() {
+	let mut s = empty_summary();
+	s.analysis_findings = vec!["root cause: cache marker placement".to_string()];
+	assert!(is_summary_substantive(&s));
 }
 
 #[test]
-fn is_summary_valid_counts_after_trim() {
-	// Padded with whitespace but inner content is below the floor.
-	let padded = format!("   {}   ", "a".repeat(MIN_SUMMARY_LEN - 1));
-	assert!(!is_summary_valid(&padded));
+fn substantive_accepts_recent_exchange_only() {
+	let mut s = empty_summary();
+	s.recent_exchanges = vec!["user asked X; assistant answered Y".to_string()];
+	assert!(is_summary_substantive(&s));
 }
 
 #[test]
-fn is_summary_valid_counts_chars_not_bytes() {
-	// 20 multibyte chars — bytes would be 60 (each emoji is 4 bytes), but
-	// we count characters so this is exactly at the boundary.
-	let unicode = "🎯".repeat(MIN_SUMMARY_LEN);
-	assert!(is_summary_valid(&unicode));
+fn render_omits_empty_sections() {
+	let mut s = empty_summary();
+	s.session_context = "investigating compression quality".to_string();
+	s.current_task = "rewriting prompt to use JSON schema".to_string();
+	let rendered = render_summary(&s);
+	assert!(rendered.contains("<session_context>"));
+	assert!(rendered.contains("<current_task>"));
+	// Sections with no signal must NOT appear as empty tags.
+	assert!(!rendered.contains("<progress>"));
+	assert!(!rendered.contains("<analysis_findings>"));
+	assert!(!rendered.contains("<key_entities>"));
+	assert!(!rendered.contains("<next_steps>"));
 }
 
 #[test]
-fn knowledge_only_response_strips_to_empty() {
-	// Regression: AI response that is ONLY knowledge tags must strip to a
-	// summary that fails validation — guarding against the force-path bug
-	// where such input would have produced a header-only "summary".
-	let content = "<knowledge>some critical fact</knowledge>";
-	let stripped = strip_knowledge_tags(content);
+fn render_includes_original_request_when_set() {
+	let mut s = summary_with_progress();
+	s.original_request = "Build a session-based AI dev assistant.".to_string();
+	let rendered = render_summary(&s);
 	assert!(
-		!is_summary_valid(&stripped),
-		"knowledge-only content must not produce a valid summary (got: {:?})",
-		stripped
+		rendered.contains(
+			"<original_request>Build a session-based AI dev assistant.</original_request>"
+		),
+		"original_request must be rendered verbatim: {}",
+		rendered
 	);
 }
 
 #[test]
-fn yes_with_knowledge_only_strips_to_empty() {
-	// Regression: `"YES\n<knowledge>...</knowledge>"` after split + strip
-	// yields an empty summary — must fail validation.
-	let after_yes_line = "<knowledge>fact A</knowledge>\n<knowledge>fact B</knowledge>";
-	let stripped = strip_knowledge_tags(after_yes_line);
-	assert!(
-		!is_summary_valid(&stripped),
-		"YES + knowledge-only must not produce a valid summary (got: {:?})",
-		stripped
-	);
+fn render_includes_errors_and_corrections() {
+	let mut s = summary_with_progress();
+	s.errors_and_corrections = vec![
+		"user said: don't add fallbacks".to_string(),
+		"compile error: borrow of moved value at ai.rs:45".to_string(),
+	];
+	let rendered = render_summary(&s);
+	assert!(rendered.contains("<errors_and_corrections>"));
+	assert!(rendered.contains("<entry>user said: don't add fallbacks</entry>"));
+	assert!(rendered.contains("<entry>compile error: borrow of moved value at ai.rs:45</entry>"));
+	assert!(rendered.contains("</errors_and_corrections>"));
 }
 
 #[test]
-fn empty_summary_in_format_produces_header_only_block() {
-	// PROOF that the bug is real: without the validator, this is exactly
-	// what `apply_compression` would write back into the conversation
-	// after draining 50+ messages. The test exists as a permanent record
-	// of why `is_summary_valid` must gate every code path that calls
-	// `format_compressed_entry_with_context`.
+fn render_key_entities_nested_tags() {
+	let mut s = summary_with_progress();
+	s.key_entities = KeyEntities {
+		files: vec!["src/foo.rs:10:20".to_string()],
+		names: vec!["compress_summary".to_string()],
+		decisions: vec!["use JSON schema for compression".to_string()],
+	};
+	let rendered = render_summary(&s);
+	assert!(rendered.contains("<key_entities>"));
+	assert!(rendered.contains("<files>"));
+	assert!(rendered.contains("<file>src/foo.rs:10:20</file>"));
+	assert!(rendered.contains("<name>compress_summary</name>"));
+	assert!(rendered.contains("<decision>use JSON schema for compression</decision>"));
+	assert!(rendered.contains("</key_entities>"));
+}
+
+#[test]
+fn format_compressed_entry_with_empty_summary_still_renders_wrapper() {
+	// Belt-and-braces: even if `is_summary_substantive` failed to gate, an
+	// empty render still produces a clearly-tagged wrapper (used during the
+	// pathological-bootstrap branch in apply_compression). Pinned here so
+	// any future refactor that changes the wrapper tag breaks
+	// strip_file_context_from_summary's matching as well.
 	let formatted = format_compressed_entry_with_context("", "", "test-id".to_string());
-	assert!(
-		formatted.contains("## Conversation Summary [COMPRESSED: test-id]"),
-		"header always present"
-	);
-	// Body after the header is just the section join (empty) → trailing whitespace only.
-	let body = formatted
-		.trim_start_matches("## Conversation Summary [COMPRESSED: test-id]")
-		.trim();
-	assert!(
-		body.is_empty(),
-		"empty summary produces header-only block (proves catastrophic loss path); got body: {:?}",
-		body
-	);
+	assert!(formatted.contains("<conversation_summary id=\"test-id\">"));
+	assert!(formatted.contains("</conversation_summary>"));
 }

--- a/src/session/chat/conversation_compression/tests.rs
+++ b/src/session/chat/conversation_compression/tests.rs
@@ -74,7 +74,7 @@ fn preserves_active_skill_in_drain_range() {
 	// first_prompt_idx = 3 (first real user prompt).
 	// find_compression_range moves anchor to idx-1 = 2 (instructions).
 	// Drain range: 3..=9.
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(3), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 2, "anchor on instructions");
 	assert_eq!(end_idx, 9);
 
@@ -236,7 +236,7 @@ fn extends_range_to_include_tool_results() {
 	messages.push(msg("user")); // 8
 	messages.push(msg("assistant")); // 9
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Compress-all: end_idx = last message
 	assert_eq!(start_idx, 1);
@@ -266,7 +266,7 @@ fn extends_when_ending_on_assistant_with_tools() {
 	messages.push(msg("user")); // 8
 	messages.push(msg("assistant")); // 9
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Compress-all: end_idx = last message
 	assert_eq!(start_idx, 1);
@@ -308,7 +308,7 @@ fn handles_multiple_assistants_with_tools() {
 	messages.push(msg("assistant")); // 9
 	messages.push(msg("user")); // 10
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Compress-all: end_idx = last message, no preserved zone
 	assert_eq!(start_idx, 1);
@@ -339,35 +339,29 @@ fn start_boundary_must_not_orphan_initial_tool_sequence() {
 	messages.push(msg("assistant")); // 6
 	messages.push(msg("user")); // 7
 	messages.push(msg("assistant")); // 8
-								  // Test with first_prompt_idx set to index 3 (first real user message)
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(3), false).unwrap();
 
-	// Safety requirement: compression starts AFTER first_prompt_idx (INCLUSIVE boundary)
-	// first_prompt_idx=3 means index 3 is PROTECTED, compression starts at 4
-	assert_eq!(
-		start_idx, 3,
-		"start_idx must equal first_prompt_idx (INCLUSIVE boundary)"
-	);
+	// First user message lives at idx 3 — anchor lands there. The leading
+	// assistant+tool sequence at indices 1-2 stays in the surviving prefix
+	// (kept across compression cycles).
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
+
+	assert_eq!(start_idx, 3, "anchor = first user message at idx 3");
 	assert!(
 		end_idx >= 4,
-		"range should start compressing only after first_prompt_idx"
+		"compression range must include messages after anchor"
 	);
 }
 
 #[test]
-fn anchor_with_tool_calls_must_advance_past_tool_results() {
-	// Reproduces the exact bug from the session log:
-	// - Message 1: assistant with 2 tool_calls (view_signatures + view)
-	// - Message 2: tool result for view_signatures
-	// - Message 3: tool result for view (this one got orphaned)
-	// - Compression summary inserted at message 3
-	// - remove_messages_in_range drained start_idx+1..=end_idx
-	// - Result: assistant at index 1 still has tool_calls but tool results are gone
-	// - API error: "tool_use ids were found without tool_result blocks"
+fn leading_tool_exchange_stays_in_prefix_no_orphans() {
+	// When the session begins with an assistant+tool_calls turn BEFORE any
+	// user message (e.g. resumed/reconstructed history), anchor lands on the
+	// first user message that follows. The leading assistant + its tool
+	// results stay together in the surviving prefix — neither side of the
+	// pair can fall into the drain range, so no orphan tool_use blocks.
 	let mut messages = Vec::new();
 	messages.push(msg("system")); // 0
 
-	// Assistant with 2 tool calls (like the real session)
 	let mut assistant = msg("assistant"); // 1
 	assistant.tool_calls = Some(json!([
 		{"id": "call_A", "type": "function", "function": {"name": "view_signatures", "arguments": "{}"}},
@@ -385,56 +379,37 @@ fn anchor_with_tool_calls_must_advance_past_tool_results() {
 	tool_b.name = Some("view".to_string());
 	messages.push(tool_b);
 
-	// Enough conversation to trigger compression (need >4 user+assistant)
 	messages.push(msg("assistant")); // 4 (response after tools)
-	messages.push(msg("user")); // 5
+	messages.push(msg("user")); // 5 - first user message (anchor)
 	messages.push(msg("assistant")); // 6
 	messages.push(msg("user")); // 7
 	messages.push(msg("assistant")); // 8
 	messages.push(msg("user")); // 9
 	messages.push(msg("assistant")); // 10
 
-	// first_prompt_idx=None means start_idx defaults to system_idx+1 = 1
-	// Index 1 is the assistant with tool_calls.
-	// Without the fix: start_idx=1, drain removes indices 2..=end_idx,
-	// orphaning tool_calls at index 1.
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	// With the fix: start_idx must advance past the tool results (indices 2, 3)
-	// to index 4 (the next assistant message after tools).
-	assert!(
-			start_idx >= 4,
-			"start_idx must advance past tool results to avoid orphaning tool_calls. Got start_idx={start_idx}"
-		);
-	assert!(
-		end_idx > start_idx,
-		"end_idx must be after start_idx for a valid range. Got start={start_idx}, end={end_idx}"
-	);
+	assert_eq!(start_idx, 5, "anchor = first user message at idx 5");
+	assert!(end_idx > start_idx);
 
-	// Verify the drain range (start_idx+1..=end_idx) doesn't include any tool messages
-	// that belong to the assistant at index 1
-	for msg in messages.iter().take(end_idx + 1).skip(start_idx + 1) {
-		if msg.role == "tool" {
-			// Any tool message in the drain range must NOT belong to the anchor's tool_calls
-			if let Some(ref tc_id) = msg.tool_call_id {
-				assert!(
-						tc_id != "call_A" && tc_id != "call_B",
-						"Drain range must not include tool results for anchor's tool_calls. Found {tc_id}"
-					);
-			}
-		}
+	// Drain range [6..=10] contains no tool messages (all asst/user), so no
+	// orphan risk. Tools at 2,3 stay paired with their assistant at 1 in the
+	// preserved prefix.
+	for m in messages.iter().take(end_idx + 1).skip(start_idx + 1) {
+		assert_ne!(m.role, "tool", "drain range must not contain tool messages");
 	}
 }
 
 #[test]
-fn anchor_with_tool_calls_and_first_prompt_idx() {
-	// When first_prompt_idx points to an assistant with tool_calls,
-	// start_idx must still advance past its tool results.
+fn anchor_when_first_user_precedes_tool_calls_assistant() {
+	// First user message sits before an assistant-with-tool_calls turn.
+	// Anchor lands on the user message (idx 1); the entire tool exchange
+	// (assistant + its tool result) is inside the drain range. Anchor is
+	// user-role so no orphan tool_use blocks can form.
 	let mut messages = Vec::new();
 	messages.push(msg("system")); // 0
-	messages.push(msg("user")); // 1
+	messages.push(msg("user")); // 1 - first user (anchor)
 
-	// Assistant with tool calls at index 2
 	let mut assistant = msg("assistant"); // 2
 	assistant.tool_calls = Some(json!([
 		{"id": "call_X", "type": "function", "function": {"name": "shell", "arguments": "{}"}}
@@ -446,7 +421,6 @@ fn anchor_with_tool_calls_and_first_prompt_idx() {
 	tool_x.name = Some("shell".to_string());
 	messages.push(tool_x);
 
-	// More conversation
 	messages.push(msg("assistant")); // 4
 	messages.push(msg("user")); // 5
 	messages.push(msg("assistant")); // 6
@@ -455,18 +429,10 @@ fn anchor_with_tool_calls_and_first_prompt_idx() {
 	messages.push(msg("user")); // 9
 	messages.push(msg("assistant")); // 10
 
-	// first_prompt_idx=Some(2) points to the assistant with tool_calls.
-	// With the anchor-move-back fix, start_idx moves to idx-1=1 (user).
-	// The assistant with tool_calls and its tool result are both in the drain range.
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(2), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(
-		start_idx, 1,
-		"anchor moves back to user at idx 1 — tool_calls asst at 2 is in drain range"
-	);
+	assert_eq!(start_idx, 1, "anchor = first user message at idx 1");
 	assert!(end_idx > start_idx, "must have valid range");
-	// Both the assistant with tool_calls (idx 2) and its tool result (idx 3) are
-	// in drain range [2..=end_idx] — no orphaned tool_use blocks.
 	assert!(end_idx >= 3, "drain must include tool result at idx 3");
 }
 
@@ -476,10 +442,10 @@ fn anchor_with_tool_calls_and_first_prompt_idx() {
 // ============================================================================
 
 #[test]
-fn bootstrap_preserved_when_first_prompt_idx_is_none_no_instructions() {
-	// Simulates resumed session without instructions file:
-	// [0] system, [1] assistant(welcome), [2+] conversation
-	// first_prompt_idx=None (resumed session)
+fn welcome_preserved_when_no_instructions_file() {
+	// Without an <instructions> message, anchor falls back to the first user
+	// message. System and welcome live BEFORE the anchor and are never in the
+	// drain range, regardless of session origin (fresh or resumed).
 	let messages = vec![
 		msg("system"),    // 0
 		msg("assistant"), // 1 - welcome message
@@ -493,32 +459,28 @@ fn bootstrap_preserved_when_first_prompt_idx_is_none_no_instructions() {
 		msg("assistant"), // 9
 	];
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	// System[0] and welcome[1] must be protected
-	assert!(
-		start_idx >= 2,
-		"start_idx must be >= 2 to protect system and welcome. Got {start_idx}"
-	);
+	assert_eq!(start_idx, 2, "anchor = first user message at idx 2");
 	assert!(end_idx > start_idx, "must have valid range");
-
-	// Drain range is start_idx+1..=end_idx — verify system and welcome are outside
 	assert!(
 		start_idx + 1 > 1,
-		"drain range must not include welcome message at index 1"
+		"drain range must not include welcome message at idx 1"
 	);
 }
 
 #[test]
-fn bootstrap_preserved_when_first_prompt_idx_is_none_with_instructions() {
-	// Simulates resumed session WITH instructions file:
-	// [0] system, [1] assistant(welcome), [2] user(instructions), [3+] conversation
-	// first_prompt_idx=None (resumed session)
+fn anchor_is_instructions_message_when_present() {
+	// When a user-role message wraps content in <instructions>…</instructions>,
+	// that message becomes the anchor — its content is never compressed away.
+	// Drain starts immediately after it.
+	let mut instructions = msg("user");
+	instructions.content = "<instructions>\nproject guidelines\n</instructions>".into();
 	let messages = vec![
 		msg("system"),    // 0
-		msg("assistant"), // 1 - welcome message
-		msg("user"),      // 2 - instructions file
-		msg("assistant"), // 3 - AI response to instructions
+		msg("assistant"), // 1 - welcome
+		instructions,     // 2 - instructions file (DETECTED via tag)
+		msg("assistant"), // 3
 		msg("user"),      // 4 - first real user prompt
 		msg("assistant"), // 5
 		msg("user"),      // 6
@@ -527,14 +489,10 @@ fn bootstrap_preserved_when_first_prompt_idx_is_none_with_instructions() {
 		msg("assistant"), // 9
 	];
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	// System[0], welcome[1], and instructions[2] must be protected
-	assert!(
-		start_idx >= 3,
-		"start_idx must be >= 3 to protect system, welcome, and instructions. Got {start_idx}"
-	);
-	assert!(end_idx > start_idx, "must have valid range");
+	assert_eq!(start_idx, 2, "anchor must be the <instructions> message");
+	assert_eq!(end_idx, 9, "compress-all: end_idx = last message");
 }
 
 #[test]
@@ -549,56 +507,54 @@ fn bootstrap_preserved_system_message_never_in_range() {
 	}
 
 	// Test with None
-	let (start_none, _end_none) = find_compression_range(&messages, None, false).unwrap();
+	let (start_none, _end_none) = find_compression_range(&messages, false).unwrap();
 	assert!(start_none > 0, "system message at 0 must not be start_idx");
 	// Drain is start_idx+1..=end_idx, so system at 0 is safe if start_idx > 0
 
 	// Test with Some(1)
-	let (start_some, end_some) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_some, end_some) = find_compression_range(&messages, false).unwrap();
 	assert!(start_some >= 1, "start_idx must be >= 1");
 	assert!(end_some > start_some);
 }
 
 #[test]
-fn bootstrap_with_tool_calls_in_welcome_response() {
-	// Edge case: welcome is followed by instructions, then AI responds with tool_calls
-	// [0] system, [1] assistant(welcome), [2] user(instructions),
-	// [3] assistant(tool_calls), [4] tool, [5+] conversation
-	let mut messages = Vec::new();
-	messages.push(msg("system")); // 0
-	messages.push(msg("assistant")); // 1 - welcome
-	messages.push(msg("user")); // 2 - instructions
+fn anchor_with_instructions_then_assistant_tool_calls() {
+	// Instructions message immediately followed by an assistant turn with
+	// tool_calls — anchor stays on the instructions message, everything
+	// after (including the tool_calls assistant and its tool results) is
+	// in the drain range. No tool-skip required: anchor is user-role, so
+	// no orphan tool_use blocks can form.
+	let mut instructions = msg("user");
+	instructions.content = "<instructions>\nrules\n</instructions>".into();
 
-	let mut assistant_tc = msg("assistant"); // 3
+	let mut assistant_tc = msg("assistant");
 	assistant_tc.tool_calls = Some(serde_json::json!([
 		{"id": "call_1", "type": "function", "function": {"name": "view", "arguments": "{}"}}
 	]));
-	messages.push(assistant_tc);
-
-	let mut tool = msg("tool"); // 4
+	let mut tool = msg("tool");
 	tool.tool_call_id = Some("call_1".to_string());
-	messages.push(tool);
 
-	messages.push(msg("assistant")); // 5
-	messages.push(msg("user")); // 6
-	messages.push(msg("assistant")); // 7
-	messages.push(msg("user")); // 8
-	messages.push(msg("assistant")); // 9
-	messages.push(msg("user")); // 10
-	messages.push(msg("assistant")); // 11
+	let messages = vec![
+		msg("system"),    // 0
+		msg("assistant"), // 1 welcome
+		instructions,     // 2 instructions
+		assistant_tc,     // 3 asst with tool_calls
+		tool,             // 4 tool result
+		msg("assistant"), // 5
+		msg("user"),      // 6
+		msg("assistant"), // 7
+		msg("user"),      // 8
+		msg("assistant"), // 9
+		msg("user"),      // 10
+		msg("assistant"), // 11
+	];
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	// Must protect: system[0], welcome[1], instructions[2]
-	// start_idx should be >= 3, and if 3 has tool_calls, advance past tool results
-	assert!(
-		start_idx >= 5,
-		"start_idx must advance past bootstrap AND tool results. Got {start_idx}"
-	);
-	assert!(
-		end_idx > start_idx,
-		"must have valid range. Got start={start_idx}, end={end_idx}"
-	);
+	assert_eq!(start_idx, 2, "anchor on <instructions> message");
+	assert_eq!(end_idx, 11, "compress-all: end_idx = last message");
+	// Drain range [3..=11] includes the assistant+tool_calls AND its tool result —
+	// both go together, no orphaning possible.
 }
 
 #[test]
@@ -661,7 +617,7 @@ fn calculate_range_tokens_must_match_removal_range() {
 	messages.push(msg("user")); // 7
 	messages.push(msg("assistant")); // 8
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Verify the range is valid
 	assert!(start_idx < end_idx, "Range must be valid");
@@ -733,7 +689,7 @@ fn bug_proof_token_mismatch_causes_zero_savings() {
 	messages.push(msg("user")); // 7
 	messages.push(msg("assistant")); // 8
 
-	let (start_idx, end_idx) = find_compression_range(&messages, None, false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 1); // Large message
 	assert_eq!(end_idx, 8); // compress-all: last message
 
@@ -1215,42 +1171,33 @@ fn test_estimate_incremental_rate_saturating_sub_prevents_underflow() {
 }
 
 // ============================================================================
-// SEQUENTIAL COMPRESSION TESTS: Verify first_prompt_idx stays at original
-// user message and old compressed summaries get re-compressed (not orphaned)
+// SEQUENTIAL COMPRESSION TESTS: Verify the anchor (re-derived from messages
+// every call) stays at the original first user message across cycles, and
+// old compressed summaries get re-compressed (not orphaned).
 // ============================================================================
 
 #[test]
-fn first_prompt_idx_never_changes_after_compression() {
-	// first_prompt_idx must always point to the original first user message.
-	// It is set once in main_loop.rs and never updated by compression.
-	// This ensures the anchor is always the original user prompt.
+fn anchor_stable_across_repeated_compressions() {
+	// Anchor is re-derived deterministically from messages every call.
+	// Without instructions, anchor = first user message and stays put
+	// across cycles because that user message remains at the same index.
 
 	let mut messages = Vec::new();
 	messages.push(msg("system")); // 0
-	messages.push(msg("user")); // 1 - first_prompt_idx
+	messages.push(msg("user")); // 1 - first user
 	for i in 0..8 {
 		messages.push(msg(if i % 2 == 0 { "assistant" } else { "user" }));
 	} // 2-9
 
-	let first_prompt_idx = Some(1usize);
-
 	// First compression
-	let (start1, end1) = find_compression_range(&messages, first_prompt_idx, false).unwrap();
-	assert_eq!(start1, 1, "start_idx must be first_prompt_idx");
+	let (start1, end1) = find_compression_range(&messages, false).unwrap();
+	assert_eq!(start1, 1, "anchor = first user message");
 	assert!(end1 >= 4);
-
-	// After compression, first_prompt_idx stays Some(1) — NOT updated.
-	// The compressed summary is inserted at index 2, but the anchor stays at 1.
-	assert_eq!(
-		first_prompt_idx,
-		Some(1),
-		"first_prompt_idx must not change"
-	);
 
 	// Simulate post-compression state: anchor at 1, summary at 2, preserved tail
 	let mut after = Vec::new();
 	after.push(msg("system")); // 0
-	after.push(msg("user")); // 1 - anchor (kept)
+	after.push(msg("user")); // 1 - first user (kept)
 	let mut comp = msg("assistant");
 	comp.name = Some("plan_compression".to_string());
 	after.push(comp); // 2 - compressed summary
@@ -1258,12 +1205,9 @@ fn first_prompt_idx_never_changes_after_compression() {
 		after.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
 	} // 3-10
 
-	// Second compression — first_prompt_idx is STILL Some(1)
-	let (start2, end2) = find_compression_range(&after, first_prompt_idx, false).unwrap();
-	assert_eq!(
-		start2, 1,
-		"second compression also starts at original anchor"
-	);
+	// Second compression — anchor is STILL idx 1 (re-derived, not cached)
+	let (start2, end2) = find_compression_range(&after, false).unwrap();
+	assert_eq!(start2, 1, "anchor re-derives to same index");
 	assert!(end2 >= 4);
 }
 
@@ -1285,7 +1229,7 @@ fn old_compressed_summary_is_recompressed_on_next_cycle() {
 		messages.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
 	} // 3-10
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 1, "start at permanent anchor");
 
 	// Drain range is start_idx+1..=end_idx = 2..=end_idx
@@ -1307,24 +1251,14 @@ fn old_compressed_summary_is_recompressed_on_next_cycle() {
 }
 
 #[test]
-fn bootstrap_messages_before_start_idx_dont_inflate_compress_count() {
-	// Reproduces the real-world bug: bootstrap messages (system, welcome, instructions)
-	// exist before first_prompt_idx. The old code collected ALL conversation messages
-	// including bootstrap ones, inflating compress_count and leaving end_idx too low.
-	//
-	// Layout from the log:
-	// 0: system
-	// 1: assistant (welcome)
-	// 2: user (instructions)
-	// 3: user (first real prompt) ← first_prompt_idx
-	// 4: assistant (compressed summary from prior cycle)
-	// 5: assistant (tool_calls)
-	// 6: tool
-	// 7: assistant (tool_calls)
-	// 8: tool
-	// 9: assistant (tool_calls)
-	// 10: tool
-	// 11: assistant (final response)
+fn bootstrap_messages_before_anchor_preserved() {
+	// Bootstrap messages (system, welcome, instructions) sit before the anchor
+	// and are NEVER touched by compression. Drain covers [anchor+1..=end] and
+	// keeps the entire prefix intact regardless of tool_calls / tool result
+	// content inside the drain range.
+	let mut instructions = msg("user");
+	instructions.content = "<instructions>\nrules\n</instructions>".into();
+
 	let mut comp = msg("assistant");
 	comp.name = Some("plan_compression".to_string());
 	let mut a5 = msg("assistant");
@@ -1335,47 +1269,27 @@ fn bootstrap_messages_before_start_idx_dont_inflate_compress_count() {
 	a7.tool_calls = Some(json!([{"id": "c2", "type": "function", "function": {"name": "shell"}}]));
 	let mut t8 = msg("tool");
 	t8.tool_call_id = Some("c2".to_string());
-	let mut a9 = msg("assistant");
-	a9.tool_calls = Some(json!([{"id": "c3", "type": "function", "function": {"name": "plan"}}]));
-	let mut t10 = msg("tool");
-	t10.tool_call_id = Some("c3".to_string());
 
 	let messages = vec![
 		msg("system"),    // 0
 		msg("assistant"), // 1 - welcome
-		msg("user"),      // 2 - instructions
-		msg("user"),      // 3 - first_prompt_idx
+		instructions,     // 2 - instructions (anchor)
+		msg("user"),      // 3 - first real prompt
 		comp,             // 4 - old compressed summary
 		a5,               // 5 - tool_calls
 		t6,               // 6 - tool result
 		a7,               // 7 - tool_calls
 		t8,               // 8 - tool result
-		a9,               // 9 - tool_calls
-		t10,              // 10 - tool result
-		msg("assistant"), // 11 - final response
+		msg("assistant"), // 9 - final response
 	];
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(3), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(start_idx, 3, "start at first_prompt_idx");
-	// Conversation indices at/after start_idx=3: [3, 4, 5, 7, 9, 11] (6 items)
-	// Keep last 4: [5, 7, 9, 11]
-	// compress_count = 2, first preserved = index 5
-	// end_idx = 5 - 1 = 4
-	// Drain range: [4..=4] — removes old summary
-	// BUT the old bug would have: conversation_indices = [1, 2, 3, 4, 5, 7, 9, 11] (8 items)
-	// compress_count = 4, first preserved = conversation_indices[4] = 5
-	// end_idx = 5 - 1 = 4 — same result by coincidence in THIS case.
-	// The real difference shows when preserve_count adjustment kicks in.
-	assert!(
-		end_idx >= 4,
-		"end_idx must cover at least the old summary at index 4, got {end_idx}"
-	);
-	// The drain range must actually remove messages
-	assert!(
-		end_idx > start_idx,
-		"drain range must be non-empty: start={start_idx}, end={end_idx}"
-	);
+	assert_eq!(start_idx, 2, "anchor on <instructions> message");
+	assert_eq!(end_idx, 9, "compress-all: end_idx = last message");
+
+	// Bootstrap [0..=2] survives untouched; drain is [3..=9].
+	assert!(start_idx + 1 > 1, "welcome at idx 1 stays outside drain");
 }
 
 #[test]
@@ -1392,7 +1306,7 @@ fn bootstrap_with_many_messages_compresses_all() {
 		messages.push(msg(if i % 2 == 0 { "assistant" } else { "user" }));
 	} // 4-13
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(3), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 2, "anchor must be instructions file at idx 2");
 	assert_eq!(end_idx, 13, "compress-all: end_idx = last message");
 }
@@ -1421,7 +1335,7 @@ fn triple_compression_always_one_summary() {
 	} // 3-10
 
 	// 3rd compression — still starts at anchor (1)
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 1);
 
 	// Old summary at 2 is in drain range
@@ -1448,7 +1362,7 @@ fn anchor_message_never_included_in_drain_range() {
 		msg("assistant"), // 8
 	];
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// The drain range is start_idx+1..=end_idx
 	// The anchor at start_idx is NOT in this range
@@ -1491,7 +1405,7 @@ fn compression_preserves_message_count_consistency() {
 	}
 
 	let before_count = messages.len();
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Calculate expected removal count
 	let messages_to_remove = end_idx - start_idx; // drain removes start_idx+1..=end_idx
@@ -1532,7 +1446,7 @@ fn messages_to_compress_excludes_anchor_message() {
 	messages.push(msg("user")); // 7
 	messages.push(msg("assistant")); // 8
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 1);
 
 	let correct = &messages[start_idx + 1..=end_idx];
@@ -1575,7 +1489,7 @@ fn calculate_range_tokens_matches_actual_removal() {
 		messages.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
 	} // 6-9
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	let mut tokens_removed = 0u64;
 	for msg in messages.iter().take(end_idx + 1).skip(start_idx + 1) {
@@ -1634,15 +1548,14 @@ fn test_file_context_stripped_when_no_sentinel() {
 fn test_multiple_compression_cycles_anchor_never_moves() {
 	// Simulate 3 compression cycles on a growing conversation.
 	// After each cycle the old summary is at start_idx+1 and gets folded into the next.
-	// first_prompt_idx must always equal 1 (the original first user message).
+	// Anchor must always equal 1 (the original first user message), re-derived
+	// fresh every call from message structure — no cached state.
 	//
 	// Layout after each cycle:
 	//   [0] system
-	//   [1] user (anchor = first_prompt_idx)
+	//   [1] user (anchor — first user message)
 	//   [2] assistant (compressed summary, replaces old range)
 	//   [3..] new messages
-
-	let first_prompt_idx = Some(1usize);
 
 	// ── Cycle 1: 12 messages ──────────────────────────────────────────────
 	let mut messages: Vec<Message> = Vec::new();
@@ -1652,7 +1565,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 		messages.push(msg(if i % 2 == 0 { "assistant" } else { "user" }));
 	} // 2-11
 
-	let (s1, e1) = find_compression_range(&messages, first_prompt_idx, false).unwrap();
+	let (s1, e1) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(s1, 1, "Cycle 1: start must be anchor (1)");
 	assert!(e1 > s1, "Cycle 1: end must be after anchor");
 	assert!(
@@ -1672,7 +1585,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 		messages.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
 	}
 
-	let (s2, e2) = find_compression_range(&messages, first_prompt_idx, false).unwrap();
+	let (s2, e2) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(s2, 1, "Cycle 2: start must still be anchor (1)");
 	assert!(e2 > s2);
 
@@ -1687,7 +1600,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 		messages.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
 	}
 
-	let (s3, e3) = find_compression_range(&messages, first_prompt_idx, false).unwrap();
+	let (s3, e3) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(s3, 1, "Cycle 3: start must still be anchor (1)");
 	assert!(e3 > s3);
 
@@ -1708,7 +1621,7 @@ fn compress_all_includes_last_message() {
 	} // 2-21
 	messages.push(msg("user")); // 22
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 1);
 	assert_eq!(end_idx, 22, "compress-all: end_idx must be last message");
 }
@@ -1735,7 +1648,7 @@ fn compress_all_with_tool_loop_after_user_prompt() {
 		msg("assistant"), // 14 response
 	];
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(3), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 2, "anchor at instructions");
 	assert_eq!(end_idx, 14, "compress-all: end_idx = last message");
 }
@@ -1777,7 +1690,7 @@ fn compress_all_with_tool_cycles() {
 		msg("assistant"), // 8
 	];
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(start_idx, 1);
 	assert_eq!(end_idx, 8, "compress-all: end_idx = last message");
 
@@ -1844,7 +1757,7 @@ fn tool_loop_only_one_user_message_still_compresses() {
 	// Final assistant response (no tool_calls)
 	messages.push(msg("assistant")); // 22
 
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Must return a valid compression range, NOT (0, 0)
 	assert!(
@@ -1852,8 +1765,8 @@ fn tool_loop_only_one_user_message_still_compresses() {
 		"Tool-loop session must produce valid compression range, got ({start_idx}, {end_idx})"
 	);
 
-	// start_idx = first_prompt_idx = 1 (tool-loop: single user, no instructions)
-	assert_eq!(start_idx, 1, "start_idx must be first_prompt_idx = 1");
+	// Tool-loop: single user message, no instructions → anchor = first user (idx 1).
+	assert_eq!(start_idx, 1, "anchor = first user message at idx 1");
 
 	// compress-all: end_idx = last message
 	assert_eq!(
@@ -1868,7 +1781,6 @@ fn test_triple_compression_only_one_summary_in_drain() {
 	// After 3 compression cycles, the drain range must always contain exactly
 	// one prior compressed summary (the previous cycle's output), never zero or two.
 	// This verifies that old summaries are folded into new ones, not accumulated.
-	let first_prompt_idx = Some(1usize);
 
 	let mut messages: Vec<Message> = Vec::new();
 	messages.push(msg("system")); // 0
@@ -1883,7 +1795,7 @@ fn test_triple_compression_only_one_summary_in_drain() {
 			messages.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
 		}
 
-		let (s, e) = find_compression_range(&messages, first_prompt_idx, false).unwrap();
+		let (s, e) = find_compression_range(&messages, false).unwrap();
 
 		// Count compressed summaries in the drain range (s+1..=e)
 		let summaries_in_drain = messages[s + 1..=e]
@@ -1912,6 +1824,72 @@ fn test_triple_compression_only_one_summary_in_drain() {
 }
 
 #[test]
+fn regression_session_260521_no_stuck_first_turn_prefix() {
+	// Regression for the 260521-dk-1148-b53e bug: the OLD None-branch heuristic
+	// would advance past welcome + (any user followed by assistant) and then
+	// run a tool-skip over the resulting assistant's tool_calls — anchoring on
+	// the 2nd assistant turn and permanently stranding the first user message
+	// plus its 3-tool reply (5 extra prefix messages, forever).
+	//
+	// Exact layout from the broken session before the second /done:
+	//   0: system
+	//   1: assistant (welcome 🐙, no tool_calls)
+	//   2: user ("lets crawl...")              ← MUST be anchor
+	//   3: assistant ("Let me pull up...", has tool_calls)
+	//   4: tool (MEMORIES)
+	//   5: tool (MEMORIES)
+	//   6: tool (browser_get_current_tab)
+	//   7: assistant ("Got it, Don...")         ← OLD bug parked anchor here
+	//   8..N: rest of conversation
+	let mut a3 = msg("assistant");
+	a3.tool_calls = Some(json!([
+		{"id": "c1", "type": "function", "function": {"name": "remember"}},
+		{"id": "c2", "type": "function", "function": {"name": "remember"}},
+		{"id": "c3", "type": "function", "function": {"name": "browser_get_current_tab"}}
+	]));
+	let mut t4 = msg("tool");
+	t4.tool_call_id = Some("c1".to_string());
+	let mut t5 = msg("tool");
+	t5.tool_call_id = Some("c2".to_string());
+	let mut t6 = msg("tool");
+	t6.tool_call_id = Some("c3".to_string());
+
+	let mut messages = vec![
+		msg("system"),    // 0
+		msg("assistant"), // 1 welcome
+		msg("user"),      // 2 first user prompt
+		a3,               // 3 assistant + tool_calls
+		t4,               // 4 tool result
+		t5,               // 5 tool result
+		t6,               // 6 tool result
+		msg("assistant"), // 7 follow-up assistant
+	];
+	// Pad with enough conversation turns to satisfy min_conv.
+	for i in 0..6 {
+		messages.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
+	}
+
+	let (start_idx, end_idx) = find_compression_range(&messages, true).unwrap();
+
+	// New rule: anchor = first user message. NOT idx 7.
+	assert_eq!(
+		start_idx, 2,
+		"anchor MUST be the first user message, not parked past the bootstrap turn"
+	);
+	assert_eq!(end_idx, messages.len() - 1, "drain extends to last message");
+
+	// Stuck-prefix check: under the OLD bug, indices 3..=7 (assistant + 3 tools
+	// + follow-up assistant) were preserved across /done forever. The new
+	// behavior includes them in the drain range so each /done cleans them up.
+	for stuck_idx in 3..=7 {
+		assert!(
+			(start_idx + 1..=end_idx).contains(&stuck_idx),
+			"idx {stuck_idx} must be in drain range, not stuck in the prefix"
+		);
+	}
+}
+
+#[test]
 fn bug_proof_invalid_range_must_set_cooldown() {
 	// BUG SCENARIO: should_check_compression runs the full expensive path:
 	//   threshold exceeded → cooldown passed → cost analysis → find_compression_range
@@ -1936,7 +1914,7 @@ fn bug_proof_invalid_range_must_set_cooldown() {
 		msg("assistant"), // 4
 	];
 	// Only 4 conversation messages (user+assistant) — need >4 to compress
-	let (start_idx, end_idx) = find_compression_range(&messages, Some(1), false).unwrap();
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 	assert_eq!(
 		(start_idx, end_idx),
 		(0, 0),

--- a/src/session/chat/file_context.rs
+++ b/src/session/chat/file_context.rs
@@ -12,26 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// File context parsing and generation for compression summaries
+// File-context auto-expansion for compression summaries.
+//
+// AI emits file ranges via the schema's structured `file_context` array
+// (see `conversation_compression::schema::FileContextEntry`). The compression
+// path converts that array to tuples and calls `generate_file_context_content`
+// here to read each range from disk and render it as XML — same auto-expansion
+// behaviour as before, just without a text-parsing step in the middle.
+//
+// The legacy regex parser (`parse_file_contexts`) was removed once the schema
+// rollout eliminated its sole production caller. The underlying file-reference
+// parser still lives in `utils::file_parser` and is used by other code paths
+// (chat-message file context via `file_renderer`).
 
-use crate::utils::file_parser::parse_file_references;
 use crate::utils::file_renderer::render_files_as_xml;
-
-/// Parse file context requirements from AI summary response
-/// Expected format: filename:startline:endline (in code blocks or specific sections)
-pub fn parse_file_contexts(summary_content: &str) -> Vec<(String, usize, usize)> {
-	let file_refs = parse_file_references(summary_content);
-
-	// Convert HashMap to Vec for existing API
-	let mut contexts = Vec::new();
-	for (filepath, ranges) in file_refs {
-		for range in ranges {
-			contexts.push((filepath.clone(), range.start, range.end));
-		}
-	}
-
-	contexts
-}
 
 /// Generate file context content from parsed file requirements in XML format
 pub fn generate_file_context_content(file_contexts: &[(String, usize, usize)]) -> String {
@@ -181,139 +175,4 @@ pub fn merge_file_refs(refs: &[String]) -> Vec<String> {
 	}
 
 	merged
-}
-#[cfg(test)]
-mod tests {
-	use super::parse_file_contexts;
-
-	#[test]
-	fn test_parse_file_contexts_code_block() {
-		let summary = r#"
-## REQUIRED FILE CONTEXTS
-List ALL files needed as context to continue work. Use EXACT format:
-```
-src/main.rs:1:50
-src/lib.rs:100:150
-config/settings.toml:10:20
-```
-		"#;
-
-		let contexts = parse_file_contexts(summary);
-		assert_eq!(contexts.len(), 3);
-
-		// Since HashMap iteration order is not guaranteed, check that all expected items are present
-		assert!(contexts.contains(&("src/main.rs".to_string(), 1, 50)));
-		assert!(contexts.contains(&("src/lib.rs".to_string(), 100, 150)));
-		assert!(contexts.contains(&("config/settings.toml".to_string(), 10, 20)));
-	}
-
-	#[test]
-	fn test_parse_file_contexts_section() {
-		let summary = r#"
-## REQUIRED FILE CONTEXTS
-The following files need context:
-- src/session/mod.rs:200:300
-- tests/integration.rs:1:100
-
-## NEXT STEPS
-Continue with implementation...
-		"#;
-
-		let contexts = parse_file_contexts(summary);
-		assert_eq!(contexts.len(), 2);
-		assert!(contexts.contains(&("src/session/mod.rs".to_string(), 200, 300)));
-		assert!(contexts.contains(&("tests/integration.rs".to_string(), 1, 100)));
-	}
-
-	#[test]
-	fn test_parse_file_contexts_fallback() {
-		let summary = r#"
-We need to look at src/core.rs:50:100 and also check lib/utils.rs:1:25 for the implementation.
-		"#;
-
-		let contexts = parse_file_contexts(summary);
-		assert_eq!(contexts.len(), 2);
-		assert!(contexts.contains(&("src/core.rs".to_string(), 50, 100)));
-		assert!(contexts.contains(&("lib/utils.rs".to_string(), 1, 25)));
-	}
-
-	#[test]
-	fn test_parse_file_contexts_mandatory_format() {
-		let summary = r#"
-## REQUIRED FILE CONTEXTS
-CRITICAL: List ALL files needed as context using EXACT format below.
-
-**MANDATORY FORMAT - Use code block with exact pattern:**
-```
-src/session/chat/session_continuation.rs:100:200
-src/config/mod.rs:50:100
-tests/integration_test.rs:1:50
-```
-
-**PARSING REQUIREMENTS:**
-- Each line must be exactly: filepath:number:number
-		"#;
-
-		let contexts = parse_file_contexts(summary);
-		assert_eq!(contexts.len(), 3);
-		assert!(contexts.contains(&(
-			"src/session/chat/session_continuation.rs".to_string(),
-			100,
-			200
-		)));
-		assert!(contexts.contains(&("src/config/mod.rs".to_string(), 50, 100)));
-		assert!(contexts.contains(&("tests/integration_test.rs".to_string(), 1, 50)));
-	}
-
-	#[test]
-	fn test_parse_file_contexts_invalid_ranges() {
-		let summary = r#"
-```
-src/main.rs:0:50
-src/lib.rs:100:50
-src/test.rs:1:20000
-```
-		"#;
-
-		let contexts = parse_file_contexts(summary);
-		// Should filter out invalid ranges (start=0, end<start, end>10000)
-		assert_eq!(contexts.len(), 0);
-	}
-
-	#[test]
-	fn test_parse_file_contexts_with_context_tags() {
-		let summary = r#"
-## REQUIRED FILE CONTEXTS
-<context>
-src/session/chat/continuation.rs:100:200
-src/config/mod.rs:50:100
-tests/integration_test.rs:1:50
-</context>
-		"#;
-
-		let contexts = parse_file_contexts(summary);
-		assert_eq!(contexts.len(), 3);
-		assert!(contexts.contains(&("src/session/chat/continuation.rs".to_string(), 100, 200)));
-		assert!(contexts.contains(&("src/config/mod.rs".to_string(), 50, 100)));
-		assert!(contexts.contains(&("tests/integration_test.rs".to_string(), 1, 50)));
-	}
-
-	#[test]
-	fn test_parse_file_contexts_context_tags_priority() {
-		// Context tags should take priority over code blocks
-		let summary = r#"
-<context>
-src/main.rs:1:10
-</context>
-
-```
-src/lib.rs:20:30
-```
-		"#;
-
-		let contexts = parse_file_contexts(summary);
-		// Should only parse context tags, not code blocks
-		assert_eq!(contexts.len(), 1);
-		assert!(contexts.contains(&("src/main.rs".to_string(), 1, 10)));
-	}
 }

--- a/src/session/chat/session/commands/done.rs
+++ b/src/session/chat/session/commands/done.rs
@@ -17,7 +17,16 @@
 use super::super::core::ChatSession;
 use crate::config::Config;
 use anyhow::Result;
-use colored::Colorize;
+
+/// Outcome of a /done invocation. Callers (CLI, ACP, WebSocket) decide how to
+/// surface this — keep this layer transport-agnostic. Writing to stdout here
+/// corrupts the ACP JSON-RPC framing on stdio.
+#[derive(Debug, Clone)]
+pub enum DoneOutcome {
+	Compressed,
+	NothingToCompress,
+	Failed(String),
+}
 
 /// Force-compress conversation context, bypassing all automatic threshold/cooldown/cost guards.
 /// The user explicitly requested compression, so we always run it.
@@ -25,8 +34,8 @@ pub async fn handle_done(
 	session: &mut ChatSession,
 	config: &Config,
 	operation_cancelled: tokio::sync::watch::Receiver<bool>,
-) -> Result<(bool, bool)> {
-	let compressed =
+) -> Result<DoneOutcome> {
+	let outcome =
 		match crate::session::chat::conversation_compression::check_and_compress_conversation(
 			session,
 			config,
@@ -35,21 +44,12 @@ pub async fn handle_done(
 		)
 		.await
 		{
-			Ok(true) => {
-				println!("{}", "✅ Conversation compressed.".bright_green());
-				true
-			}
-			Ok(false) => {
-				println!("{}", "ℹ️  Nothing to compress.".bright_cyan());
-				false
-			}
-			Err(e) => {
-				println!("{}: {}", "❌ Compression failed".bright_red(), e);
-				false
-			}
+			Ok(true) => DoneOutcome::Compressed,
+			Ok(false) => DoneOutcome::NothingToCompress,
+			Err(e) => DoneOutcome::Failed(e.to_string()),
 		};
 
-	crate::log_debug!("/done: compression={}", compressed);
+	crate::log_debug!("/done: outcome={:?}", outcome);
 
 	// Fire-and-forget lesson extraction — do NOT block the prompt on the LLM round-trip.
 	// Same pattern as /exit and Ctrl+D in main_loop.rs.
@@ -62,6 +62,5 @@ pub async fn handle_done(
 		session.learning_injected = false;
 	}
 
-	// Returns (exit_flag, reset_first_message_processed)
-	Ok((false, false))
+	Ok(outcome)
 }

--- a/src/session/chat/session/commands/mod.rs
+++ b/src/session/chat/session/commands/mod.rs
@@ -19,7 +19,7 @@ mod context;
 mod copy;
 mod display;
 mod done;
-pub use done::handle_done;
+pub use done::{handle_done, DoneOutcome};
 mod analyze;
 mod effort;
 mod exit;

--- a/src/session/chat/session/commands/role.rs
+++ b/src/session/chat/session/commands/role.rs
@@ -124,7 +124,18 @@ pub async fn handle_role(
 	// Commit the merged config into the live session config BEFORE reinit so
 	// that downstream code (MCP init, system-prompt build, thread-local config)
 	// sees the new servers/roles/settings.
-	*config = resolved_config;
+	//
+	// We commit the *merged-for-new-role* view (filtered `mcp.servers`,
+	// patched `role_map`) — not the raw base config returned by the resolver.
+	// Reason: the chat loop's `current_config` (`main_loop.rs:395`) is
+	// initialized from `get_merged_config_for_role(...)` at startup, and the
+	// MCP routing ownership check in `src/mcp/mod.rs:769-783` inspects
+	// `config.mcp.servers` to decide whether a tool's server is owned by the
+	// current session. If we wrote the base config here, the new role's
+	// merged server list would silently regress to the full disk list,
+	// breaking that invariant and producing spurious "belongs to another
+	// session" errors after a role swap.
+	*config = resolved_config.get_merged_config_for_role(&target_role);
 
 	// Apply role-level settings (temperature, optional model override)
 	let (role_config, _, _, _, _) = config.get_role_config(&target_role);

--- a/src/session/chat/session/core.rs
+++ b/src/session/chat/session/core.rs
@@ -1095,8 +1095,13 @@ impl ChatSession {
 			);
 		}
 
-		// SIMPLIFIED: Use the same initialization logic as startup
-		// This handles both server initialization AND tool map update
+		// Mirror the session-startup boot sequence so /role swaps get the same
+		// tool surface a fresh session for the new role would get: static MCP
+		// init + env-driven skills + env-driven capabilities. Without the
+		// env-* steps, tools from OCTOMIND_SKILLS / OCTOMIND_CAPABILITIES
+		// (e.g. playwright's browser_*) wouldn't register for the new role,
+		// and the routing ownership check would reject calls with
+		// "belongs to another session".
 		if let Err(e) = crate::mcp::initialize_mcp_for_role(new_role, config).await {
 			println!(
 				"{}: {}",
@@ -1110,6 +1115,13 @@ impl ChatSession {
 				"✓ MCP servers and tools updated for new role".bright_green()
 			);
 		}
+
+		// Load env-driven skills and capabilities for the new role BEFORE the
+		// system prompt is rebuilt so the prompt reflects the resulting tool
+		// surface. Both calls are idempotent; the underlying registries guard
+		// against double activation.
+		crate::mcp::core::skill_auto::load_env_skills(self).await;
+		crate::mcp::core::capability::load_env_capabilities(&config_for_role, None).await;
 
 		// Create new system prompt for the role (AFTER MCP servers are initialized)
 		// This ensures the tools definition reflects the new role's available tools

--- a/src/session/chat/session/core.rs
+++ b/src/session/chat/session/core.rs
@@ -177,9 +177,6 @@ pub struct ChatSession {
 
 	// This cache ensures all systems (display, compression) use identical calculations
 	pub cached_tools: Option<Vec<crate::mcp::McpFunction>>, // Cached tool definitions for consistent token counting
-	// First user prompt index - compression NEVER goes below this (INCLUSIVE boundary)
-	// Set once when first user message is added, protects bootstrap/instructions forever
-	pub first_prompt_idx: Option<usize>,
 	/// Optional JSON schema for structured output (set via WebSocket/ACP protocol)
 	pub schema: Option<serde_json::Value>,
 	/// Critical knowledge entries extracted from compressions — persisted across cycles.
@@ -303,7 +300,6 @@ impl ChatSession {
 			compression_hint_count: 0,          // Initialize compression hint counter
 			last_compression_hint_shown: 0,     // Initialize last hint timestamp
 			cached_tools: None,                 // Initialize tool cache (populated on first use)
-			first_prompt_idx: None,             // Initialize first prompt index (set on first user message)
 			schema: None,                       // Schema set later via CLI override
 			critical_knowledge: Vec::new(),     // Populated from session log on resume
 			learning_injected: false,
@@ -501,7 +497,6 @@ impl ChatSession {
 						compression_hint_count,     // Restore from session.info
 						last_compression_hint_shown: last_compression_hint, // Restore from session.info
 						cached_tools: None,         // Initialize tool cache (populated on first use)
-						first_prompt_idx: None,     // Will be detected from existing messages
 						schema: None,               // Schema applied after init via CLI override
 						critical_knowledge: Vec::new(), // Will be restored from session log below
 						learning_injected: false,
@@ -567,39 +562,6 @@ impl ChatSession {
 						if msg.role == "assistant" {
 							chat_session.last_response = msg.content.clone();
 							break;
-						}
-					}
-
-					// Detect first_prompt_idx from existing messages.
-					// Bootstrap pattern: system[0] → assistant(welcome)[1] → optional user(instructions)[2]
-					// The first real user prompt is the first user message after bootstrap.
-					{
-						let msgs = &chat_session.session.messages;
-						let system_idx = msgs.iter().position(|m| m.role == "system").unwrap_or(0);
-						let mut idx = system_idx + 1;
-						// Skip welcome message (assistant immediately after system, WITHOUT tool_calls)
-						let has_welcome = idx < msgs.len()
-							&& msgs[idx].role == "assistant"
-							&& msgs[idx].tool_calls.is_none();
-						if has_welcome {
-							idx += 1;
-						}
-						// Skip instructions file ONLY if welcome was present.
-						// Bootstrap: system → assistant(welcome) → user(instructions).
-						// Without welcome, the first user message is a real prompt.
-						if has_welcome
-							&& idx < msgs.len() && msgs[idx].role == "user"
-							&& (idx + 1 >= msgs.len() || msgs[idx + 1].role == "assistant")
-						{
-							idx += 1;
-						}
-						// idx now points to the first real user prompt (or past end if none)
-						if idx < msgs.len() {
-							chat_session.first_prompt_idx = Some(idx);
-							crate::log_debug!(
-								"Session resume: Detected first_prompt_idx={} from message history",
-								idx
-							);
 						}
 					}
 
@@ -1260,7 +1222,6 @@ mod tests {
 			compression_hint_count: 0,
 			last_compression_hint_shown: 0,
 			cached_tools: None,
-			first_prompt_idx: None,
 			schema: None,
 			critical_knowledge: Vec::new(),
 			learning_injected: false,

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -339,6 +339,27 @@ pub async fn run_interactive_session(
 					println!("> {}", msg.content.bright_blue());
 				}
 			}
+		} else {
+			// New interactive session: print the welcome message (assistant) as
+			// user-facing AI output, stripping any <system>...</system> AI-only
+			// blocks and rendering markdown when applicable.
+			if let Some(welcome_msg) = chat_session
+				.session
+				.messages
+				.iter()
+				.find(|m| m.role == "assistant")
+			{
+				let visible =
+					crate::session::chat::assistant_output::strip_system_tags(&welcome_msg.content);
+				if !visible.is_empty() {
+					crate::session::chat::assistant_output::print_assistant_response(
+						&visible,
+						&config_for_role,
+						&role,
+						&None,
+					);
+				}
+			}
 		}
 
 		// Set up advanced cancellation system for proper CTRL+C handling

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -908,13 +908,18 @@ pub async fn run_interactive_session(
 					animation_manager.stop_current().await;
 
 					match done_result {
-						Some(Ok((exit_flag, reset_first_message))) => {
-							if reset_first_message {
-								// Reset first_message_processed to false so that the next message goes through layers again
-								first_message_processed = false;
-							}
-							if exit_flag {
-								break;
+						Some(Ok(outcome)) => {
+							use crate::session::chat::session::commands::DoneOutcome;
+							match outcome {
+								DoneOutcome::Compressed => {
+									println!("{}", "✅ Conversation compressed.".bright_green());
+								}
+								DoneOutcome::NothingToCompress => {
+									println!("{}", "ℹ️  Nothing to compress.".bright_cyan());
+								}
+								DoneOutcome::Failed(e) => {
+									println!("{}: {}", "❌ Compression failed".bright_red(), e);
+								}
 							}
 						}
 						Some(Err(e)) => {

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -1067,17 +1067,6 @@ pub async fn run_interactive_session(
 					.unwrap_or_default()
 					.as_millis()
 			);
-			// CRITICAL: Set first_prompt_idx BEFORE compression runs so the anchor is always
-			// correct. Compression uses first_prompt_idx as the lower boundary — if it's None
-			// during the first compression, the system message index is used as fallback, which
-			// can allow compressing the very first user message.
-			// We use the current message count because that is exactly where the user message
-			// will be inserted after compression finishes (compression only removes/replaces
-			// older messages, never appends).
-			if !workflow_modified_session && chat_session.first_prompt_idx.is_none() {
-				chat_session.first_prompt_idx = Some(chat_session.session.messages.len());
-			}
-
 			// CONVERSATION COMPRESSION: Check if AI should compress older exchanges
 			// This happens BEFORE user message is added to ensure user's new request is not broken by summarization
 			// AI decides if compression is beneficial based on conversation history

--- a/src/session/prompt.rs
+++ b/src/session/prompt.rs
@@ -104,15 +104,12 @@ pub fn add_compression_hints_to_prompt(
 	}
 
 	prompt.push_str(&format!(
-		"\n\n## CONTEXT COMPRESSION ACTIVE\n\
-		- {} compressions performed ({} tokens saved, {:.1}% reduction)\n\
-		- Compressed sections marked with [COMPRESSED: id]\n\
-		- **ANALYSIS FINDINGS in compressed summaries are trustworthy** — they were extracted from real tool results. \
-		Do NOT re-read files or re-run searches just to verify what the summary already states.\n\
-		- **FILE CONTEXT sections contain real file content** auto-read from disk at compression time. \
-		Treat this content as current and accurate — do NOT re-read files that are already in FILE CONTEXT.\n\
-		- If you need a file NOT in FILE CONTEXT, read it normally. But for files already there, use the provided content.\n\
-		- Focus on recent uncompressed messages for current intent, compressed summaries for background knowledge.",
+		"\n\n<context_compression status=\"active\" compressions=\"{}\" tokens_saved=\"{}\" reduction=\"{:.1}%\">\n\
+		Compressed turns appear as XML blocks: <conversation_summary id=\"…\">, <task_compressed id=\"…\">, <phase_compressed id=\"…\">, <project_compressed id=\"…\">.\n\
+		<analysis_findings> inside a <conversation_summary> are trustworthy — they were extracted from real tool results. Trust them; do not re-read files or re-run searches just to verify what the summary already states.\n\
+		<file_context> sections inside a compressed summary contain real file content auto-read from disk at compression time. Treat this content as current and accurate; for files already there, use the provided content. For files NOT in <file_context>, read them normally.\n\
+		Focus on recent uncompressed messages for current intent and on compressed summaries for background knowledge.\n\
+		</context_compression>",
 		compression_stats.total_compressions(),
 		compression_stats.total_tokens_saved,
 		compression_stats.avg_compression_ratio() * 100.0

--- a/src/websocket/server.rs
+++ b/src/websocket/server.rs
@@ -925,12 +925,6 @@ async fn handle_user_message(
 	)
 	.await?;
 
-	// Set first_prompt_idx BEFORE compression so the anchor is always correct.
-	// Compression uses first_prompt_idx as the lower boundary.
-	if !layers_modified_session && chat_session.first_prompt_idx.is_none() {
-		chat_session.first_prompt_idx = Some(chat_session.session.messages.len());
-	}
-
 	// Conversation compression: check if AI should compress older exchanges.
 	// Runs BEFORE user message is added to avoid breaking the new request.
 	let _compression_occurred =

--- a/src/websocket/server.rs
+++ b/src/websocket/server.rs
@@ -751,14 +751,25 @@ async fn handle_command_message(
 	// Handle /done specially — it hits unreachable!() in process_command
 	// because the CLI intercepts it before routing. We handle it here directly.
 	if command_name == "done" {
-		use crate::session::chat::session::commands::handle_done;
+		use crate::session::chat::session::commands::{handle_done, DoneOutcome};
 		match handle_done(&mut chat_session, &config_for_role, operation_rx).await {
-			Ok(_) => {
+			Ok(DoneOutcome::Compressed) => {
 				let status = ServerMessage::status(
 					"Conversation compressed".to_string(),
 					Some(session_id.clone()),
 				);
 				send_message(ws_sender, &status).await?;
+			}
+			Ok(DoneOutcome::NothingToCompress) => {
+				let status = ServerMessage::status(
+					"Nothing to compress".to_string(),
+					Some(session_id.clone()),
+				);
+				send_message(ws_sender, &status).await?;
+			}
+			Ok(DoneOutcome::Failed(e)) => {
+				let error = ServerMessage::error(format!("Compression failed: {}", e));
+				send_message(ws_sender, &error).await?;
 			}
 			Err(e) => {
 				let error = ServerMessage::error(format!("Compression failed: {}", e));


### PR DESCRIPTION
- Remove first_prompt_idx field and tracking from ChatSession
- Simplify find_compression_range to derive anchors deterministically
- Use priority-based anchoring starting with instructions or user roles
- Prevent orphaned tool calls by ensuring user-role anchors
- Resolve bug where bootstrap turns remained in preserved prefix
- Remove manual index updates in session resume and websocket handlers
- Update compression tests to align with new anchor derivation logic