### PR TITLE
feat(session): implement persistent command logging

### DIFF
--- a/src/mcp/core/plan/storage.rs
+++ b/src/mcp/core/plan/storage.rs
@@ -38,26 +38,6 @@ pub struct MessageRange {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PhaseCompression {
-	pub phase_name: String,
-	pub task_range: (usize, usize),
-	pub summary: String,
-	pub compressed_at: DateTime<Utc>,
-	pub message_range: MessageRange,
-	pub metrics: super::compression::CompressionMetrics,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProjectCompression {
-	pub summary: String,
-	pub compressed_at: DateTime<Utc>,
-	pub message_range: MessageRange,
-	pub metrics: super::compression::CompressionMetrics,
-	pub total_tasks: usize,
-	pub total_phases: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanTask {
 	pub title: String,
 	pub description: String,     // Detailed explanation of what needs to be done

--- a/src/session/cache.rs
+++ b/src/session/cache.rs
@@ -112,107 +112,6 @@ impl CacheManager {
 		}
 	}
 
-	/// Manage user content cache markers using 2-marker system
-	/// Returns true if a marker was added/moved, false otherwise
-	pub fn manage_content_cache_markers(
-		&self,
-		session: &mut Session,
-		target_message_index: Option<usize>,
-		_automatic: bool,
-	) -> Result<bool> {
-		let target_index = match target_message_index {
-			Some(idx) => idx,
-			None => {
-				// Find the last user or tool message
-				session
-					.messages
-					.iter()
-					.enumerate()
-					.rev()
-					.find(|(_, msg)| msg.role == "user" || msg.role == "tool")
-					.map(|(i, _)| i)
-					.ok_or_else(|| anyhow::anyhow!("No user or tool messages found for caching"))?
-			}
-		};
-
-		// Check if message exists and is eligible for caching
-		let msg = session
-			.messages
-			.get(target_index)
-			.ok_or_else(|| anyhow::anyhow!("Message index {} not found", target_index))?;
-
-		if msg.role != "user" && msg.role != "tool" {
-			return Err(anyhow::anyhow!(
-				"Only user and tool messages can be marked for content caching"
-			));
-		}
-
-		// Count existing content cache markers
-		let mut existing_markers: Vec<usize> = session
-			.messages
-			.iter()
-			.enumerate()
-			.filter_map(|(i, msg)| {
-				if msg.cached && (msg.role == "user" || msg.role == "tool") {
-					Some(i)
-				} else {
-					None
-				}
-			})
-			.collect();
-
-		existing_markers.sort();
-
-		// Check if this message is already cached
-		if existing_markers.contains(&target_index) {
-			return Ok(false); // Already cached
-		}
-
-		// Implement 2-marker system logic
-		match existing_markers.len().cmp(&self.max_content_markers) {
-			std::cmp::Ordering::Less => {
-				// We have space for another marker
-				if let Some(target_msg) = session.messages.get_mut(target_index) {
-					target_msg.cached = true;
-					return Ok(true);
-				}
-			}
-			std::cmp::Ordering::Equal => {
-				// We're at capacity, move the first marker to the new position
-				if let Some(first_marker_index) = existing_markers.first() {
-					// Remove cache from first marker
-					if let Some(first_msg) = session.messages.get_mut(*first_marker_index) {
-						first_msg.cached = false;
-					}
-					// Add cache to new position
-					if let Some(target_msg) = session.messages.get_mut(target_index) {
-						target_msg.cached = true;
-						return Ok(true);
-					}
-				}
-			}
-			std::cmp::Ordering::Greater => {
-				// This shouldn't happen in normal usage but handle gracefully
-				// Remove excess markers starting from the first
-				while existing_markers.len() > self.max_content_markers {
-					if let Some(first_marker_index) = existing_markers.first() {
-						if let Some(first_msg) = session.messages.get_mut(*first_marker_index) {
-							first_msg.cached = false;
-						}
-						existing_markers.remove(0);
-					}
-				}
-				// Now add the new marker
-				if let Some(target_msg) = session.messages.get_mut(target_index) {
-					target_msg.cached = true;
-					return Ok(true);
-				}
-			}
-		}
-
-		Ok(false)
-	}
-
 	/// Move cache marker to the latest tool/user message on every call.
 	/// Replaces the previous time/token threshold logic — the provider's
 	/// cache TTL governs lifetime; we just keep the marker fresh on every turn.
@@ -254,40 +153,6 @@ impl CacheManager {
 		Ok(false)
 	}
 
-	/// Move cache marker to a specific tool-result message.
-	/// Called after each tool result is appended so the cache window always
-	/// covers the freshest content.
-	pub fn check_and_apply_auto_cache_threshold_on_tool_result(
-		&self,
-		session: &mut Session,
-		_config: &Config,
-		supports_caching: bool,
-		tool_message_index: usize,
-		_role: &str,
-	) -> Result<bool> {
-		if !supports_caching {
-			return Ok(false);
-		}
-
-		if session.messages.len() <= tool_message_index {
-			return Ok(false);
-		}
-
-		if let Some(msg) = session.messages.get(tool_message_index) {
-			if msg.role != "tool" {
-				return Ok(false);
-			}
-		} else {
-			return Ok(false);
-		}
-
-		match self.apply_cache_to_message(session, tool_message_index, supports_caching) {
-			Ok(v) => Ok(v),
-			Err(_) => Ok(false),
-		}
-	}
-
-	/// Update token tracking after API response
 	/// Update token tracking after API response
 	/// This should be called after EVERY API request to accumulate token usage
 	/// for proper cache threshold calculations
@@ -395,7 +260,6 @@ impl CacheManager {
 				// If we have any input tokens but no tool calls yet, check if it's a cacheable model with system cached
 				session.info.tool_calls > 0 ||
 				(session.info.input_tokens > 0 && has_cached_system) ||
-				// For brand new sessions with cacheable models and cached system, assume tools are available
 				// For brand new sessions with cacheable models and cached system, assume tools are available
 				(session.info.input_tokens == 0 && session.info.cache_read_tokens == 0 && has_cached_system)
 			};
@@ -540,55 +404,6 @@ impl CacheManager {
 		Err(anyhow::anyhow!("No user message found to cache"))
 	}
 
-	/// Apply cache marker to the current tool message when auto-threshold is reached
-	/// This should be called immediately when threshold is reached during tool processing
-	pub fn apply_cache_to_current_tool_message(
-		&self,
-		session: &mut Session,
-		supports_caching: bool,
-	) -> Result<bool> {
-		if !supports_caching {
-			return Ok(false);
-		}
-
-		// Find the last tool message
-		for (i, msg) in session.messages.iter().enumerate().rev() {
-			if msg.role == "tool" {
-				return self.apply_cache_to_message(session, i, supports_caching);
-			}
-		}
-
-		// If no tool message found, fall back to last user message
-		for (i, msg) in session.messages.iter().enumerate().rev() {
-			if msg.role == "user" {
-				return self.apply_cache_to_message(session, i, supports_caching);
-			}
-		}
-
-		Err(anyhow::anyhow!("No suitable message found to cache"))
-	}
-
-	/// Validate cache configuration for a provider/model
-	pub fn validate_cache_support(&self, provider: &str, model: &str) -> bool {
-		match provider.to_lowercase().as_str() {
-			"openrouter" => {
-				// OpenRouter supports caching for Claude models (with or without "anthropic" prefix)
-				model.contains("claude") ||
-				// And also for Gemini models through OpenRouter
-				model.contains("gemini")
-			}
-			"anthropic" => {
-				// Anthropic supports caching for Claude 3.5 models
-				model.contains("claude-3-5") || model.contains("claude-3.5")
-			}
-			"google" => {
-				// Google Vertex AI supports caching for Gemini 1.5 models
-				model.contains("gemini-1.5")
-			}
-			// Do not use our markers, OpenAI uses implicit caching, for example
-			_ => false,
-		}
-	}
 }
 
 /// Cache statistics for display and monitoring
@@ -650,7 +465,6 @@ impl CacheStatistics {
 		}
 
 		// Show session-wide cache efficiency in a clearer way
-		// Show session-wide cache efficiency in a clearer way
 		if self.total_input_tokens > 0 {
 			let session_cached_pct =
 				(self.total_cache_read_tokens as f64 / self.total_input_tokens as f64) * 100.0;
@@ -670,116 +484,11 @@ impl CacheStatistics {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::session::{Session, SessionInfo};
-
-	fn create_test_session() -> Session {
-		Session {
-			info: SessionInfo {
-				name: "test".to_string(),
-				created_at: 0,
-				model: "openrouter:anthropic/claude-3.5-sonnet".to_string(),
-				role: String::new(),
-				input_tokens: 0,
-				output_tokens: 0,
-				cache_read_tokens: 0,
-				cache_write_tokens: 0,
-				reasoning_tokens: 0,
-				total_cost: 0.0,
-				duration_seconds: 0,
-				layer_stats: Vec::new(),
-				tool_calls: 0,
-				total_api_time_ms: 0,
-				total_layer_time_ms: 0,
-				total_tool_time_ms: 0,
-				compression_stats: crate::session::CompressionStats::default(),
-				anchor: crate::session::anchor::Anchor::default(),
-				total_api_calls: 0,
-				// Cache state (Phase 1)
-				current_non_cached_tokens: 0,
-				current_total_tokens: 0,
-				last_cache_checkpoint_time: 0,
-				// Runtime state (Phase 2)
-				cache_next_user_message: false,
-				spending_threshold_checkpoint: 0.0,
-				compression_hint_count: 0,
-				last_compression_hint_shown: 0,
-				context_tokens_after_last_compression: 0,
-				predicted_turns_at_last_compression: 0.0,
-				api_calls_at_last_compression: 0,
-				output_tokens_at_last_compression: 0,
-				consecutive_compressions: 0,
-			},
-
-			messages: Vec::new(),
-			session_file: None,
-		}
-	}
 
 	#[test]
 	fn test_cache_manager_creation() {
 		let manager = CacheManager::new();
 		assert_eq!(manager.max_content_markers, 2);
-	}
-
-	#[test]
-	fn test_two_marker_system() {
-		let manager = CacheManager::new();
-		let mut session = create_test_session();
-
-		// Add some messages
-		session.add_message("user", "First message");
-		session.add_message("assistant", "First response");
-		session.add_message("user", "Second message");
-		session.add_message("assistant", "Second response");
-		session.add_message("user", "Third message");
-
-		// Add first marker
-		let result = manager.manage_content_cache_markers(&mut session, Some(0), false);
-		assert!(result.is_ok());
-		assert!(result.unwrap());
-		assert!(session.messages[0].cached);
-
-		// Add second marker
-		let result = manager.manage_content_cache_markers(&mut session, Some(2), false);
-		assert!(result.is_ok());
-		assert!(result.unwrap());
-		assert!(session.messages[2].cached);
-
-		// Add third marker - should move first marker
-		let result = manager.manage_content_cache_markers(&mut session, Some(4), false);
-		assert!(result.is_ok());
-		assert!(result.unwrap());
-		assert!(!session.messages[0].cached); // First marker removed
-		assert!(session.messages[2].cached); // Second marker remains
-		assert!(session.messages[4].cached); // Third marker added
-	}
-
-	#[test]
-	fn test_cache_support_validation() {
-		let manager = CacheManager::new();
-
-		// Test OpenRouter with Claude models (should work with or without "anthropic" prefix)
-		assert!(manager.validate_cache_support("openrouter", "anthropic/claude-3.5-sonnet"));
-		assert!(manager.validate_cache_support("openrouter", "claude-3-opus"));
-
-		// Test OpenRouter with Gemini models
-		assert!(manager.validate_cache_support("openrouter", "google/gemini-1.5-pro"));
-		assert!(manager.validate_cache_support("openrouter", "gemini-1.5-flash"));
-
-		// Test OpenRouter with non-cacheable models
-		assert!(!manager.validate_cache_support("openrouter", "openai/gpt-4"));
-
-		// Test direct Anthropic (only Claude 3.5 models)
-		assert!(manager.validate_cache_support("anthropic", "claude-3.5-sonnet"));
-		assert!(manager.validate_cache_support("anthropic", "claude-3-5-haiku"));
-		assert!(!manager.validate_cache_support("anthropic", "claude-3-opus")); // Only 3.5 models
-
-		// Test direct Google (only Gemini 1.5 models)
-		assert!(manager.validate_cache_support("google", "gemini-1.5-pro"));
-		assert!(!manager.validate_cache_support("google", "gemini-pro")); // Only 1.5 models
-
-		// Test unsupported providers
-		assert!(!manager.validate_cache_support("openai", "gpt-4"));
 	}
 
 	#[test]

--- a/src/session/chat/command_executor.rs
+++ b/src/session/chat/command_executor.rs
@@ -19,6 +19,21 @@ use crate::session::chat::session::ChatSession;
 use crate::session::{layers::layer_trait::Layer, layers::LayerProcessor};
 use anyhow::Result;
 use colored::Colorize;
+use std::path::PathBuf;
+
+/// Persist a single message as a JSON line to the session log so `/run` command
+/// output survives session reload, mirroring the atomic-add path used for chat
+/// messages. Best-effort: failures are logged but never abort the command.
+fn persist_session_message(session_file: &PathBuf, message: &crate::session::Message) {
+	match serde_json::to_string(message) {
+		Ok(json) => {
+			if let Err(e) = crate::session::append_to_session_file(session_file, &json) {
+				crate::log_debug!("session message persist failed: {}", e);
+			}
+		}
+		Err(e) => crate::log_debug!("session message serialize failed: {}", e),
+	}
+}
 
 /// Execute a command layer without storing it in the session history
 pub async fn execute_command_layer(
@@ -138,11 +153,16 @@ pub async fn execute_command_layer(
 				"{}",
 				"Output mode: append (adding to session)".bright_cyan()
 			);
-			// Add all command outputs as messages with configured role
+			// Add all command outputs as messages with configured role, persisting each
+			// so they are restored on reload. OUTPUT_MODE_APPEND does not clear, so these
+			// lines are read back as-is.
 			for output_text in &result.outputs {
-				chat_session
+				let message = chat_session
 					.session
 					.add_message(command_config.output_role.as_str(), output_text);
+				if let Some(session_file) = &chat_session.session.session_file {
+					persist_session_message(session_file, &message);
+				}
 			}
 
 			// Log the append operation for session restoration
@@ -246,6 +266,14 @@ pub async fn execute_command_layer(
 			// Update session with final messages
 			chat_session.session.messages = final_messages;
 
+			// Persist the rebuilt message set so resume reconstructs it after the
+			// OUTPUT_MODE_REPLACE marker (which clears prior messages on reload).
+			if let Some(session_file) = &chat_session.session.session_file {
+				for message in &chat_session.session.messages {
+					persist_session_message(session_file, message);
+				}
+			}
+
 			// Save session to persist the replacement
 			if let Err(e) = chat_session.save() {
 				crate::log_debug!("session save failed: {}", e);
@@ -258,11 +286,15 @@ pub async fn execute_command_layer(
 				"Output mode: last (adding last response only to session)".bright_cyan()
 			);
 
-			// Add only the last output as message with configured role to session
+			// Add only the last output as message with configured role to session,
+			// persisting it so it is restored on reload (OUTPUT_MODE_LAST does not clear).
 			if let Some(last_output) = result.outputs.last() {
-				chat_session
+				let message = chat_session
 					.session
 					.add_message(command_config.output_role.as_str(), last_output);
+				if let Some(session_file) = &chat_session.session.session_file {
+					persist_session_message(session_file, &message);
+				}
 			}
 
 			// Log the last append operation for session restoration
@@ -324,6 +356,14 @@ pub async fn execute_command_layer(
 				chat_session
 					.session
 					.add_message(command_config.output_role.as_str(), last_output);
+			}
+
+			// Persist the single replacement message so resume reconstructs it after the
+			// OUTPUT_MODE_RESTART marker (which clears prior messages on reload).
+			if let Some(session_file) = &chat_session.session.session_file {
+				for message in &chat_session.session.messages {
+					persist_session_message(session_file, message);
+				}
 			}
 
 			// Save session to persist the replacement

--- a/src/session/chat/session/messages.rs
+++ b/src/session/chat/session/messages.rs
@@ -181,14 +181,8 @@ impl ChatSession {
 	fn ensure_file_initialized(&mut self) -> Result<()> {
 		if let Some(session_file) = &self.session.session_file {
 			if !session_file.exists() {
-				let summary_entry = serde_json::json!({
-					"type": "SUMMARY",
-					"timestamp": std::time::SystemTime::now()
-						.duration_since(std::time::UNIX_EPOCH)
-						.unwrap_or_default()
-						.as_secs(),
-					"session_info": &self.session.info
-				});
+				let summary_entry =
+					crate::session::persistence::summary_log_entry(&self.session.info);
 				let session_file = session_file.clone();
 				crate::session::append_to_session_file(
 					&session_file,

--- a/src/session/dedup.rs
+++ b/src/session/dedup.rs
@@ -93,9 +93,7 @@ pub fn clear_session(session_id: &str) {
 /// originals our placeholders point at no longer exist, so future
 /// duplicates of the same content must be kept verbatim again.
 pub fn clear_current_session() {
-	let key =
-		crate::session::context::current_session_id().unwrap_or_else(|| "_global_".to_string());
-	state().write().unwrap().remove(&key);
+	clear_session(&session_key());
 }
 
 /// Number of distinct tool results recorded in the given session (testing/observability).

--- a/src/session/history/mod.rs
+++ b/src/session/history/mod.rs
@@ -123,8 +123,7 @@ fn migrate_legacy_history_if_needed(role: &str) -> Result<()> {
 		for line in legacy_content.lines() {
 			if !line.trim().is_empty() {
 				// Encode newlines to preserve multiline entries as single history records
-				let encoded_line = line.replace("\\", "\\\\").replace("\n", "\\n");
-				writeln!(role_file, "{}", encoded_line)?;
+				writeln!(role_file, "{}", escape_history_line(line))?;
 			}
 		}
 
@@ -147,6 +146,36 @@ fn migrate_legacy_history_if_needed(role: &str) -> Result<()> {
 	}
 
 	Ok(())
+}
+
+/// Encode a history line so multiline entries persist as a single record:
+/// `\` → `\\`, then newline → `\n`. Order matters — backslash is escaped first.
+fn escape_history_line(line: &str) -> String {
+	line.replace("\\", "\\\\").replace("\n", "\\n")
+}
+
+/// Reverse of `escape_history_line`: `\\` → `\`, `\n` → newline. A single
+/// left-to-right pass is required — chained `str::replace` would corrupt a
+/// literal `\n` (backslash + 'n') typed in the original command text.
+fn unescape_history_line(line: &str) -> String {
+	let mut out = String::with_capacity(line.len());
+	let mut chars = line.chars();
+	while let Some(c) = chars.next() {
+		if c == '\\' {
+			match chars.next() {
+				Some('n') => out.push('\n'),
+				Some('\\') => out.push('\\'),
+				Some(other) => {
+					out.push('\\');
+					out.push(other);
+				}
+				None => out.push('\\'),
+			}
+		} else {
+			out.push(c);
+		}
+	}
+	out
 }
 
 /// Load history from a role-specific file
@@ -176,9 +205,8 @@ pub fn load_session_history_from_file(role: &str) -> Result<Vec<String>> {
 			continue;
 		}
 
-		// Decode newlines to restore multiline entries
-		let decoded_line = line.replace("\\n", "\n").replace("\\\\", "\\");
-		history_lines.push(decoded_line);
+		// Decode escape sequences (reverse of escape_history_line).
+		history_lines.push(unescape_history_line(&line));
 	}
 
 	Ok(history_lines)
@@ -210,8 +238,7 @@ pub fn append_to_session_history_file(role: &str, line: &str) -> Result<()> {
 		.with_context(|| format!("Failed to open history file for append: {:?}", history_path))?;
 
 	// Encode newlines to preserve multiline entries as single history records
-	let encoded_line = line.replace("\\", "\\\\").replace("\n", "\\n");
-	writeln!(file, "{}", encoded_line)?;
+	writeln!(file, "{}", escape_history_line(line))?;
 	file.flush()?;
 
 	Ok(())

--- a/src/session/logger.rs
+++ b/src/session/logger.rs
@@ -25,13 +25,11 @@
 
 use crate::mcp::core::plan::storage::ExecutionPlan;
 use crate::mcp::core::schedule::storage::ScheduleEntry;
+use crate::session::persistence::append_to_session_file;
 use crate::session::Message;
 use anyhow::Result;
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use zstd::stream::write::Encoder as ZstdEncoder;
 
 /// Get the session file path for a specific session.
 pub fn get_session_log_file(session_name: &str) -> Result<PathBuf> {
@@ -57,7 +55,7 @@ pub fn log_restoration_point(
 		"user_message": user_message,
 		"assistant_response": assistant_response,
 	});
-	append_to_log(&log_file, &serde_json::to_string(&entry)?)
+	append_to_session_file(&log_file, &serde_json::to_string(&entry)?)
 }
 
 /// Log compression point — clears prior messages on reload (messages were compressed).
@@ -82,13 +80,13 @@ pub fn log_compression_point(
 		"messages_removed": messages_removed,
 		"tokens_saved": tokens_saved,
 	});
-	append_to_log(&log_file, &serde_json::to_string(&entry)?)?;
+	append_to_session_file(&log_file, &serde_json::to_string(&entry)?)?;
 
 	// Snapshot the post-compression message state so resume can reconstruct it.
 	// The parser wipes `messages` at the marker and expects to re-read them below.
 	for msg in post_compression_messages {
 		let json = serde_json::to_string(msg)?;
-		append_to_log(&log_file, &json)?;
+		append_to_session_file(&log_file, &json)?;
 	}
 
 	Ok(())
@@ -103,7 +101,7 @@ pub fn log_knowledge_entry(session_name: &str, knowledge: &str) -> Result<()> {
 		"timestamp": get_timestamp(),
 		"content": knowledge,
 	});
-	append_to_log(&log_file, &serde_json::to_string(&entry)?)
+	append_to_session_file(&log_file, &serde_json::to_string(&entry)?)
 }
 
 /// Log runtime-only commands (`/model`, `/role`, `/layers`, `/cache`) so they
@@ -115,7 +113,7 @@ pub fn log_session_command(session_name: &str, command_line: &str) -> Result<()>
 		"timestamp": get_timestamp(),
 		"command": command_line,
 	});
-	append_to_log(&log_file, &serde_json::to_string(&entry)?)
+	append_to_session_file(&log_file, &serde_json::to_string(&entry)?)
 }
 
 /// Log a snapshot of the active plan so it can be restored on session resume.
@@ -127,7 +125,7 @@ pub fn log_plan_snapshot(session_name: &str, plan: &ExecutionPlan) -> Result<()>
 		"timestamp": get_timestamp(),
 		"plan": plan,
 	});
-	append_to_log(&log_file, &serde_json::to_string(&entry)?)
+	append_to_session_file(&log_file, &serde_json::to_string(&entry)?)
 }
 
 /// Log that the active plan has been cleared (done/reset).
@@ -138,7 +136,7 @@ pub fn log_plan_cleared(session_name: &str) -> Result<()> {
 		"type": "PLAN_CLEARED",
 		"timestamp": get_timestamp(),
 	});
-	append_to_log(&log_file, &serde_json::to_string(&entry)?)
+	append_to_session_file(&log_file, &serde_json::to_string(&entry)?)
 }
 
 /// Log a full snapshot of the schedule store so it can be restored on session resume.
@@ -151,7 +149,7 @@ pub fn log_schedule_snapshot(session_name: &str, entries: &[ScheduleEntry]) -> R
 		"timestamp": get_timestamp(),
 		"entries": entries,
 	});
-	append_to_log(&log_file, &serde_json::to_string(&entry)?)
+	append_to_session_file(&log_file, &serde_json::to_string(&entry)?)
 }
 
 fn get_timestamp() -> u64 {
@@ -159,25 +157,4 @@ fn get_timestamp() -> u64 {
 		.duration_since(UNIX_EPOCH)
 		.unwrap_or_default()
 		.as_secs()
-}
-
-/// Append a single-line entry to the session log file as an independent zstd frame.
-/// Each call produces one complete frame; the zstd decoder reads all frames
-/// sequentially on load (concatenated-frame format).
-fn append_to_log(log_file: &PathBuf, content: &str) -> Result<()> {
-	let file = OpenOptions::new()
-		.create(true)
-		.append(true)
-		.open(log_file)?;
-
-	// Ensure content is on a single line — replace any newlines with spaces
-	let single_line = content.replace(['\n', '\r'], " ");
-
-	// Level 1 is fast and still gives good compression for JSONL lines.
-	// Each call writes one independent zstd frame; finish() flushes and closes the frame.
-	let mut encoder = ZstdEncoder::new(file, 1)?;
-	encoder.write_all(single_line.as_bytes())?;
-	encoder.write_all(b"\n")?;
-	encoder.finish()?;
-	Ok(())
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -435,17 +435,9 @@ impl Session {
 	// Save the session to a file - append-only approach
 	pub fn save(&self) -> Result<(), anyhow::Error> {
 		if let Some(session_file) = &self.session_file {
-			// In append-only design, individual messages are already saved when added
-			// This method just ensures session metadata is up to date
-			// We append an updated SUMMARY entry to reflect current session state
-			let summary_entry = serde_json::json!({
-				"type": "SUMMARY",
-				"timestamp": std::time::SystemTime::now()
-					.duration_since(std::time::UNIX_EPOCH)
-					.unwrap_or_default()
-					.as_secs(),
-				"session_info": &self.info
-			});
+			// Append-only design: individual messages are persisted when added.
+			// This just appends an updated SUMMARY snapshot of the current session state.
+			let summary_entry = persistence::summary_log_entry(&self.info);
 			append_to_session_file(session_file, &serde_json::to_string(&summary_entry)?)?;
 			Ok(())
 		} else {

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -377,9 +377,10 @@ fn parse_log_lines<R: BufRead>(reader: R) -> Result<ParsedLogLines> {
 						// Commands are processed separately in extract_runtime_state_from_log
 						continue;
 					}
-					"OUTPUT_MODE_REPLACE" => {
-						// Handle Replace mode operations during session restoration
-						// This clears messages like a restoration point but from a command
+					// Replace and Restart both rebuild the session from scratch: clear prior
+					// messages here so the rebuilt snapshot (persisted as message lines after
+					// this marker by command_executor) is the only state that survives reload.
+					"OUTPUT_MODE_REPLACE" | "OUTPUT_MODE_RESTART" => {
 						if restoration_point_found {
 							restoration_messages.clear();
 						} else {
@@ -387,20 +388,17 @@ fn parse_log_lines<R: BufRead>(reader: R) -> Result<ParsedLogLines> {
 						}
 						pending_tool_calls.clear(); // Clear stale tool calls from before replace
 
-						// Log the replace operation for debugging
 						if let Some(command) = json_value.get("command").and_then(|c| c.as_str()) {
-							println!(
-								"Session restoration: Found OUTPUT_MODE_REPLACE from command '{}'",
+							crate::log_debug!(
+								"Session restoration: Found {} from command '{}'",
+								log_type,
 								command
 							);
 						}
 					}
-					"OUTPUT_MODE_APPEND" => {
-						// Handle Append mode operations during session restoration
-						// These are tracked but don't need special handling since the messages
-						// are already in the session file as regular assistant messages
-						continue;
-					}
+					// Append and Last only add messages; the appended message lines follow
+					// this marker in the log, so no clearing is needed.
+					"OUTPUT_MODE_APPEND" | "OUTPUT_MODE_LAST" => continue,
 					"STATS" => {
 						// STATS entries provide incremental updates during a session
 						// BUT: Only apply STATS that are NEWER than the last SUMMARY
@@ -505,15 +503,11 @@ fn parse_log_lines<R: BufRead>(reader: R) -> Result<ParsedLogLines> {
 							}));
 						}
 					}
-					"API_REQUEST" | "API_RESPONSE" | "TOOL_RESULT" | "CACHE" | "ERROR"
-					| "SYSTEM" | "USER" | "ASSISTANT" => {
-						// Skip debug log entries during message parsing
-						continue;
-					}
-					_ => {
-						// Unknown log type, skip
-						continue;
-					}
+					// Everything else is irrelevant to message reconstruction: debug log
+					// entries (API_REQUEST/RESPONSE, TOOL_RESULT, CACHE, ERROR,
+					// SYSTEM/USER/ASSISTANT), command/plan/schedule markers consumed by
+					// other readers, and any unknown future types.
+					_ => continue,
 				}
 			} else if line.contains("\"role\":") && line.contains("\"content\":") {
 				// This is a regular message JSON line
@@ -889,6 +883,17 @@ fn apply_command_to_runtime_state(state: &mut SessionRuntimeState, command_line:
 			// Unknown command, ignore
 		}
 	}
+}
+
+/// Build the SUMMARY log entry that snapshots full session metadata.
+/// SUMMARY is the source of truth for session state on reload, so every save
+/// path (initial file creation and incremental saves) writes one through here.
+pub fn summary_log_entry(info: &SessionInfo) -> serde_json::Value {
+	serde_json::json!({
+		"type": "SUMMARY",
+		"timestamp": crate::utils::time::now_secs(),
+		"session_info": info,
+	})
 }
 
 // Helper function to append to session file as an independent zstd frame.

--- a/src/session/report.rs
+++ b/src/session/report.rs
@@ -67,8 +67,9 @@ struct RequestContext {
 impl SessionReport {
 	/// Generate a session report from the session log file
 	pub fn generate_from_log(session_log_path: &str) -> Result<SessionReport> {
+		// Session logs are zstd-compressed JSONL — decode before reading lines.
 		let file = File::open(session_log_path)?;
-		let reader = BufReader::new(file);
+		let reader = BufReader::new(zstd::stream::read::Decoder::new(file)?);
 
 		let mut contexts: Vec<RequestContext> = Vec::new();
 		let mut current_context: Option<RequestContext> = None;


### PR DESCRIPTION
- Persist /run command outputs to disk for session survival
- Support OUTPUT_MODE_RESTART during session restoration
- Improve history escaping and decoding to prevent corruption
- Extract summary log entry and persistence logic into helpers
- Fix missing zstd decompression in session report generation
- Remove unused compression structs and redundant imports
- Replace println calls with debug logging in restoration process
- Streamline log line parsing and session clearing logic