### PR TITLE
docs: comprehensively expand project and protocol documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ max_session_spending_threshold = 5.00    # USD per session
 - Mid-session model swap with `/model anthropic:claude-haiku-4-5`.
 - Real-time cost tracking per request and per session.
 - Cache-aware token accounting (`cache_read_tokens`, `cache_write_tokens` separated from input/output).
-- Hard spending thresholds with enforcement — agent stops, falls back, or warns before the bill.
+- Hard spending thresholds with enforcement. On a **session cap** Octomind prompts you to continue (interactive) or auto-stops (non-interactive); on a **request cap** it stops execution outright — before the bill, not after.
 
-> Cursor users get $7,000 surprise bills. Octomind agents trip a budget and stop, fall back, or warn — before the bill, not after.
+> Cursor users get $7,000 surprise bills. Octomind agents trip a budget and stop — interactive sessions ask before continuing, non-interactive runs halt automatically.
 
 ---
 
@@ -272,11 +272,15 @@ octomind run developer
 ```
 
 ```
-octomind v0.29.0 · role: developer · model: openrouter:...
+        Octomind v0.29.0
+        Role: developer · Model: openrouter:...
+        ~/your/project
 > _
 ```
 
 You're in an interactive session with a specialist that can read your code, run commands, edit files, and grow capabilities as needed.
+
+> `developer` (and `lawyer:sg`, `doctor:blood`, …) come from the built-in default tap [`muvon/tap`](https://github.com/muvon/octomind-tap), not your local config. The config's own default tag is `assistant:concierge`, so plain `octomind run` starts that. The banner above is illustrative (the real one renders a pixel icon to the left of the text block).
 
 ---
 
@@ -296,11 +300,13 @@ You're in an interactive session with a specialist that can read your code, run 
 
 ### Filesystem tools (via [octofs](https://github.com/muvon/octofs))
 
-`view`, `text_editor`, `batch_edit`, `shell`, `semantic_search`, `structural_search`, `workdir` — file operations come from the companion octofs MCP server, included by default in tap formulas that need them.
+`view`, `text_editor`, `batch_edit`, `extract_lines`, `shell`, `ast_grep`, `list_files`, `workdir` — file operations come from the companion octofs MCP server (`ast_grep` is its AST-based code search). Included by default in tap formulas that need them.
 
 ### Brain (via [octobrain](https://github.com/muvon/octobrain))
 
 `memorize`, `remember`, `forget`, `knowledge`, `relate`, `memory_graph` — long-term memory, knowledge indexing, and relationship graphs. The companion octobrain MCP server is included by default in taps that need persistent context across sessions.
+
+> **Only `core`, `runtime`, and `agent` are built-in MCP servers** shipped in the default config. The `filesystem` (octofs) and `brain` (octobrain) servers are supplied by tap formulas — a freshly generated config won't list them.
 
 ### Providers
 
@@ -322,6 +328,7 @@ model = "anthropic:claude-opus-4-7"
 temperature = 0.2
 [roles.mcp]
 server_refs = ["filesystem", "github"]
+# view/ast_grep are octofs (filesystem) tools; create_pr comes from the github MCP server
 allowed_tools = ["view", "ast_grep", "create_pr"]
 
 # Sandbox — lock all writes to current directory
@@ -350,21 +357,29 @@ Octomind isn't just a CLI. It runs in every context an agent needs to live in:
 | Mode | Use for |
 |---|---|
 | Interactive CLI | Daily work, any domain |
-| `--format jsonl` pipe | CI/CD pipelines, shell scripts, automation |
-| `--daemon` + `send` | Background agents, continuous monitoring, long-running tasks |
-| WebSocket server | IDE plugins, web dashboards, external integrations |
-| ACP protocol | Multi-agent orchestration, being called by other agents |
+| `octomind run --format jsonl` pipe | CI/CD pipelines, shell scripts, automation |
+| `octomind run --daemon` + `octomind send` | Background agents, continuous monitoring, long-running tasks |
+| WebSocket server (`octomind server`) | IDE plugins, web dashboards, external integrations |
+| ACP protocol (`octomind acp`) | Multi-agent orchestration, being called by other agents |
 
 ```bash
 # ACP — drop into any multi-agent system as a sub-agent
 octomind acp developer:general
 
-# Non-interactive — single message, plain output
-octomind run developer "Explain the auth module" --format plain
+# Non-interactive — the message is read from stdin (pipe it in), output as plain text
+echo "Explain the auth module" | octomind run developer --format plain
 
-# Structured JSON output for pipelines
-octomind run developer "List TODO items" --format jsonl
+# Structured JSONL output for pipelines
+echo "List TODO items" | octomind run developer --format jsonl
+
+# Daemon — keep a session alive and inject messages into it from anywhere
+echo "first task" | octomind run --name watcher --daemon --format jsonl
+octomind send --name watcher "now run the test suite"
 ```
+
+`octomind run` has **no message argument** — when `--format` is set, input comes from piped stdin. `--format` is `run`-only (it accepts only `plain` or `jsonl`; `server` and `acp` do not take it). Setting `--format` triggers non-interactive mode only when stdin is *not* a terminal: `octomind run developer --format plain` typed at a TTY stays interactive, while piping into it runs once and exits.
+
+See [WebSocket Server](doc/integration/01-websocket-server.md), [ACP Protocol](doc/integration/02-acp-protocol.md), and [Daemon & Hooks](doc/integration/03-daemon-and-hooks.md) for the integration modes.
 
 One binary. Every workflow.
 
@@ -483,17 +498,19 @@ Every domain expert who publishes a specialist makes Octomind useful for an enti
 - [Quickstart](doc/usage/02-quickstart.md)
 - [Configuration](doc/usage/03-configuration.md)
 - [Providers & Models](doc/usage/04-providers.md)
-- [Sessions & Compression](doc/usage/05-sessions.md)
+- [Sessions](doc/usage/05-sessions.md)
+- [Compression](doc/usage/08-compression.md)
 - [Roles](doc/usage/06-roles.md)
 - [MCP Tools](doc/usage/07-mcp-tools.md)
 - [Workflows](doc/usage/09-workflows.md)
 - [Guardrails](doc/usage/18-guardrails.md)
 - [Learning](doc/usage/13-learning.md)
-- [WebSocket & ACP](doc/integration/01-websocket-server.md)
+- [WebSocket Server](doc/integration/01-websocket-server.md)
+- [ACP Protocol](doc/integration/02-acp-protocol.md)
 - [CLI Reference](doc/reference/01-cli-reference.md)
 - [Config Reference](doc/reference/03-config-reference.md)
 
-Full index: [doc/README.md](doc/README.md).
+Links above are local files in this repo; the [hosted docs site](https://octomind.run/docs/) mirrors them. Full index: [doc/README.md](doc/README.md).
 
 ---
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -30,6 +30,7 @@ For users working with Octomind day-to-day.
 | [Skills](usage/15-skills.md) | Auto-expanding skills, capabilities, validators |
 | [Token Efficiency](usage/16-token-efficiency.md) | Capabilities, auto-activation, LRU eviction |
 | [Local Tools](usage/17-local-tools.md) | Project-local shebang scripts auto-exposed as MCP tools |
+| [Guardrails](usage/18-guardrails.md) | Deterministic policy-as-code: pipes, guards, hooks, validators in .agents/guardrails.toml |
 
 ## Integration Guide
 
@@ -80,7 +81,7 @@ Real-world examples showing how to solve practical problems with Octomind.
 | Document | Description |
 |----------|-------------|
 | [CLI Reference](reference/01-cli-reference.md) | All CLI commands and flags |
-| [Session Commands](reference/02-session-commands.md) | All 27 interactive session commands |
+| [Session Commands](reference/02-session-commands.md) | All interactive session commands (25 distinct, plus /quit and /? aliases) |
 | [Config Reference](reference/03-config-reference.md) | Every configuration field documented |
 | [Environment Variables](reference/04-environment-variables.md) | API keys, overrides, template variables |
 

--- a/doc/dev/01-building-from-source.md
+++ b/doc/dev/01-building-from-source.md
@@ -26,32 +26,61 @@ cargo build --release
 
 ## Development Workflow
 
+Use the same flags the pre-commit hooks and CI use, so problems surface locally
+instead of at commit time. The `--all-targets --all-features` flags make clippy
+and check cover tests, examples, and feature-gated code — without them you run a
+weaker check than the hooks.
+
 ```bash
-# Check compilation (fast)
-cargo check
+# Check compilation (matches the hook / CI)
+cargo check --all-targets --all-features
 
-# Run clippy (linting)
-cargo clippy -- -D warnings
+# Run clippy (linting; warnings treated as errors)
+cargo clippy --all-targets --all-features -- -D warnings
 
-# Format code
-cargo fmt
+# Format code (matches the fmt hook args)
+cargo fmt --all
 
 # Run tests
 cargo test
 
-# Run specific test
+# Run a specific test
 cargo test test_name
 ```
 
+### Make targets
+
+The `Makefile` wraps these commands and adds cross-platform build helpers. The
+most useful targets for building from source:
+
+| Target | Action |
+|--------|--------|
+| `make build` | Release build for the current platform (`cargo build --release`) |
+| `make quick` | Debug build (`cargo build`) |
+| `make fmt` | Format code (`cargo fmt --all`) |
+| `make fmt-check` | Check formatting without modifying files |
+| `make clippy` | `cargo clippy --all-targets --all-features -- -D warnings` |
+| `make test` | Run tests (`cargo test --release`) |
+| `make dev` | Run `fmt`, `clippy`, then `test` in sequence |
+| `make pre-commit` | Run all pre-commit hooks on all files |
+| `make pre-commit-install` | Install the pre-commit Git hook |
+| `make install` | Build release and copy the binary to `/usr/local/bin` (uses `sudo`) |
+| `make install-completions` | Install shell completions |
+| `make audit` | Run `cargo audit` (requires `cargo-audit`) |
+
+Run `make help` to see the full list.
+
 ## Pre-commit Hooks
 
-Install pre-commit hooks to enforce quality before committing:
+Pre-commit hooks enforce quality before each commit. Installation is **required**
+and per-clone: the hook is not committed to the repo, so `.git/hooks/pre-commit`
+does not exist until you install it. Hooks do not run out of the box after `git clone`.
 
 ```bash
 # Install pre-commit (if not installed)
 pip install pre-commit
 
-# Install hooks
+# Install hooks (or: make pre-commit-install)
 pre-commit install
 ```
 
@@ -59,13 +88,13 @@ pre-commit install
 
 | Check | Description |
 |-------|-------------|
-| `cargo fmt` | Rust formatting |
-| `cargo clippy` | Linting (warnings as errors) |
-| `cargo check` | Compilation |
+| `cargo fmt` | Rust formatting (`--all`) |
+| `cargo clippy` | Linting, warnings as errors (`--all-targets --all-features -- -D warnings`) |
+| `cargo check` | Compilation (`--all-targets --all-features`) |
 | `check-merge-conflict` | No merge conflict markers |
 | `check-toml` | Valid TOML files |
 | `check-yaml` | Valid YAML files |
-| `check-added-large-files` | No files > 1MB |
+| `check-added-large-files` | No files > 1000 KB (~1 MB) |
 | `trailing-whitespace` | No trailing whitespace |
 | `end-of-file-fixer` | Files end with newline |
 
@@ -85,14 +114,61 @@ pre-commit run --all-files
 git commit --no-verify
 ```
 
+## Code Style
+
+The hooks (and CI) enforce a few style rules. Code that violates them will fail
+the commit, so set your editor up accordingly:
+
+- **Tabs, not spaces** — `rustfmt.toml` sets `hard_tabs = true`.
+- **LF line endings, UTF-8, final newline, 120-column limit** — defined in `.editorconfig`.
+- **Apache 2.0 copyright header** — every new `.rs` file must begin with the
+  standard Apache License header (see `CONTRIBUTING.md` for the exact block).
+
+Running `cargo fmt --all` before committing handles formatting automatically.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full code-style, architecture,
+and contribution guidelines.
+
 ## Release Build Optimizations
 
-The release profile in `Cargo.toml`:
+The `[profile.release]` section in `Cargo.toml`:
 - LTO enabled (link-time optimization)
-- Single codegen unit
+- Single codegen unit (`codegen-units = 1`)
 - `opt-level = "z"` (optimize for size)
 - `panic = "abort"` (smaller binary)
-- Symbol stripping
+- Symbol stripping (`strip = true`)
+- `overflow-checks = false` (disabled in release)
+
+## Cross-Compilation
+
+The `Makefile` can build static binaries for seven targets using
+[`cross`](https://github.com/cross-rs/cross):
+
+- `x86_64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`
+- `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`
+- `x86_64-pc-windows-gnu`
+- `x86_64-apple-darwin`, `aarch64-apple-darwin` (built natively on macOS hosts only)
+
+```bash
+# Install Rust targets, cross, and audit tooling
+make setup
+
+# Generate Cross.toml (cross-compilation config)
+make cross-config
+
+# Build everything (Linux + Windows + macOS-on-macOS)
+make build-all
+
+# Or build a single platform group
+make build-linux
+make build-windows
+make build-macos      # macOS host only
+
+# Package release archives into dist/
+make dist
+```
+
+Linux and Windows targets build inside `cross` containers (Docker or Podman, set
+via `CROSS_CONTAINER_ENGINE`). macOS targets compile natively and require a macOS host.
 
 ## Cross-Platform Notes
 

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -38,7 +38,7 @@ src/
     providers.rs             # Provider token config
     migrations.rs            # Config format upgrades
     env_source.rs            # .env tracking
-    registry.rs              # Capability resolution
+    registry.rs              # RegistryConfig: [registry] manifest cache TTL
     runtime_overlay.rs       # Runtime config overlay for tap agents
 
   embeddings/
@@ -61,6 +61,7 @@ src/
     inject_listener.rs       # Unix socket for message injection
     webhook_listener.rs      # HTTP webhook → inbox injection
     guardrails.rs            # Project-local tool deny/hook/validator rules (.agents/guardrails.toml)
+    pipe.rs                  # Pipe execution (pre-model input transform)
     hooks.rs                 # Webhook hook listener management (--hook flag)
     completion.rs            # Chat completion orchestration
     chat_helper.rs           # CommandCompleter (fuzzy autocomplete for reedline)
@@ -85,7 +86,7 @@ src/
 
     chat/
       mod.rs                 # Chat orchestration
-      commands.rs            # Command constants (27 entries, COMMANDS array)
+      commands.rs            # COMMANDS array ([&str; 27]: 25 distinct commands + /? and /quit aliases)
       animation.rs / animation_manager.rs  # Spinner & animation
       status_prefix.rs       # Shared status formatting (prompt + spinner)
       assistant_output.rs    # Assistant output formatting
@@ -101,7 +102,8 @@ src/
         decision.rs          # Compression decision logic
         knowledge.rs         # Knowledge retention across compressions
         prompt.rs            # Compression prompts
-        range.rs             # Range selection for compression
+        range.rs             # Range selection for compression (find_compression_range)
+        schema.rs            # Typed compression summary schema (CompressionSummary, KeyEntities, FileContextEntry)
         tests.rs             # Compression tests
       cost_tracker.rs        # Token cost tracking
       edit_mode.rs           # Edit mode handling
@@ -122,7 +124,7 @@ src/
         core.rs              # ChatSession struct, SessionInitParams builder
         api_executor.rs      # API call execution
         api_prep.rs          # API call preparation (compression, auto-activation)
-        commands/            # 26 command handler modules (28 files incl. mod.rs + utils.rs)
+        commands/            # 25 command handler modules (28 files incl. mod.rs, utils.rs, display.rs)
         display.rs           # Session display
         error_utils.rs       # Error utilities
         layer_processor.rs   # Layer processing in session context
@@ -142,10 +144,9 @@ src/
       mod.rs                   # Role-based history management (per-role files, legacy migration)
 
     layers/
-      mod.rs                   # Layer trait & processor
-    workflows/               # Workflow orchestrator (with step timing)
-    guardrails.rs            # Guardrails loading/evaluation
-    pipe.rs                   # Pipe execution logic
+      mod.rs                   # Layer module root
+      layer_trait.rs           # Layer trait
+      processor.rs             # Layer processor
 
   mcp/
     mod.rs                   # MCP coordinator, tool routing (try_execute_tool_call)
@@ -168,14 +169,14 @@ src/
       skill.rs               # Skill management
       skill_auto.rs          # Skill auto-activation & validation hooks
       skill_tests.rs         # Skill unit tests
+      plan_tests.rs          # Plan tool unit tests
       plan/                  # Plan tool
         mod.rs, core.rs, compression.rs, storage.rs, memory_storage.rs
-        plan_tests.rs        # Plan tool unit tests
       schedule/              # Schedule tool (with persistence)
         mod.rs, core.rs, storage.rs
 
     runtime/
-      mod.rs                 # Runtime server: mcp, agent, skill tools
+      mod.rs                 # Runtime server: mcp, agent, skill, schedule, capability tools
 
     agent/
       mod.rs                 # Agent server: agent_* tools
@@ -201,6 +202,13 @@ src/
     mod.rs                   # ACP agent implementation
     agent.rs                 # ACP session handler
     commands.rs              # ACP command routing
+
+  workflow/
+    mod.rs                   # Module root, re-exports (execute_workflow, WorkflowDef)
+    schema.rs                # WorkflowDef, Step (enum), Condition, Sequential/Parallel/Loop steps
+    validate.rs              # Pre-flight validation (validate)
+    run.rs                   # Orchestrator: execute(), stats aggregation, progress to stderr
+    proc.rs                  # Per-step subprocess (octomind run --format jsonl), JSONL stream parsing
 
   websocket/
     mod.rs                   # WebSocket server
@@ -241,11 +249,22 @@ MCP server processes are managed via global statics:
 - `SERVER_STDERR` -- recent stderr per server
 - `SERVER_CAPABILITIES` -- parsed server capabilities
 
+### Tool Routing & Builtin Servers (`src/mcp/mod.rs`)
+
+A tool call flows `execute_tool_call` -> `try_execute_tool_call` (resolves the target server from `TOOL_MAP`) -> for builtin servers, `route_builtin_tool` dispatches by server name; for external servers it forwards to `server::execute_tool_call`. `execute_tool_calls` runs a batch.
+
+Builtin tools are split across three in-process servers:
+- `core` -- hosts `plan` and `tap`
+- `runtime` -- hosts `mcp`, `agent`, `skill`, `schedule`, `capability` (via `runtime::execute_runtime_tool`)
+- `agent` -- hosts the dynamic per-agent execution tools
+
+Dynamic per-agent tool: each registered agent yields a distinct runtime tool named `agent_<name>` (generated by `core/dynamic_agents.rs`) that EXECUTES that agent. It is separate from the `agent` management tool (which lists/enables/disables agents). Dynamic MCP servers and local shebang tools are similarly contributed at runtime (`core/dynamic.rs`, `core/local_tool.rs`).
+
 ### Session Context
 
-- `CLI_SESSION_CONTEXT` -- global (role, project) pair
+- `CLI_SESSION_CONTEXT` -- global (role, project, workdir) triple (set via `set_session_context`, `src/mcp/process.rs`)
 - `CLI_NOTIFICATION_SENDER` -- channel for MCP notifications
-- Session ID derived from SHA256 of git remote or CWD
+- Project ID derived from SHA-256 of the git remote origin URL (else CWD) via `derive_project_id()`; session NAMES are generated separately as `YYMMDD-basename-HHMM-uuid4short` (`generate_session_name`, `src/session/chat/session/core.rs`)
 
 ### Output Abstraction (`src/session/output.rs`)
 
@@ -264,26 +283,30 @@ Zero-sized types for zero-cost output routing:
 ### Config Loading (`src/config/loading.rs`)
 
 1. Load `config.toml` (TOML -> `toml::Value`)
-2. Load other `*.toml` files alphabetically
+2. Load other `*.toml` files alphabetically, EXCEPT `mcp-*.toml` (dash) files, which are loaded last as override files (`is_mcp_extension_file`); `mcp.toml` without a dash loads in normal alphabetical order
 3. Deep-merge tables, concatenate arrays of tables
 4. Deduplicate by `name` field (last wins)
 5. Deserialize to `Config` struct
 6. Validate all fields
 
-### Compression Pipeline
+### Compression Pipeline (`src/session/chat/conversation_compression/`)
 
-1. Token monitor checks pressure levels
+Entry points: `should_check_compression` gates whether a check runs (returns a pressure ratio); `check_and_compress_conversation` is the orchestrator (called from `api_prep.rs` before an API call and from the tool-result path); `apply_compression` rewrites the message list.
+
+1. Token monitor checks pressure levels (`should_check_compression`)
 2. Exponential cooldown prevents loops
 3. Cache-aware economics calculates net benefit
-4. Decision model (cheap AI) decides whether to compress
-5. Semantic chunking preserves conversation structure
-6. Summary replaces compressed content
+4. Decision model (cheap AI, separate from the main model: `[compression.decision] model`, default `openai:gpt-5-mini`) decides whether to compress
+5. Range selected by anchor (latest `<instructions>` user message, else first user message); messages after the anchor up to the end are drained and replaced (`find_compression_range`, `range.rs`)
+6. A typed summary (`CompressionSummary`, `schema.rs`) replaces the drained content
 7. Knowledge entries retained across compressions
+
+Persistence model (`src/session/logger.rs`, `src/session/persistence.rs`): the session JSONL log records `SUMMARY` (session metadata, source of truth on resume) plus marker entries `COMPRESSION_POINT`, `RESTORATION_POINT`, and `KNOWLEDGE_ENTRY`. On restore, `COMPRESSION_POINT` clears the corresponding messages to reflect the compressed state.
 
 ## Dependencies
 
 Key external crates:
-- `octolib` -- provider abstraction, LLM integration
+- `octolib` -- provider abstraction, LLM integration, and local embedding engine (FastEmbedProviderImpl)
 - `rmcp` -- MCP protocol implementation
 - `agent-client-protocol` -- ACP support
 - `tokio` -- async runtime
@@ -294,4 +317,3 @@ Key external crates:
 - `hyper` -- HTTP server
 - `reedline` -- interactive readline
 - `syntect` -- syntax highlighting
-- `octolib` -- local embedding engine (FastEmbedProviderImpl)

--- a/doc/dev/03-mcp-server-development.md
+++ b/doc/dev/03-mcp-server-development.md
@@ -2,6 +2,8 @@
 
 Guide for adding new built-in MCP servers to Octomind.
 
+> Terminology: the codebase defines a tool with the `McpFunction` struct (a `name`, `description`, and a JSON-Schema `parameters` value), and calls the runtime invocation an `McpToolCall` that returns an `McpToolResult`. "Function" = the static definition, "tool" = the thing the model calls. This guide uses both deliberately.
+
 ## When to Add a New Server
 
 Add a built-in server when you need:
@@ -11,18 +13,24 @@ Add a built-in server when you need:
 
 For external tools, prefer configuring a `stdio` or `http` server in config.
 
+> Smallest reference to copy: read `src/mcp/core/functions.rs` (which collects two functions) together with `src/mcp/core/plan/` and how the `core` server is wired into `src/mcp/mod.rs`. Every code block below is modeled on that real `plan` tool.
+
 ## Built-in Servers
 
-| Server | Location | Purpose |
-|--------|----------|---------|
-| `core` | `src/mcp/core/` | Plan, tap |
-| `runtime` | `src/mcp/runtime/` | MCP management, agent delegation, skills, scheduling, capability |
-| `agent` | `src/mcp/agent/` | Agent delegation via ACP |
+Three built-in servers are shipped as `[[mcp.servers]]` entries in `config-templates/default.toml` (`core`, `runtime`, `agent`):
+
+| Server | Location | Tools |
+|--------|----------|-------|
+| `core` | `src/mcp/core/` | `plan`, `tap` |
+| `runtime` | `src/mcp/runtime/` | `mcp`, `agent`, `skill`, `schedule`, `capability` |
+| `agent` | `src/mcp/agent/` | one `agent_<name>` tool per configured agent (built from `config.agents`) |
 
 External:
 | Server | Type | Purpose |
 |--------|------|---------|
-| `filesystem` (octofs) | stdio | File ops, shell, AST grep |
+| `filesystem` (octofs) | stdio | `view`, `text_editor`, `batch_edit`, `extract_lines`, `shell`, `ast_grep`, `list_files`, `workdir` |
+
+> `filesystem` is **not** declared in `default.toml`'s `[[mcp.servers]]`. It is supplied by a tap and referenced by name in roles' `server_refs` / `allowed_tools`. Only `core`, `runtime`, and `agent` are shipped as built-in server entries.
 
 ## Step-by-Step Guide
 
@@ -31,72 +39,136 @@ External:
 ```
 src/mcp/
   your_server/
-    mod.rs        # Server implementation
+    mod.rs        # Function definitions + execute fn
 ```
 
 ### 2. Implement `get_all_functions()`
 
-Return a list of MCP tool definitions:
+Return a list of `McpFunction` definitions. The `parameters` field is a JSON Schema built with `serde_json::json!`. Model it on `get_plan_function()` (`src/mcp/core/plan/mod.rs`):
 
 ```rust
-use rmcp::model::{Tool, ToolInputSchema};
+use crate::mcp::McpFunction;
 use serde_json::json;
 
-pub fn get_all_functions() -> Vec<Tool> {
-    vec![
-        Tool {
-            name: "your_tool".into(),
-            description: Some("Description shown to AI".into()),
-            input_schema: ToolInputSchema {
-                r#type: "object".into(),
-                properties: Some(json!({
-                    "param1": {
-                        "type": "string",
-                        "description": "Parameter description"
-                    }
-                })),
-                required: Some(vec!["param1".into()]),
-                ..Default::default()
+pub fn get_all_functions() -> Vec<McpFunction> {
+    vec![McpFunction {
+        name: "your_tool".to_string(),
+        description: "Description shown to the model".to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "param1": {
+                    "type": "string",
+                    "description": "Parameter description"
+                }
             },
-        },
-    ]
+            "required": ["param1"],
+            "additionalProperties": false
+        }),
+    }]
 }
 ```
 
-### 3. Register in `src/mcp/mod.rs`
-
-Add your server to the MCP coordinator's server registry.
-
-### 4. Implement Tool Execution
-
-Handle tool calls and return results:
+If your function list depends on configuration, take `&Config` directly instead — that is the real config-dependent pattern (see [Config-Dependent Functions](#config-dependent-functions)):
 
 ```rust
-use crate::mcp::McpToolResult;
+pub fn get_all_functions(config: &crate::config::Config) -> Vec<McpFunction> { /* ... */ }
+```
 
-pub async fn execute_tool(
-    tool_name: &str,
-    params: &serde_json::Value,
-    tool_id: &str,
-) -> McpToolResult {
-    match tool_name {
-        "your_tool" => {
-            let param1 = match params.get("param1").and_then(|v| v.as_str()) {
-                Some(v) => v,
-                None => return McpToolResult::error(
-                    "your_tool".to_string(),
-                    tool_id.to_string(),
-                    "Missing required parameter: param1".to_string()
-                ),
-            };
+### 3. Register in `src/mcp/mod.rs` (TWO match arms)
 
-            // Do work...
-            McpToolResult::success("your_tool".to_string(), tool_id.to_string(), "Result text".to_string())
+This is the most error-prone step: a new built-in server must be wired into **two** separate match arms in `src/mcp/mod.rs`, plus a module declaration. Listing-only or execution-only wiring is a silent bug.
+
+**(a)** Declare the module near the other `pub mod` lines (`src/mcp/mod.rs`):
+
+```rust
+pub mod your_server;
+```
+
+**(b)** Add a listing arm in `server_functions_for` so the tool shows up in the system prompt. For a stateless server, use the cache helper `get_filtered_server_functions`:
+
+```rust
+"your_server" => {
+    get_filtered_server_functions("your_server", server.tools(), your_server::get_all_functions)
+}
+```
+
+If your function list is config-dependent, call it directly and filter (like the `agent` arm):
+
+```rust
+"your_server" => {
+    let fns = your_server::get_all_functions(config);
+    filter_tools_by_patterns(fns, server.tools())
+}
+```
+
+**(c)** Add an execution arm in `route_builtin_tool` (`src/mcp/mod.rs`) that dispatches to your execute function and maps a hard error into a soft error result:
+
+```rust
+"your_server" => {
+    let result = your_server::execute_tool(call, config)
+        .await
+        .map_err(|e| format!("your_server tool failed: {}", e));
+    match result {
+        Ok(mut r) => {
+            r.tool_id = call.tool_id.clone();
+            Ok(r)
         }
-        _ => McpToolResult::error("your_tool".to_string(), tool_id.to_string(), format!("Unknown tool: {tool_name}")),
+        Err(msg) => Ok(McpToolResult::error(
+            call.tool_name.clone(),
+            call.tool_id.clone(),
+            msg,
+        )),
     }
 }
 ```
+
+### 4. Implement Tool Execution
+
+Execute functions take the `&McpToolCall` (which carries `tool_name`, `parameters`, and `tool_id`) and usually `&Config`. They return `anyhow::Result<McpToolResult>`. Read parameters off `call.parameters`:
+
+```rust
+use crate::config::Config;
+use crate::mcp::{McpToolCall, McpToolResult};
+use anyhow::Result;
+
+pub async fn execute_tool(call: &McpToolCall, config: &Config) -> Result<McpToolResult> {
+    match call.tool_name.as_str() {
+        "your_tool" => {
+            let param1 = match call.parameters.get("param1").and_then(|v| v.as_str()) {
+                Some(v) => v,
+                // Soft (user-facing) failure: return Ok(error result), do NOT bail with Err.
+                None => return Ok(McpToolResult::error(
+                    call.tool_name.clone(),
+                    call.tool_id.clone(),
+                    "Missing required parameter: param1".to_string(),
+                )),
+            };
+
+            // Do work with `param1` and `config`...
+            Ok(McpToolResult::success(
+                call.tool_name.clone(),
+                call.tool_id.clone(),
+                "Result text".to_string(),
+            ))
+        }
+        // Unexpected internal/routing failure: Err is fine — route_builtin_tool wraps it.
+        other => Err(anyhow::anyhow!("Unknown tool: {}", other)),
+    }
+}
+```
+
+Existing references for the exact signatures:
+- `pub async fn execute_plan(call: &McpToolCall) -> Result<McpToolResult>` (`src/mcp/core/plan/core.rs`)
+- `pub async fn execute_tap_command(call: &McpToolCall, config: &Config) -> Result<McpToolResult>` (`src/mcp/core/tap.rs`)
+- `pub async fn execute_runtime_tool(call: &McpToolCall, config: &Config) -> Result<McpToolResult>` (`src/mcp/runtime/mod.rs`)
+
+#### Error-handling contract
+
+This is non-obvious and worth stating up front:
+
+- **Soft / user-facing failures** (missing param, bad input, tool-level rejection): return `Ok(McpToolResult::error(name, tool_id, msg))`. The model sees the error text and can retry.
+- **Hard / internal failures** (unexpected routing/internal errors): return `Err(anyhow!...)`. `route_builtin_tool` catches it and wraps it into an error result for you (it never propagates a panic to the wire).
 
 ### 5. Add Config Registration
 
@@ -110,47 +182,64 @@ timeout_seconds = 30
 tools = []
 ```
 
-### 6. Add Misuse Hints (Optional)
+`tools = []` means **all** tools from this server are exposed. A non-empty array filters by exact name or wildcard pattern (`is_tool_allowed_by_patterns`), e.g. `tools = ["your_tool", "prefix_*"]`. For external servers, the runtime overlay (`capability enable ...`) can additionally unlock tools that the static filter would otherwise hide.
 
-Provide hints when the AI misuses a tool:
+### 6. Surface Misuse Hints (Optional)
+
+There is no static hint table to declare. To nudge the model when it misuses a tool, push a hint imperatively from inside your execute function:
 
 ```rust
-pub fn get_misuse_hints() -> Vec<(&'static str, &'static str)> {
-    vec![
-        ("your_tool", "Use param1 for X, not Y"),
-    ]
-}
+crate::mcp::hint_accumulator::push_hint("Use param1 for X, not Y");
 ```
+
+Hints are session-scoped, deduplicated, and drained once per tool round by the session layer (`drain_hints()`), then injected as a single user-role message — so they guide the model without polluting individual tool-result strings (`src/mcp/hint_accumulator.rs`).
 
 ## Protocol Compliance
 
-All tools must follow MCP protocol:
+All tools must follow the MCP protocol:
 
-- Return `McpToolResult::error()` instead of panicking
-- Validate all parameters with clear error messages
-- Handle missing/empty/wrong-type parameters gracefully
-- Support cancellation via `CancellationToken`
-- Use standard response format: `{content: [{type: "text", text: "..."}], isError: bool}`
+- Return `McpToolResult::error(...)` instead of panicking.
+- Validate all parameters with clear error messages.
+- Handle missing/empty/wrong-type parameters gracefully.
+- Long-running tools may accept `cancellation_token: Option<tokio::sync::watch::Receiver<bool>>` (as the `agent` server does). Otherwise cancellation is enforced centrally by `try_execute_tool_call`, which races your future against the cancel signal via `tokio::select!`. `execute_plan` / `execute_tap_command` take no token.
+- The wire response shape is `{content: [{type: "text", text: "..."}], isError: bool}`, but you never build it by hand. Return `McpToolResult::success(name, tool_id, text)` or `McpToolResult::error(name, tool_id, msg)`; the content-array + `isError` serialization (wrapping `rmcp::model::CallToolResult`) is handled for you.
+
+### Returning metadata alongside text
+
+To attach structured metadata to a successful result, use `McpToolResult::success_with_metadata(name, tool_id, text, json_value)`. The metadata is stored as the result's `structured_content`; `extract_content()` appends it to the text as a `[Metadata: ...]` block (`src/mcp/mod.rs`).
 
 ## Testing
+
+Build a real `McpToolCall` and pass it (plus a `&Config`) to your execute function. `is_error()` is a method, not a field:
 
 ```rust
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::McpToolCall;
 
     #[tokio::test]
     async fn test_your_tool() {
-        let params = serde_json::json!({"param1": "test"});
-        let result = execute_tool("your_tool", &params, "test-id").await;
-        assert!(!result.is_error);
+        let config = crate::config::Config::load().unwrap();
+        let call = McpToolCall {
+            tool_name: "your_tool".to_string(),
+            parameters: serde_json::json!({"param1": "test"}),
+            tool_id: "test-id".to_string(),
+        };
+        let result = execute_tool(&call, &config).await.unwrap();
+        assert!(!result.is_error());
     }
 
     #[tokio::test]
     async fn test_missing_params() {
-        let params = serde_json::json!({});
-        let result = execute_tool("your_tool", &params, "test-id").await;
-        assert!(result.is_error);
+        let config = crate::config::Config::load().unwrap();
+        let call = McpToolCall {
+            tool_name: "your_tool".to_string(),
+            parameters: serde_json::json!({}),
+            tool_id: "test-id".to_string(),
+        };
+        let result = execute_tool(&call, &config).await.unwrap();
+        assert!(result.is_error());
     }
 }
 ```
@@ -159,15 +248,18 @@ mod tests {
 
 ### Config-Dependent Functions
 
+When a server's function list depends on config, implement `get_all_functions(config: &Config)` directly — there is no separate wrapper. The `agent` server is the canonical example: it maps over `config.agents` to produce one `agent_<name>` tool each (`src/mcp/agent/functions.rs`), and is wired in `server_functions_for` as:
+
 ```rust
-pub fn get_config_functions(config: &Config) -> Vec<Tool> {
-    let mut tools = get_all_functions();
-    if config.some_feature_enabled {
-        tools.push(additional_tool());
-    }
-    tools
+"agent" => {
+    let fns = agent::get_all_functions(config);
+    filter_tools_by_patterns(fns, server.tools())
 }
 ```
+
+### Function Caching
+
+Stateless built-in function lists are memoized through `get_filtered_server_functions(...)`, which caches per `server_type` + allowed-tools key in `INTERNAL_FUNCTION_CACHE` (`src/mcp/mod.rs`). Use it for servers whose tool list never changes (like `core`/`runtime`). Config-dependent servers (like `agent`) skip the cache and call `get_all_functions(config)` each time. `clear_function_cache()` empties the cache — call it in tests or when the tools configuration changes.
 
 ### Async Operations with Timeout
 
@@ -182,6 +274,14 @@ let result = timeout(
 .map_err(|_| anyhow!("Operation timed out"))?;
 ```
 
+### Session-Ownership Checks for Dynamic Tools
+
+If you add dynamic or runtime-registered tools (e.g. `agent_*` tools or dynamic servers), be aware that `execute_tool_without_cancellation` (`src/mcp/mod.rs`) enforces session ownership: the global tool map can contain tools registered by other sessions, so in a session context it verifies that a dynamic tool either is config-defined or belongs to the current session, returning a "belongs to another session" error otherwise. Static built-in tools (`plan`, `tap`, etc.) and project-local tools under the synthetic `local` server bypass this check.
+
 ### Server Stderr Capture
 
-For stdio servers, stderr is captured in `SERVER_STDERR` buffer for debugging. Access via `get_server_stderr(server_name)`.
+For stdio servers, the last ~50 lines of each server's stderr are drained into a private `SERVER_STDERR` map (`Arc<RwLock<HashMap<String, StderrBuffer>>>` in `src/mcp/process.rs`) by background reader threads, and surfaced in init-failure diagnostics and health checks. There is **no** public `get_server_stderr` accessor.
+
+### Initialization Progress
+
+To surface init progress to the UI, pass a callback to `initialize_servers_for_role_with_callback(config, Some(&callback))` (`src/mcp/mod.rs`). It receives `McpInitProgress::Starting { servers }` before initialization and `McpInitProgress::Completed { server, success, function_count }` as each server finishes.

--- a/doc/integration/01-websocket-server.md
+++ b/doc/integration/01-websocket-server.md
@@ -12,6 +12,8 @@ octomind server --host 127.0.0.1 --port 8080
 websocat ws://127.0.0.1:8080
 ```
 
+On connect, the server sends a single `status` frame (`"Connected to Octomind WebSocket server..."`). Nothing else happens until you send a `session` message — that must be the **first frame** you send. Only after a session is established will `message` and `command` frames work.
+
 ## Starting the Server
 
 ```bash
@@ -20,10 +22,10 @@ octomind server [TAG] [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `TAG` | config default | Agent tag or role name |
+| `TAG` | config default | Agent tag (e.g. `developer:general`) or role name (e.g. `developer`) |
 | `--host` | `127.0.0.1` | Bind address |
-| `--port` | `8080` | Port |
-| `--sandbox` | `false` | Restrict filesystem writes |
+| `--port`, `-p` | `8080` | Port |
+| `--sandbox` | `false` | Restrict all filesystem writes to the current working directory |
 
 ## Protocol
 
@@ -50,6 +52,10 @@ Communication uses JSON messages over WebSocket.
 }
 ```
 
+`command` is the slash-command name **without** the leading `/` (see [Session Commands](../reference/02-session-commands.md) for the full list). `args` is optional. The command channel only accepts recognized commands: an unknown command returns `{"type":"error","message":"Unknown command: '...'..."}` — it is **not** treated as free-text AI input. Use a `message` frame for that.
+
+The `done` command (`/done`) is special: it compresses the conversation and replies with a `status` frame (`"Conversation compressed"` or `"Nothing to compress"`). If you supply `args`, they are joined and immediately processed as a follow-up user message after compression.
+
 **Session creation** (auto-named):
 ```json
 {
@@ -65,9 +71,35 @@ Communication uses JSON messages over WebSocket.
 }
 ```
 
-`session_id` is optional — omit it to create an auto-named session, or provide a name to create or resume.
+`session_id` is optional. Omit it to create an auto-named session. If you provide a name, the server resumes the on-disk session at `~/.local/share/octomind/sessions/<session_id>.jsonl.zst` if it exists, otherwise it creates a new session with that name. The `status` reply distinguishes the two: `"Session created: <id>"` vs `"Session resumed: <id>"` (a `session` message never makes an AI call).
+
+`message` and `command` frames require an established session. Sending one for a `session_id` that is neither in memory nor on disk returns:
+
+```json
+{
+  "type": "error",
+  "message": "Session not found: my-session. Send a \"session\" message first to create or resume a session."
+}
+```
+
+The server never auto-creates a session from a `message`/`command` frame.
+
+#### Concurrency
+
+Each session is processed **serially**. While a session is busy handling a `message` or `command`, any concurrent `message`/`command` for that same session is rejected (not queued) with:
+
+```json
+{
+  "type": "error",
+  "message": "Session 'my-session' is busy processing another request. Please wait."
+}
+```
+
+Wait for the prior request to finish — i.e. for its terminating `cost` frame (see below) — before sending the next one. Different `session_id`s run independently.
 
 ### Server to Client
+
+Responses to a single `message` arrive as a **stream** of frames: zero or more `thinking`, `tool_use`, `tool_result`, and `assistant` frames, terminated by a final `cost` frame that marks the end of the turn.
 
 **Assistant response:**
 ```json
@@ -93,7 +125,7 @@ Communication uses JSON messages over WebSocket.
   "type": "tool_use",
   "tool": "view",
   "tool_id": "call_123",
-  "server": "core",
+  "server": "filesystem",
   "params": {"path": "src/auth.rs"},
   "session_id": "my-session"
 }
@@ -105,7 +137,7 @@ Communication uses JSON messages over WebSocket.
   "type": "tool_result",
   "tool": "view",
   "tool_id": "call_123",
-  "server": "core",
+  "server": "filesystem",
   "content": "file contents...",
   "success": true,
   "session_id": "my-session"
@@ -131,10 +163,13 @@ Communication uses JSON messages over WebSocket.
 ```json
 {
   "type": "status",
-  "message": "Processing...",
-  "session_id": "my-session"
+  "message": "Command 'mcp' executed successfully",
+  "session_id": "my-session",
+  "data": { "...": "structured command output" }
 }
 ```
+
+Both `session_id` and `data` are optional. The connection-time welcome status omits `session_id`. The `data` field is present only for commands that return structured output (e.g. `mcp list`, `info`) — it carries that command's JSON result.
 
 **Error:**
 ```json
@@ -165,7 +200,7 @@ Communication uses JSON messages over WebSocket.
 }
 ```
 
-**Injected message:**
+**Injected message** -- a message added to the session by something other than the user, emitted just before the AI processes it:
 ```json
 {
   "type": "injected",
@@ -175,6 +210,10 @@ Communication uses JSON messages over WebSocket.
   "session_id": "my-session"
 }
 ```
+
+`source_kind` is one of: `schedule`, `background_agent`, `tap_run`, `skill`, `skill_validator`, `inject`, `webhook`, `guardrail_hook`, `guardrail_validator`.
+
+After a session is established, the server runs a background monitor that watches the session inbox (schedules, background agents, webhooks). These can fire **asynchronously without any user prompt**, producing `injected` frames followed by the normal `thinking`/`tool_use`/`tool_result`/`assistant`/`cost` stream. Clients should handle server frames arriving at any time, not only in direct response to a `message`.
 
 ## Client Examples
 
@@ -211,7 +250,7 @@ ws.onmessage = (event) => {
       console.log(`Cost: $${msg.session_cost}`);
       break;
     case 'error':
-      console.error('Error:', msg.content);
+      console.error('Error:', msg.message);
       break;
   }
 };
@@ -245,7 +284,7 @@ async def main():
             if msg['type'] == 'assistant':
                 print(f"AI: {msg['content']}")
             elif msg['type'] == 'error':
-                print(f"Error: {msg['content']}")
+                print(f"Error: {msg['message']}")
 
 asyncio.run(main())
 ```
@@ -253,9 +292,19 @@ asyncio.run(main())
 ## Validation
 
 - `session_id` (when provided) and `content` must be non-empty strings
-- Message content is limited to 10MB
+- Message `content` is limited to 10MB
 - Commands must be non-empty strings (without leading `/`)
 - Command `args` is optional
+
+A malformed JSON frame returns `{"type":"error","message":"Invalid JSON: ..."}` and the connection **stays open** — the same is true for validation failures, so clients can recover and keep sending.
+
+### Transport limits
+
+Separate from content validation, the transport layer enforces:
+
+- **Max frame size: 10MB.** Frames larger than this are rejected by the WebSocket layer.
+- **Unmasked frames are rejected.** Per spec, client frames must be masked; standard clients do this automatically.
+- **Ping/Pong:** the server replies to client `Ping` frames with `Pong` to keep the connection alive.
 
 ## Security
 
@@ -278,4 +327,9 @@ location /ws {
 
 ## Logging
 
-WebSocket server logs to `~/.local/share/octomind/logs/websocket-debug.log` when `log_level = "debug"`.
+The WebSocket server writes file logs to `~/.local/share/octomind/logs/websocket-debug.log`. The file is always opened; verbosity follows the configured `log_level` (`none` / `info` / `debug`, default `info`). Set `log_level = "debug"` for full request/message tracing.
+
+## See also
+
+- [Structured Output](../usage/11-structured-output.md) — the JSONL output mode shares this same `ServerMessage` schema.
+- [Session Commands](../reference/02-session-commands.md) — the commands usable over the `command` channel.

--- a/doc/integration/02-acp-protocol.md
+++ b/doc/integration/02-acp-protocol.md
@@ -7,9 +7,10 @@ The Agent Client Protocol (ACP) enables Octomind to run as a sub-agent over stdi
 ACP provides:
 - JSON-RPC over stdio communication
 - Tool execution with streaming results
-- Slash command support
-- MCP server injection from the host
+- Slash command support (advertised set) plus a programmatic [extension-command](#extension-commands) method
+- MCP server injection from the host (Stdio/HTTP)
 - Session lifecycle management
+- Out-of-band [cost/token usage](#cost--token-usage-side-channel) reporting via `_meta`
 
 ## Starting an ACP Agent
 
@@ -27,34 +28,157 @@ octomind acp [TAG] [OPTIONS]
 | `--sandbox` | Restrict filesystem writes to CWD |
 | `--hook` | Activate a webhook hook by name (repeatable) |
 
-The agent reads JSON-RPC messages from stdin and writes responses to stdout. Stderr is reserved for logging (written to `~/.local/share/octomind/logs/acp-debug.log`).
+The agent reads JSON-RPC messages from stdin and writes responses to stdout. Stdout and stderr are reserved for the protocol, so all diagnostics go to files in `~/.local/share/octomind/logs/`:
+
+| File | Contents |
+|------|----------|
+| `acp-debug.log` | Tracing output for the ACP session (controlled by `RUST_LOG` / config `log_level`) |
+| `acp-errors.jsonl` | Structured JSONL error sink for programmatic protocol-error analysis |
+| `acp-init-errors.log` | Fallback for failures that happen *before* logging is up (tracing / error-sink initialization). Written directly with no formatting. |
+
+> ACP output reuses the same internal `ServerMessage` pipeline as the WebSocket server — `ToolCall`/`ToolCallUpdate` translation mirrors the WebSocket message types. See [WebSocket Server](01-websocket-server.md) for the shared message shapes.
 
 ## Protocol Flow
 
-1. **Host starts** `octomind acp <role>` as a subprocess
-2. **Initialization handshake**: host sends capabilities, agent responds with available features
-3. **Authentication**: host authenticates (no-op by default)
-4. **Session creation**: host calls `new_session` or `load_session` (resume by ID)
-5. **Message exchange**: host sends user messages, agent streams responses
-6. **Tool execution**: agent announces tool calls, streams results
-7. **Cancellation**: host can cancel in-progress prompts via `cancel`
-8. **Shutdown**: host closes stdin or sends shutdown message
+Each step is labelled with who acts — **(host)** = the editor/parent client, **(agent)** = Octomind.
+
+1. **(host)** Starts `octomind acp [TAG]` as a subprocess.
+2. **(host → agent)** `initialize`: host sends its capabilities; agent responds with `ProtocolVersion::LATEST`, its capabilities, agent identity, and an `octomind.dev` extension marker (see [Agent Capabilities](#agent-capabilities)).
+3. **(host → agent)** `authenticate`: a no-op — the agent always returns success and never requires credentials.
+4. **(host → agent)** Session creation: `session/new` starts a fresh session; `session/load` resumes a specific session id from disk. See [Session Creation](#session-creation-new_session-vs-load_session) for the behavioral difference.
+5. **(host ↔ agent)** Message exchange: host sends `session/prompt`; agent streams responses as `session/update` notifications.
+6. **(agent → host)** Tool execution: agent announces tool calls as `ToolCall` updates and streams `ToolCallUpdate` results.
+7. **(host → agent)** Cancellation: host sends `session/cancel`; the in-flight prompt returns `StopReason::Cancelled`.
+8. **(host)** Shutdown: the agent runs until stdin closes (client disconnect), at which point the JSON-RPC I/O loop ends and `run()` returns. There is **no** dedicated shutdown RPC.
+
+### Example message exchange
+
+A minimal session looks like this on the wire (one JSON object per line, newline-delimited):
+
+```jsonc
+// host → agent
+{"jsonrpc":"2.0","id":1,"method":"initialize",
+ "params":{"protocolVersion":1,"clientCapabilities":{}}}
+
+// agent → host (capabilities + identity, see below)
+{"jsonrpc":"2.0","id":1,"result":{
+  "protocolVersion":1,
+  "agentCapabilities":{"loadSession":true,
+    "mcpCapabilities":{"http":true},
+    "promptCapabilities":{"image":true,"embeddedContext":true},
+    "_meta":{"octomind.dev":{"commands":true}}},
+  "agentInfo":{"name":"octomind","version":"0.29.0"}}}
+
+// host → agent
+{"jsonrpc":"2.0","id":2,"method":"session/new",
+ "params":{"cwd":"/path/to/project","mcpServers":[]}}
+
+// agent → host
+{"jsonrpc":"2.0","id":2,"result":{"sessionId":"<session-id>"}}
+
+// host → agent
+{"jsonrpc":"2.0","id":3,"method":"session/prompt",
+ "params":{"sessionId":"<session-id>",
+   "prompt":[{"type":"text","text":"Explain main.rs"}]}}
+
+// agent → host (streamed; many notifications) then the final result
+{"jsonrpc":"2.0","method":"session/update",
+ "params":{"sessionId":"<session-id>",
+   "update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"..."}}}}
+{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}
+```
+
+### Cost / token usage side-channel
+
+The standard ACP `UsageUpdate` variant is not used. Instead, token and cost usage is delivered out-of-band as a `SessionInfoUpdate` notification carrying an `octomind.usage` object in the notification `_meta`:
+
+```jsonc
+{"jsonrpc":"2.0","method":"session/update",
+ "params":{"sessionId":"<session-id>",
+   "update":{"sessionUpdate":"session_info_update"},
+   "_meta":{"octomind.usage":{
+     "session_tokens": 12000,
+     "session_cost": 0.0123,
+     "input_tokens": 9000,
+     "output_tokens": 3000,
+     "cache_read_tokens": 0,
+     "cache_write_tokens": 0,
+     "reasoning_tokens": 0
+   }}}}
+```
+
+`_meta` is the spec-blessed extensibility channel, so this works on any ACP 0.10.x client that forwards `_meta` through unchanged.
 
 ## Agent Capabilities
 
-The agent advertises these capabilities during initialization:
+The `initialize` response advertises:
 
-- **Session management**: `new_session`, `load_session` (resume by session ID)
-- **Prompt**: image support, embedded context
-- **MCP**: HTTP transport support (SSE is not supported)
-- **Cancellation**: cancel in-progress prompts
-- **Commands**: extension commands via `octomind/command` namespace
+- **Protocol version**: `ProtocolVersion::LATEST` (the newest version the bundled `agent_client_protocol` crate supports).
+- **Agent identity**: `agentInfo` = `{ name: "octomind", version: <crate version> }`.
+- **Session management**: `loadSession: true` — both `session/new` and `session/load` (resume by session id) are supported.
+- **Prompt**: `image: true` (inline base64 images) and `embeddedContext: true` (embedded resources, used to carry video — see [Prompt Content](#prompt-content)).
+- **MCP**: `http: true` — HTTP transport is advertised so clients offer HTTP MCP servers. SSE is **not** supported and such servers are skipped silently.
+- **Cancellation**: in-progress prompts can be cancelled.
+- **Extension commands**: `_meta["octomind.dev"] = { commands: true }` signals support for the `octomind/command` extension method (see [Extension Commands](#extension-commands)).
+
+### Session creation: `new_session` vs `load_session`
+
+Both calls run the session in `websocket` output mode, merge any client-injected MCP servers (see [MCP Server Injection](#mcp-server-injection)), and spawn a [background inbox monitor](#background-inbox-monitor). They differ in how they pick the session:
+
+- **`session/new`** creates a fresh session and, on the **first** call, consumes the one-shot CLI overrides `--name` / `--resume` / `--resume-recent`. After that first call those overrides revert to defaults; subsequent `session/new` calls ignore them.
+- **`session/load`** always resumes the specific session id supplied by the client, read from disk. It does not touch the one-shot overrides.
+
+The `--model` and `--hook` flags, by contrast, apply to **every** session created or loaded for the agent's lifetime.
+
+### Advertised slash commands
+
+After a session is created the agent sends an `AvailableCommandsUpdate` listing the slash commands the client may offer. Names are sent **without** the leading `/` (the client prepends it for display). This is the ACP-advertised set and is distinct from the full interactive CLI command set:
+
+| Command | Input hint | Description |
+|---------|-----------|-------------|
+| `help` | — | Show available commands |
+| `role` | `<role_name>` | View or change current role |
+| `model` | `<provider:model>` | View or change current AI model |
+| `done` | — | Force-compress the conversation context; if learning is enabled, extract lessons in the background (no memory write, no auto-commit) |
+| `info` | — | Display token and cost breakdown for this session |
+| `clear` | — | Clear the screen |
+| `copy` | — | Copy last response to clipboard |
+| `context` | `[all\|assistant\|user\|tool\|large]` | Display session context |
+| `list` | `[page]` | List all available sessions |
+| `session` | `[session_name]` | Switch to or create a session |
+| `run` | `<command_name>` | Execute a command layer |
+| `workflow` | `<workflow_name> [input]` | **Legacy / no-op** — still advertised over ACP, but `/workflow` was removed; run workflows via the `octomind workflow <file.toml>` CLI instead |
+| `mcp` | `[info\|list\|full\|health\|dump\|validate]` | MCP server management |
+| `plan` | — | Display current plan stored in MCP plan tool |
+| `prompt` | `[template_name]` | Manage prompt templates |
+| `image` | `<path>` | Attach image to next message |
+| `video` | `<path>` | Attach video to next message |
+| `loglevel` | `[none\|info\|debug]` | Set logging level |
+| `report` | — | Generate detailed usage report for this session |
+| `skill` | `[name\|pattern\|page]` | List, filter, or toggle skills |
+| `effort` | `[low\|medium\|high\|xhigh\|max]` | View or change reasoning effort level |
+| `schedule` | `[list\|add\|remove\|edit] [<id>] [when=...] [message=...] [every=...]` | Schedule a message to be injected at a future time |
+| `exit` | — | Exit the session |
+
+Slash commands are sent as ordinary `session/prompt` text per the ACP spec. The agent intercepts any prompt beginning with `/` *before* the AI pipeline, runs it via the session command handler, and streams the result back as an `agent_message_chunk`. `/done` (optionally with trailing instructions, e.g. `/done now write tests`) is intercepted first: it compresses the conversation, reports a status chunk, and — if trailing instructions are present — falls through to process them as a normal prompt.
+
+### Prompt Content
+
+`session/prompt` content blocks are mapped as follows:
+
+- **Text** blocks are joined with newlines into the prompt.
+- **Image** blocks are attached as inline base64 image attachments (using the block's `mimeType`).
+- **Resource** blocks carrying a blob resource with a `video/*` MIME type are attached as video (ACP has no native video block). Audio and resource-link blocks are ignored.
+
+If the prompt has no text, image, or video content, the agent immediately returns `StopReason::EndTurn`.
 
 ## Use Cases
 
 ### Editor Integration
 
 Editors (Neovim, Zed, JetBrains) use ACP to embed Octomind as an AI assistant. See [Editor Integration](../usage/12-editor-integration.md).
+
+> Compatibility note: usage and extension data are delivered through ACP `_meta`, so any ACP 0.10.x client that forwards `_meta` through unchanged will see them; clients that strip `_meta` still work but won't surface cost/usage.
 
 ### Agent Delegation
 
@@ -68,11 +192,13 @@ command = "octomind acp context_gatherer"
 workdir = "."
 ```
 
-When the AI calls `agent_context_gatherer(task="...")`, Octomind:
-1. Spawns `octomind acp context_gatherer` as a subprocess
-2. Sends the task via JSON-RPC
-3. Collects the agent's response (all `agent_message_chunk` text)
-4. Returns the result as a tool output
+When the AI calls `agent_context_gatherer(task="...")`, Octomind acts as the **ACP client**:
+1. Spawns `octomind acp context_gatherer` as a subprocess.
+2. Sends `initialize` (with `protocolVersion: "0.1.0"`) — it does **not** call `authenticate`.
+3. Sends `session/new` with an empty `mcpServers` list.
+4. Sends `session/prompt` carrying the task as a single text block.
+5. Accumulates every `agent_message_chunk` text into the result, and forwards intermediate `session/update` events (thinking, tool calls, tool results) up to the parent's notification sink so the user sees the sub-agent's progress live.
+6. Returns the accumulated text as the tool output (surfacing any `session/prompt` error instead of an empty string).
 
 ### Custom ACP Servers
 
@@ -80,44 +206,94 @@ The `command` field in `[[agents]]` can point to any ACP-compatible binary, not 
 
 ## Background Inbox Monitor
 
-ACP sessions automatically spawn a background task that monitors the session's inbox for incoming messages from schedules, webhooks, injections, and background agents. When a message arrives:
+ACP sessions automatically spawn a background task that monitors the session's schedules and inbox for incoming messages from schedules, webhooks, injections, and background agents. When a message arrives:
 
-1. The monitor acquires the session
-2. Processes the message through the full AI pipeline (tool calls, streaming, etc.)
-3. Streams the response back to the ACP client
-4. Returns the session to the pool
+1. The monitor acquires the session (via a per-session exclusion lock, so it never races with a concurrent user prompt).
+2. Surfaces the injected message to the client as a `UserMessageChunk` prefixed with its source label, e.g. `[Scheduled] run the test suite`.
+3. Processes the message through the full AI pipeline (tool calls, streaming, etc.).
+4. Streams the response back to the ACP client.
+5. Returns the session to the pool.
 
-This uses `tokio::sync::Notify` for efficient event-driven wake-ups — no polling. The monitor exits when the session is destroyed.
+The same source-label surfacing happens in the `prompt()` path: before processing a user's prompt, the agent drains any inbox messages that arrived earlier and streams each as a `[<source>] ...` user chunk.
 
-## Session ID in MCP Capabilities
+The monitor is event-driven, not polling: each loop it flushes due/idle schedule entries into the inbox, then waits on a `tokio::select!` over either the next schedule timer (`next_schedule_sleep`) or an inbox notification. It exits when the session is destroyed.
 
-MCP servers receive a `session_id` field during the initialize handshake. This is sent under `capabilities.experimental.session`:
+## Session context passed to downstream MCP servers
+
+This is **not** part of the ACP handshake with the host. It is the payload Octomind sends *downstream* to the stdio MCP servers it spawns: when Octomind initializes a stdio MCP server, the MCP `initialize` request (MCP `protocolVersion` `2025-03-26`) carries the current session context under `params.capabilities.experimental.session`:
 
 ```json
 {
-  "capabilities": {
-    "experimental": {
-      "session": {
-        "role": "developer",
-        "spec": "...",
-        "project": "my-project",
-        "session_id": "abc123..."
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "clientInfo": { "name": "octomind", "version": "0.29.0" },
+    "protocolVersion": "2025-03-26",
+    "capabilities": {
+      "experimental": {
+        "session": {
+          "role": "developer",
+          "spec": "...",
+          "project": "my-project",
+          "session_id": "abc123...",
+          "workdir": "/path/to/project"
+        }
       }
     }
   }
 }
 ```
 
-This allows MCP servers to identify and track specific sessions, enabling session-scoped state and per-session behavior.
+This lets MCP servers identify and track specific sessions, enabling session-scoped state and per-session behavior. The full object is `role` (the role domain), `spec`, `project`, `session_id`, and `workdir`.
+
+## Extension Commands
+
+Beyond the slash commands sent as prompts, a host can invoke session commands programmatically through the `octomind/command` ACP extension method.
+
+> The ACP library strips the leading `_` from a method name before routing, so the agent matches the method name without the underscore prefix.
+
+**Request** (`CommandRequest`):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `session_id` | string | Session to run the command in |
+| `command` | string | Command to execute, e.g. `/info` |
+| `args` | string[] | Optional arguments (defaults to `[]`) |
+
+**Response** (`CommandResponse`):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `success` | bool | Whether the command executed successfully |
+| `output` | JSON \| null | Structured command output, when any |
+| `error` | string \| null | Error message when `success` is false |
+
+The command result maps to the response as:
+
+| Command result | Response |
+|----------------|----------|
+| Handled | `success: true`, no `output` |
+| Handled with output | `success: true`, `output` = the command's JSON |
+| Exit | `success: true`, `output` = `{ "action": "exit" }` |
+| Treated as user input (unknown command) | `success: false`, `error` = `"Unknown command: <command>"` |
 
 ## Error Handling
 
-- Protocol errors are logged to `~/.local/share/octomind/logs/acp-errors.jsonl`
-- Structured JSONL format for programmatic error analysis
-- Stdout/stderr are separated to prevent protocol corruption
+- ACP diagnostics are split across three log files in `~/.local/share/octomind/logs/` — see [Starting an ACP Agent](#starting-an-acp-agent) for the full table (`acp-debug.log`, `acp-errors.jsonl`, `acp-init-errors.log`).
+- Protocol errors land in `acp-errors.jsonl` as structured JSONL for programmatic analysis.
+- Stdout and stderr are reserved for the JSON-RPC protocol, so they are never used for logging — this prevents protocol corruption.
+
+## Cancellation
+
+A `session/cancel` notification triggers `SessionCancellation::shutdown()` for the targeted session, signalling the in-flight operation to stop. The corresponding `session/prompt` then returns `StopReason::Cancelled` rather than `StopReason::EndTurn`. Because the agent runs single-threaded inside a `LocalSet`, cancellation only takes effect at the prompt's next await point.
 
 ## MCP Server Injection
 
-Hosts can inject additional MCP servers during the ACP initialization handshake. The injected servers become available to the agent's session alongside its configured servers.
+Hosts can inject additional MCP servers when creating a session (`session/new` or `session/load`). The injected servers become available to that session alongside its configured servers, letting editors provide project-specific tools (e.g. language servers, project databases) to the AI.
 
-This enables editors to provide project-specific tools (e.g., language servers, project databases) to the AI session.
+Injection semantics:
+
+- **Transports**: `Stdio` and `HTTP` servers are accepted (timeout hard-coded to 30s, no tool filter — all tools exposed). `SSE` and unknown transports are skipped silently with a log line.
+- **Session-scoped**: injection is applied to a per-session config snapshot; the base config is never mutated.
+- **Deduped by name**: a server whose name is already present is not re-added.

--- a/doc/integration/03-daemon-and-hooks.md
+++ b/doc/integration/03-daemon-and-hooks.md
@@ -2,6 +2,8 @@
 
 Run Octomind as a persistent background session that reacts to external events.
 
+> **`octomind send` and `--hook` webhooks are `run`-only.** The message-injection listener (the Unix socket / named pipe that `octomind send` connects to) and any activated `--hook` webhook listeners are started **only** on the `octomind run` path — both interactive `octomind run` and non-interactive `octomind run --format ...` (`init_session_runtime`, `src/session/chat/session/main_loop.rs`). The WebSocket `octomind server` and `octomind acp` drive their sessions over their own client transports and do **not** bind an inject socket or webhook listener — `octomind send` cannot reach them, and `acp`'s `--hook` flag, while accepted, starts nothing. Daemon mode (`--daemon`) is special only because it keeps the loop alive *after* the first turn so injected messages still have somewhere to land.
+
 ## Daemon Mode
 
 Start a session that stays alive after processing, accepting injected messages:
@@ -12,17 +14,50 @@ octomind run --name ci-watcher --daemon --format jsonl
 
 | Flag | Purpose |
 |------|---------|
-| `--name` | Required for daemon. Identifies the session. |
-| `--daemon` | Keep session alive after processing |
-| `--format jsonl` | Structured output for programmatic consumption |
+| `--name` | Optional. Without it the session gets an auto-generated name. Provide a stable name if you want to inject messages with `octomind send`. |
+| `--daemon` | Keep the session alive after the first turn, waiting for injected messages. |
+| `--format <plain\|jsonl>` | Run non-interactively. Required for `--daemon` (see below). `jsonl` is recommended for programmatic consumers; `plain` also works. |
+| `--hook <NAME>` | Activate a configured webhook listener. Repeatable. |
+
+`--daemon` requires **non-interactive mode**, not `jsonl` specifically. A session is non-interactive when you pass any `--format` value *or* when stdin is piped rather than a TTY (`is_interactive_session = format.is_none() && stdin.is_terminal()`). Passing `--daemon` from an interactive terminal without `--format` will not enter daemon mode.
+
+### Other long-lived background sessions
+
+`octomind run --daemon` is not the only long-lived entry point — `octomind server` (WebSocket) and `octomind acp` also run persistent sessions. But they reach you differently:
+
+- **`octomind server`** — a WebSocket server (see [WebSocket Server](01-websocket-server.md)). Clients send messages over the WebSocket connection; there is no inject socket and no `--hook` support.
+- **`octomind acp`** — the Agent Client Protocol bridge. The ACP client drives the session over stdio; `octomind acp` accepts a `--hook` flag but does not start a webhook listener from it, and it exposes no `octomind send` socket.
+
+All entry points share the same internal inbox abstraction, but only `octomind run` binds the external `octomind send` and `--hook` webhook listeners described below.
 
 ### Sending Messages
 
-Inject messages into a running daemon:
+Inject a message into a running session by name. Pass it as an argument or pipe it via stdin:
 
 ```bash
+# As an argument
+octomind send --name ci-watcher "Check the build status"
+
+# Or piped from stdin
 echo "Check the build status" | octomind send --name ci-watcher
 ```
+
+The listener replies on the wire with `ok\n` on success or `error: ...\n` on failure; the `send` command surfaces a non-zero exit when it gets an error. If no session by that name is running, `send` fails immediately:
+
+```
+no running session named 'ci-watcher' (socket not found at ...)
+```
+
+#### IPC endpoints
+
+Each running session exposes one per-name IPC endpoint that `octomind send` connects to:
+
+| Platform | Endpoint | Extra |
+|----------|----------|-------|
+| Unix (macOS/Linux) | Unix socket at `~/.local/share/octomind/run/<name>.sock` | PID written to `<name>.pid` |
+| Windows | Named pipe `\\.\pipe\octomind-<name>` | — |
+
+These files are created on session start and auto-cleaned when the session exits (a stale socket from a crash is removed on next bind). The injected message is trimmed; an empty message is rejected with `error: empty message`.
 
 ## Webhook Hooks
 
@@ -40,10 +75,12 @@ timeout = 30
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `name` | string | required | Unique hook identifier |
-| `bind` | string | required | HTTP server address:port |
-| `script` | string | required | Path to executable script |
-| `timeout` | u32 | 30 | Script timeout (1-3600 seconds) |
+| `name` | string | required | Unique hook identifier (referenced by `--hook`). Must be unique across `[[hooks]]`. |
+| `bind` | string | required | HTTP listener `address:port`. Must parse as a socket address and be unique across `[[hooks]]`. |
+| `script` | string | required | Path to the executable script |
+| `timeout` | u64 | 30 | Script timeout in seconds (must be > 0, max 3600) |
+
+> **Startup validation.** Config validation rejects duplicate hook names, duplicate bind addresses, empty/invalid bind addresses, and timeouts outside `1..=3600`. When a hook is activated, it is validated again before binding: the bind address must parse, the script must exist and be a regular file, and on Unix it must be executable (`chmod +x`). Any failure aborts session start, so a missing `chmod +x` is a startup error, not a silent no-op.
 
 ### Activating Hooks
 
@@ -51,24 +88,41 @@ timeout = 30
 octomind run --name ci-watcher --daemon --format jsonl --hook github-push
 ```
 
-Multiple hooks can be activated:
+Multiple hooks can be activated (repeat `--hook`):
 ```bash
-octomind run --daemon --hook github-push --hook slack-notify
+octomind run --name ci-watcher --daemon --format jsonl --hook github-push --hook slack-notify
 ```
 
 ### Script Interface
 
-When a webhook request arrives:
+Only **POST** requests invoke the script. Non-POST requests are rejected with `405` *before* the script is ever spawned, so `HOOK_METHOD` (see below) is effectively always `POST`.
+
+When a POST arrives:
 
 | Channel | Content |
 |---------|---------|
-| **stdin** | Raw HTTP body |
-| **stdout** | Message to inject into session (on exit 0) |
+| **stdin** | Raw HTTP request body |
+| **stdout** | Message to inject into the session (on exit 0) |
 | **stderr** | Error info (logged on non-zero exit) |
 
 **Exit codes:**
-- `0` -- success, stdout is injected as user message
-- Non-zero -- failure, stderr is logged
+- `0` -- success. stdout is **trimmed** (leading/trailing whitespace stripped) and injected as a user message. If stdout is **empty after trimming, nothing is injected** and the listener returns `204` — even on exit 0.
+- Non-zero -- failure. stderr is logged and the listener returns `500`.
+
+#### HTTP response contract
+
+External senders (GitHub, Slack, etc.) can interpret these status codes:
+
+| Status | Meaning |
+|--------|---------|
+| `200 ok` | Script succeeded; trimmed stdout injected into the session |
+| `204` | Script succeeded but produced empty output; nothing injected |
+| `400` | Failed to read the request body |
+| `405` | Non-POST request rejected (script not run) |
+| `500` | Script failed to spawn, hit an I/O error, or exited non-zero |
+| `504` | Script exceeded `timeout` seconds and was killed |
+
+> **Debugging "why didn't my message inject?"** If your sender logs a `204`, the script ran fine but printed nothing (after trimming) — check that it actually echoes a message. A `405` means the request reached the listener but was not a POST.
 
 ### Environment Variables
 
@@ -77,7 +131,7 @@ Available to hook scripts:
 | Variable | Description |
 |----------|-------------|
 | `HOOK_NAME` | Hook identifier |
-| `HOOK_METHOD` | HTTP method (GET, POST, etc.) |
+| `HOOK_METHOD` | HTTP method — always `POST` (non-POST requests never reach the script) |
 | `HOOK_PATH` | Request path |
 | `HOOK_QUERY` | Query string |
 | `HOOK_CONTENT_TYPE` | Content-Type header |
@@ -105,7 +159,7 @@ echo "New push to $repo ($branch) by $pusher: $commits commit(s). Please review 
 
 ## Unified Inbox
 
-All injected messages flow through a unified inbox system:
+All injected messages flow through a unified inbox system. Each session has its own isolated queue with async notification support.
 
 **Message sources:**
 - **Schedule** -- scheduled messages from the `schedule` tool
@@ -115,8 +169,19 @@ All injected messages flow through a unified inbox system:
 - **SkillValidator** -- skill validation results
 - **Inject** -- external injection via `octomind send`
 - **Webhook** -- HTTP webhook requests
+- **GuardrailHook** -- output from a guardrail post-result `[[hook]]` script (see [Guardrails](../usage/18-guardrails.md))
+- **GuardValidator** -- output from a guardrail end-of-turn `[[validator]]` (see [Guardrails](../usage/18-guardrails.md))
 
-Messages are drained in order: scheduled → background → tap run → skill → skill validator → inject → webhook. Each session has an isolated queue with async notification support.
+Messages are drained in **FIFO arrival order** — the queue is a per-session `VecDeque` and the loop pops from the front. The source kind only sets the display label and icon shown next to the injected turn; it does **not** affect ordering or priority. A message is processed in the order it arrived, regardless of which source produced it.
+
+### Background agent completions
+
+Async agent jobs (`agent` tool) inject their result through the **BackgroundAgent** source when they finish, with a wrapper prefix the AI sees on its next turn:
+
+- Success: `[Async agent '<name>' completed]` followed by the agent output.
+- Failure: `[Async agent '<name>' failed]` followed by the error.
+
+These are tracked by a background job manager that caps the number of concurrent async jobs (`max_concurrent`); attempts to launch beyond the limit are rejected.
 
 ## Use Cases
 
@@ -134,13 +199,13 @@ octomind run --name ci-bot --daemon --format jsonl --hook github-push
 ### Slack Integration
 
 ```bash
-octomind run --name slack-bot --daemon --hook slack-event
+octomind run --name slack-bot --daemon --format jsonl --hook slack-event
 ```
 
 ### Automated Code Review
 
 ```bash
-octomind run --name reviewer --daemon --hook github-pr
+octomind run --name reviewer --daemon --format jsonl --hook github-pr
 # Script extracts PR details
 # AI reviews code and posts comments
 ```

--- a/doc/integration/04-tap-system.md
+++ b/doc/integration/04-tap-system.md
@@ -9,19 +9,24 @@ A tap is a Git repository (or local directory) containing:
 ```
 agents/
   category/
-    variant.toml    # Agent manifest
+    variant.toml         # Agent manifest (tag = category:variant)
 deps/
-  [dependency definitions]
+  org/
+    tool.sh              # Dependency install script (idempotent)
 skills/
   skill-name/
-    SKILL.md        # Skill instructions
-    scripts/        # Executable scripts
-    references/     # Documentation files
-    assets/         # Static files
+    SKILL.md             # Skill instructions
+    scripts/             # Executable scripts
+    references/          # Documentation files
+    assets/              # Static files
 capabilities/
   capability-name/
-    provider.toml   # Provider-specific capability config
+    config.toml          # REQUIRED: triggers = [...] (drives auto-activation); optional domains = [...]
+    default.toml         # Provider wiring (deps / server_refs / allowed_tools / mcp.servers)
+    octocode.toml        # Alternate provider, selected via [capabilities] override
 ```
+
+> Two distinct files are involved when you work with taps: the **on-disk tap repo** (the tree above — `agents/`, `deps/`, `skills/`, `capabilities/`) and **your `config.toml`** (where `[taps]`, `[capabilities]`, and `[registry]` live). Each TOML snippet below notes which file it belongs to.
 
 ## Managing Taps
 
@@ -49,7 +54,7 @@ octomind untap myorg/my-agents
 
 ### Built-in Tap
 
-The default tap `muvon/tap` is always active and ships production-ready agents.
+The default tap `muvon/tap` is always present as the **last-priority fallback**. It is auto-cloned on first use, and it cannot be added (`tap muvon/tap` is rejected) or removed (`untap muvon/tap` is rejected).
 
 ## Tap Priority
 
@@ -57,22 +62,28 @@ When multiple taps provide the same agent tag, priority is:
 1. User-added taps (in order added)
 2. Built-in default tap (`muvon/tap`)
 
+When more than one tap provides the same `category:variant`, the **first-listed tap wins** and a debug-level log line is emitted (`'…' found in multiple taps — using first match`). The same first-wins rule applies to skills and capabilities.
+
 ## Using Tap Agents
 
 ### From the CLI
 
-Run a tap agent with `domain:spec` format:
+Run a tap agent with `category:variant` format:
 
 ```
 octomind run octomind:assistant
 octomind run developer:general
 ```
 
-When you specify a tag with `:`, Octomind:
-1. Searches taps for a matching agent manifest
-2. Downloads and resolves dependencies
-3. Merges the manifest into config
-4. Starts the session with the agent's role
+When you specify a tag containing `:`, Octomind runs the full resolution pipeline:
+1. **Fetch** the matching agent manifest from taps (first-wins; cached locally — see [Manifest Caching](#manifest-caching))
+2. **Expand capabilities** — any `capabilities = [...]` declared in the manifest are resolved and merged in
+3. **Resolve placeholders** — `{{INPUT:KEY}}` (prompt once, cached) and `{{ENV:KEY}}` (env var, with `.env` fallback) are substituted (see [Manifest Placeholders](#manifest-placeholders))
+4. **Run dependency scripts** — any `[deps] require = [...]` scripts run before MCP init (see [Dependencies](#dependencies-deps))
+5. **Inject the tag** as the role name (`category:variant` becomes the role's `name`)
+6. **Merge** the manifest into config and start the session
+
+If a manifest needs a credential it cannot find, this is where you will see an `Enter value for …` prompt (step 3) — not at startup.
 
 ### From within a session — the `tap` core tool
 
@@ -85,6 +96,10 @@ Inside a running session you can launch a tap role as a subagent via the `tap` c
 {"action": "stop", "session": "tap-lawyer-sg-9b2c1d"}
 ```
 
+Each `run` returns a run id of the form `tap-<role-with-dashes>-<6hex>` (e.g. `tap-lawyer-sg-9b2c1d` for `lawyer:sg`). Use that id to `stop` a run or to resume it (pass it back as `session` on a subsequent `run`).
+
+`discover` matches your `intent` semantically against each agent's title + description (cosine score must exceed `0.2`, top 5 returned) and requires the local embedding model to be ready, erroring if it is not.
+
 Use `background: true` for long tasks; the reply lands as a user message in the next turn. See [MCP Tools — `tap`](../usage/07-mcp-tools.md#tap----run-specialist-roles-from-taps) for the full schema.
 
 ### Model Overrides
@@ -92,17 +107,17 @@ Use `background: true` for long tasks; the reply lands as a user message in the 
 Set a preferred model for specific tap agents in your config:
 
 ```toml
+# In config.toml
 [taps]
 "developer:general" = "ollama:glm-5"
 ```
 
 This overrides the model for `octomind run developer:general` while leaving other agents unchanged.
-**Priority:** CLI `--model` > `[taps]` override > role.model > config.model
+**Priority (highest wins):** CLI `--model` > the agent's manifest/role `model` > root `config.model`. The session model is resolved in `src/session/chat/session/core.rs` as `CLI --model ?? role.model ?? config.model`; a `[taps]` entry for this tag overrides the `config.model` tier (`src/agent/resolver.rs`), so it applies only when neither `--model` nor the agent's manifest role declares its own `model`.
 
 ## Agent Manifests
 
-
-Agent manifests are TOML files in `agents/<category>/<variant>.toml`. The header comment block is part of the schema — `# Title:` and `# Description:` are required (used by `tap discover` and `octomind run` autocomplete):
+Agent manifests are TOML files in `agents/<category>/<variant>.toml`. The header comment block is part of the schema — `# Title:` and `# Description:` are required and feed `tap discover`'s semantic matching (they are the embedding corpus). They are **not** used by `octomind run` shell autocomplete, which derives `category:variant` purely from the file path:
 
 ```toml
 # agents/developer/general.toml
@@ -119,13 +134,17 @@ server_refs = ["core", "runtime", "filesystem"]
 allowed_tools = ["core:*", "runtime:*", "filesystem:*"]
 ```
 
-The role's `name` is auto-injected from the file path (`category:variant` becomes the name) — manifests don't need to declare it. Manifests can include any config sections: roles, layers, workflows, MCP servers, etc.
+The role's `name` is **always force-injected from the tag** — `category:variant` is written into the first `[[roles]]` entry's `name`, overwriting any value you declare there. The shipped templates set `name` anyway for readability, but it has no effect. Manifests can include any config sections: roles, layers, MCP servers, etc.
 
-If the role needs runtime harness control (`mcp` / `agent` / `skill` tools), include `"runtime"` in `server_refs`. Most roles only need `"core"` (planning, scheduling, capability, tap) plus the data servers they actually use.
+If the role needs runtime harness control (`mcp` / `agent` / `skill` / `schedule` / `capability` tools), include `"runtime"` in `server_refs`. Most roles only need `"core"` (`plan` + `tap`) plus the data servers they actually use.
 
 ## Skills
 
-Skills are reusable instruction packs managed via the `skill` MCP tool. Auto-activation uses declarative `rules:` in SKILL.md frontmatter — see [Skills](../usage/15-skills.md) for full documentation.
+Skills are reusable instruction packs. Auto-activation uses declarative `rules:` in SKILL.md frontmatter — see [Skills](../usage/15-skills.md) for full documentation.
+
+Skills are **not tap-only**. They are resolved (first-wins, deduped by name) from, in order: taps, then `<workdir>/.agents/skills/`, then `~/.config/agents/skills/`. So "managed via taps" is only part of the story — local project and per-user skills are loaded too.
+
+A skill may declare `capabilities: [...]` in its frontmatter. Activating the skill auto-loads those capabilities; `skill(action="forget", …)` offloads them (refcount-aware — a capability is only unloaded when no remaining active skill needs it) and triggers compression.
 
 ### Skill Structure
 
@@ -158,19 +177,61 @@ skill(action="forget", name="code-review")
 
 When activated, the skill's `SKILL.md` is injected into context, and a resource catalog lists all available scripts, references, and assets with absolute paths.
 
-## Dependencies
+## Manifest Placeholders
 
-Agent manifests can declare dependencies:
+Tap manifests may embed three placeholder forms, resolved during the [resolution pipeline](#from-the-cli) (INPUT, then ENV, then deps run, before MCP init). Escape any literal you do not want substituted by doubling the braces (`{{{{INPUT:KEY}}}}`).
+
+- **`{{INPUT:KEY}}`** — persistent value store. Prompted from the user **once**, then saved to `~/.local/share/octomind/inputs.toml` and reused on every later run. Use it for credentials/IDs you want to enter a single time. (In a non-interactive subagent, a missing INPUT surfaces as a structured error instead of blocking on stdin.)
+- **`{{ENV:KEY}}`** — environment variable. If `KEY` is set (and non-empty) it is used directly; otherwise the user is prompted and the value is appended to `./.env` in the current directory (loaded automatically next run) and set in the current process.
+- **`{{CWD}}`** — the runtime current working directory (resolved by the prompt-placeholder layer, e.g. inside a role `system` prompt).
 
 ```toml
-dependencies = ["octocode", "octofs"]
+# In an agent manifest (in the tap repo)
+[[roles]]
+system = "Project root: {{CWD}}. Use the API at https://api.example.com."
+
+[[roles.mcp.servers]]
+name = "example"
+# Token prompted once and stored; API base read from env / .env
+args = ["--token", "{{INPUT:EXAMPLE_TOKEN}}", "--url", "{{ENV:EXAMPLE_API_URL}}"]
 ```
 
-Dependencies are resolved and installed automatically on first run.
+## Dependencies (`[deps]`)
 
-## Capability Overrides
+Agent manifests (and capability provider files) declare external tool dependencies under `[deps] require`:
 
-Taps provide capability implementations. Override which provider is used:
+```toml
+# In an agent manifest or capability provider .toml (in the tap repo)
+[deps]
+require = ["astral-sh/uv", "muvon/octocode"]
+```
+
+Each entry is an `org/tool` string that maps to a script at `<tap_root>/deps/<org>/<tool>.sh` (e.g. `astral-sh/uv` → `deps/astral-sh/uv.sh`). A flat name like `octocode` would look for `deps/octocode.sh` and fail. The scripts:
+
+- Run in order, via `bash`, **on every resolution** of a `category:variant` tag (not just the first run) — they must be **idempotent**: exit `0` immediately if the tool is already installed, non-zero to abort.
+- Run **after** `{{INPUT}}`/`{{ENV}}` placeholder resolution and **before** MCP initialization.
+- Execution contract: stdin is null, stdout is suppressed (reserved for Octomind), stderr is captured and reported in the error message on failure; exit `0` = ok, non-zero = abort with an error.
+
+## Capabilities
+
+A capability in a tap is **two files**, not one:
+
+```
+capabilities/
+  codesearch/
+    config.toml      # REQUIRED: triggers = [...]; optional domains = [...]
+    default.toml     # default provider wiring
+    octocode.toml    # alternate provider
+```
+
+- **`config.toml`** is mandatory and carries capability-level metadata shared across all providers:
+  - `triggers = [...]` — **required and non-empty**. Short phrases a user might write that activate the capability; they drive the deterministic auto-activation (semantic) routing layer. A capability with no `triggers` is rejected at load.
+  - `domains = [...]` — optional. **Empty means universal** (available to every role). When non-empty, it hard-gates the capability to roles whose domain part matches (`developer:general` → `"developer"`). The gate applies everywhere — auto-activation, `capability list`/`discover`/`enable`, and `OCTOMIND_CAPABILITIES` — with no bypass.
+- **`<provider>.toml`** carries the provider-specific wiring: `[deps]`, `[roles.mcp]` `server_refs`/`allowed_tools`, and `[[mcp.servers]]`.
+
+### Provider Overrides
+
+Override which provider file is used for a capability in your config:
 
 ```toml
 # In config.toml
@@ -178,16 +239,40 @@ Taps provide capability implementations. Override which provider is used:
 codesearch = "octocode"
 ```
 
-This maps to `capabilities/codesearch/octocode.toml` within the tap, allowing different implementations of the same capability.
+This selects `capabilities/codesearch/octocode.toml` within the tap, allowing different implementations of the same capability (the default is `default.toml`).
 
 ## Storage
 
-Taps are stored in `~/.local/share/octomind/taps/`:
+Taps are stored under `~/.local/share/octomind/taps/`. A tap named `user/repo` lives at `taps/<user>/octomind-<repo>/` — the first path segment is the username, and every repo directory is prefixed with `octomind-`:
 
 ```
 taps/
-  user/
-    myorg-my-agents/     # Git clone or symlink
+  myorg/
+    octomind-my-agents/   # git clone or symlink (tap myorg/my-agents)
   muvon/
-    octomind-tap/        # Built-in default
+    octomind-tap/         # built-in default (muvon/tap)
 ```
+
+GitHub taps clone from `github.com/<user>/octomind-<repo>` (note the `octomind-` prefix on the repo name) and are `git pull`ed each time taps load. Local taps are live symlinks (edits are picked up immediately). The default `muvon/tap` is auto-cloned on first use.
+
+### Manifest Caching
+
+Fetched agent manifests are cached separately from the tap repos, at:
+
+```
+~/.local/share/octomind/agents/<category>/<variant>.toml
+```
+
+Cache lifetime is controlled by `[registry] cache_ttl_hours` in your config (default `24`):
+
+```toml
+# In config.toml
+[registry]
+cache_ttl_hours = 24
+```
+
+When a cached manifest is **fresh**, it is used directly. When it is **stale-but-present**, the cached copy is returned immediately and refreshed in the background — so an edit to a tap manifest may take one run to appear. When there is no cache, the manifest is fetched synchronously from the taps (first-wins) and written to the cache.
+
+Persisted `{{INPUT:KEY}}` answers live alongside the cache in `~/.local/share/octomind/inputs.toml`.
+
+> A `category:variant@version` tag is accepted (the `@version` segment is parsed) but currently unused — version pinning is not yet enforced.

--- a/doc/reference/01-cli-reference.md
+++ b/doc/reference/01-cli-reference.md
@@ -2,21 +2,63 @@
 
 Complete reference for all `octomind` CLI commands and flags.
 
-## `octomind run [TAG] [MESSAGE]`
+## Synopsis
+
+```bash
+octomind <COMMAND> [OPTIONS]
+```
+
+A subcommand is **required** — running bare `octomind` prints a usage error. There is no default action.
+
+| Command | Purpose |
+|---------|---------|
+| `run` | Start an interactive or non-interactive AI session (the main command). |
+| `server` | Start a WebSocket server for remote sessions. See [WebSocket Server](../integration/01-websocket-server.md). |
+| `acp` | Run as an Agent Client Protocol agent over stdio for editor integration. See [ACP Protocol](../integration/02-acp-protocol.md). |
+| `config` | Create, validate, display, or upgrade configuration. See [Config Reference](03-config-reference.md). |
+| `tap` | Add a registry tap (agent source) or list active taps. |
+| `untap` | Remove a previously added tap. |
+| `vars` | Show placeholder variables and their resolved values. |
+| `send` | Inject a message into a running named session. |
+| `workflow` | Run a multi-step workflow defined in a TOML file. See [Workflows](../usage/09-workflows.md). |
+| `completion` | Generate shell completion scripts. |
+
+The global config file lives at `~/.local/share/octomind/config/config.toml` on macOS and Linux
+(`%LOCALAPPDATA%\octomind\config\config.toml` on Windows). Override the path with `OCTOMIND_CONFIG_PATH`.
+
+### TAG resolution
+
+`run`, `server`, and `acp` take an optional `TAG`:
+
+- A **role name** (e.g. `developer`) — matched against `[[roles]]` in your config.
+- A **registry agent tag** in `category:variant` form (e.g. `developer:general`) — resolved through your installed [taps](../integration/04-tap-system.md).
+- Omitted — uses the default role from config.
+
+Model selection priority, highest first: `--model` (CLI) > the role/agent `model` field > root `config.model`. For a `role:tag` registry agent, a `[taps]` entry overrides the `config.model` tier.
+
+## `octomind run [TAG]`
 
 Start an interactive or non-interactive AI session.
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `TAG` | | Agent tag or role name (e.g., `developer`, `octomind:assistant`). Uses `default` from config if omitted. |
+| `TAG` | | Role name (e.g. `developer`) or registry agent tag `category:variant` (e.g. `developer:general`). Uses the default role from config if omitted. |
 | `--name` | `-n` | Named session identifier |
 | `--resume` | `-r` | Resume a specific session by name |
-| `--resume-recent` | | Resume the most recent session |
-| `--format` | | Output format: `plain` (default for pipe), `jsonl` (structured JSON Lines) |
+| `--resume-recent` | | Resume the most recent session for the current directory |
+| `--format` | | Output format: `plain` or `jsonl`. Unset by default — see note below. |
 | `--model` | `-m` | Override model (`provider:model` format) |
-| `--daemon` | | Daemon mode: stay alive after message, accept injected messages |
-| `--sandbox` | | Restrict filesystem writes to working directory |
-| `--hook` | | Activate webhook hook(s) by name. Can be specified multiple times. |
+| `--daemon` | | Keep the session alive for injected messages. Implies non-interactive mode — pair with `--format` (e.g. `--format jsonl`) and deliver messages with `octomind send`. |
+| `--sandbox` | | Restrict filesystem writes to the working directory. See [Sandbox](#sandbox). |
+| `--hook` | | Activate webhook hook(s) by name (defined in `[[hooks]]` config). Repeatable. See [Daemon & Hooks](../integration/03-daemon-and-hooks.md). |
+
+**Interactivity and `--format`:** `--format` is unset by default. If it is omitted and stdin is a TTY, the
+session runs **interactively**. If `--format` is given (`plain` or `jsonl`) **or** stdin is piped, the session
+runs **non-interactively**, reading the input from stdin. Internally, an unset format resolves to `plain`.
+
+**Daemon mode:** `--daemon` is non-interactive and effectively requires `--format` — when a daemon is launched
+attached to a terminal, the piped input is forced empty. While the session is alive, inject further messages with
+[`octomind send --name <name>`](#octomind-send). See [Daemon & Hooks](../integration/03-daemon-and-hooks.md).
 
 **Examples:**
 ```bash
@@ -26,8 +68,8 @@ octomind run
 # Interactive with specific role
 octomind run developer
 
-# Tap agent
-octomind run octomind:developer
+# Registry agent (category:variant)
+octomind run developer:general
 
 # Non-interactive: pipe message via stdin
 echo "Explain the auth module" | octomind run developer --format plain
@@ -52,10 +94,10 @@ Start a WebSocket server for remote AI sessions.
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `TAG` | | Agent tag or role name |
+| `TAG` | | Role name or registry agent tag `category:variant` |
 | `--host` | | Bind address (default: `127.0.0.1`) |
 | `--port` | `-p` | Port (default: `8080`) |
-| `--sandbox` | | Restrict filesystem writes to working directory |
+| `--sandbox` | | Restrict filesystem writes to the working directory. See [Sandbox](#sandbox). |
 
 **Examples:**
 ```bash
@@ -70,13 +112,13 @@ Run as Agent Client Protocol agent over stdio (for editor integration).
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `TAG` | | Agent tag or role name |
+| `TAG` | | Role name or registry agent tag `category:variant` |
 | `--name` | `-n` | Session name (used when client creates a session) |
 | `--resume` | `-r` | Resume a specific session by name |
 | `--resume-recent` | | Resume the most recent session |
 | `--model` | `-m` | Override model (`provider:model` format) |
-| `--sandbox` | | Restrict filesystem writes to working directory |
-| `--hook` | | Activate webhook hook(s) by name. Can be specified multiple times. |
+| `--sandbox` | | Restrict filesystem writes to the working directory. See [Sandbox](#sandbox). |
+| `--hook` | | Activate webhook hook(s) by name. Repeatable. |
 
 **Examples:**
 ```bash
@@ -120,8 +162,11 @@ Show all placeholder variables and their current values.
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--preview` | `-p` | Show preview of placeholder values (3 lines) |
+| `--preview` | `-p` | Show a short preview (up to 3 lines) of each placeholder value |
 | `--expand` | `-e` | Show full expanded values for placeholders |
+
+With no flag, `vars` runs in **list** mode (names + descriptions). If both flags are given, `--expand`
+takes precedence over `--preview`.
 
 ```bash
 octomind vars
@@ -129,11 +174,21 @@ octomind vars --preview
 octomind vars --expand
 ```
 
-Displays: `{{CWD}}`, `{{ROLE}}`, `{{DATE}}`, `{{SHELL}}`, `{{OS}}`, `{{BINARIES}}`, `{{GIT_STATUS}}`, `{{README}}`, etc.
+Displays the placeholder set `octomind vars` reports: `{{DATE}}`, `{{SHELL}}`, `{{OS}}`, `{{BINARIES}}`, `{{CWD}}`,
+`{{HOME}}`, `{{SYSTEM}}` (complete system info), `{{CONTEXT}}` (README + git status + git tree),
+`{{GIT_STATUS}}`, `{{GIT_TREE}}`, and `{{README}}`. (`{{ROLE}}` is substituted in role prompts but is **not** among the values `vars` lists.)
 
 ## `octomind send`
 
-Send a message to a running daemon session by name.
+Inject a message into a running named session.
+
+Works against any running session that has started its inject listener (typically a session launched with
+`--daemon`, but not exclusively). The message reaches the session over a per-OS transport:
+
+- **Unix:** a Unix domain socket at `<run_dir>/<name>.sock` (run dir is `~/.local/share/octomind/run/`).
+- **Windows:** a named pipe `\\.\pipe\octomind-<name>`.
+
+The session replies `ok` on successful delivery; any other reply is treated as an error and reported.
 
 | Flag | Short | Description |
 |------|-------|-------------|
@@ -147,26 +202,59 @@ octomind send --name ci-watcher "Check build status"
 
 ## `octomind config [OPTIONS]`
 
-Generate, validate, or display configuration.
+Create, validate, display, or upgrade configuration. With no flags, see the example note below.
+
+**Mutating flags** (apply changes, then save the config file):
 
 | Flag | Description |
 |------|-------------|
-| `--model` | Set root-level model (`provider:model` format) |
-| `--api-key` | Set API key (`provider:key` format) |
-| `--log-level` | Set log level |
-| `--mcp-providers` | Set MCP providers |
-| `--mcp-server` | Add/configure MCP server |
-| `--system` | Set custom system prompt (or `default` to reset) |
-| `--markdown-enable` | Enable/disable markdown rendering |
-| `--markdown-theme` | Set markdown theme |
-| `--list-themes` | List available markdown themes |
-| `--show` | Display current configuration with defaults |
-| `--validate` | Validate configuration without making changes |
-| `--upgrade` | Upgrade config file to latest version |
+| `--model` | Set root-level model (`provider:model` format). |
+| `--log-level <none\|info\|debug>` | Set the log level (case-insensitive); any other value errors. |
+| `--mcp-providers <a,b,c>` | **Replace** the MCP server list: clears all configured servers, then adds each named one as a `builtin` server (timeout 30s). |
+| `--mcp-server <name,key=value,...>` | Add or update one MCP server. See [format](#--mcp-server-format) below. |
+| `--system` | Set a custom system prompt, or pass `default` to reset to the built-in prompt. |
+| `--markdown-enable` | Enable or disable markdown rendering. |
+| `--markdown-theme` | Set the markdown theme (must be one of the themes from `--list-themes`). |
+
+**Inspect / maintenance flags** (no save):
+
+| Flag | Description |
+|------|-------------|
+| `--show` | Display the current configuration with all defaults filled in. |
+| `--validate` | Validate the configuration without making changes. |
+| `--list-themes` | List the available markdown themes. |
+| `--upgrade` | Upgrade the config file to the latest schema version. |
+
+**Note on `--api-key`:** the parser accepts an `--api-key provider:key` argument, but it is **always rejected** at
+runtime — API keys can never be stored in the config file for security reasons. Set the provider's environment
+variable instead, e.g. `export OPENROUTER_API_KEY=...`. See the [Config Reference](03-config-reference.md) for the
+full list of provider environment variables.
+
+#### `--mcp-server` format
+
+`--mcp-server name,key=value,...` — the first comma-separated token is the server name; the rest are `key=value`
+pairs:
+
+| Key | Meaning |
+|-----|---------|
+| `type` | `http`, `stdio`, or `builtin` (default `http`). |
+| `url` | Endpoint URL — **required** for `http`. |
+| `command` | Executable to launch — **required** for `stdio`. |
+| `args` | Space-separated arguments for a `stdio` command. |
+| `timeout` / `timeout_seconds` | Request timeout in seconds (default `30`). |
+
+```bash
+# HTTP server
+octomind config --mcp-server "search,url=http://localhost:9000,timeout=60"
+
+# stdio server
+octomind config --mcp-server "files,type=stdio,command=octofs,args=--root ."
+```
 
 **Examples:**
 ```bash
-# Generate default config
+# Create a default config (only if none exists; otherwise reports
+# the current state with no changes — it does NOT regenerate).
 octomind config
 
 # Show current settings
@@ -186,9 +274,12 @@ Run a multi-step workflow defined in a TOML file.
 | Flag | Short | Description |
 |------|-------|-------------|
 | `FILE` | | Path to workflow TOML file (required) |
-| `--dry-run` | | Validate and print execution plan without spawning processes |
+| `--dry-run` | | Validate and print the execution plan without running any steps |
 
-Reads input from stdin. Per-step progress, cost, and token stats go to stderr. The final step's output goes to stdout.
+Reads input from stdin. **All** output — per-step assistant responses, progress, cost, and token stats — is
+written to **stderr**. **stdout** receives output only for `--dry-run` (the execution plan); the workflow itself
+produces no stdout result stream. To capture a step's text, consume stderr (e.g. `2>flow.log`). See
+[Workflows](../usage/09-workflows.md).
 
 ```bash
 echo "build a JSON-to-CSV CLI in Rust" | octomind workflow myflow.toml
@@ -210,9 +301,19 @@ Generate shell completion scripts.
 | Fish | `octomind completion fish > ~/.config/fish/completions/octomind.fish` |
 | PowerShell | `octomind completion powershell > octomind.ps1` |
 
+Dynamic agent-tag completion for `octomind run <TAB>` is injected only into the **bash**, **zsh**, and **fish**
+scripts (they call an internal `octomind complete` helper at completion time). PowerShell and Elvish scripts are
+emitted as-is and provide static completion only.
+
+## Sandbox
+
+When enabled, the sandbox restricts all filesystem writes to the current working directory (Landlock on Linux,
+Seatbelt on macOS). It is active if **either** the config `sandbox` setting **or** the `--sandbox` flag is set, and
+it applies only to `run`, `server`, and `acp` — all other subcommands ignore both.
+
 ## Global Flags
 
-| Flag | Description |
-|------|-------------|
-| `--help` | Show help |
-| `--version` | Show version |
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--help` | `-h` | Show help |
+| `--version` | `-V` | Show version |

--- a/doc/reference/02-session-commands.md
+++ b/doc/reference/02-session-commands.md
@@ -1,20 +1,55 @@
 # Session Commands Reference
 
-All commands available within an interactive Octomind session. Type the command at the prompt.
+All interactive session commands. Type the command at the prompt. There are 25 distinct commands; the autocomplete list also includes the aliases `/quit` (= `/exit`) and `/?` (a non-functional help alias — see [`/help`](#help)). To discover commands at runtime, type `/help`, which lists the built-ins plus any custom `/run` commands defined in your config.
+
+## Command Summary
+
+| Command | Purpose |
+|---------|---------|
+| `/help` | List all commands (built-ins plus custom `/run` commands) |
+| `/exit` (`/quit`) | Exit the session |
+| `/clear` | Clear the terminal screen |
+| `/list [PAGE]` | List saved sessions |
+| `/session [NAME]` | Create a new session, or switch to/create one by name |
+| `/info` | Show session statistics (tokens, cost, cache, compression) |
+| `/report` | Detailed per-request usage report |
+| `/share` | Upload the session log and print a permanent share URL |
+| `/analyze` | Open the session in the web viewer locally, without uploading |
+| `/copy` | Copy the last assistant response to the clipboard |
+| `/model [MODEL]` | Show or switch the model (runtime + session file) |
+| `/role [ROLE]` | Show or switch the role |
+| `/effort [LEVEL]` | Show or set reasoning effort (runtime + session file) |
+| `/loglevel [LEVEL]` | Set the log level (runtime only) |
+| `/context [FILTER]` | Inspect the conversation context |
+| `/done` | Force-compress context and extract lessons |
+| `/image [PATH]` | Attach an image (from path or clipboard) |
+| `/video [PATH]` | Attach a video |
+| `/mcp [ACTION]` | Inspect MCP servers and tools |
+| `/run [COMMAND]` | Run a custom command from `[[commands]]` config |
+| `/prompt [NAME]` | Inject a prompt template from `[[prompts]]` config |
+| `/plan [show]` | Show the current structured plan |
+| `/skill [NAME\|PAGE\|PATTERN]` | List or toggle skills |
+| `/schedule [SUBCOMMAND]` | Schedule a future/recurring injected message |
+| `/learning [ACTION]` | Manage cross-session lessons |
 
 ## Session Management
 
 ### `/help`
-Show all available commands with descriptions.
+Show all available commands with descriptions, including any custom `/run` commands from your config.
+
+> **Note:** `/?` appears in autocomplete but is **not wired into the command dispatcher** — typing it sends `?` to the model as user input. Only `/help` shows help.
 
 ### `/exit` / `/quit`
-Exit the current session.
+Exit the current session. `/quit` is an alias of `/exit`.
 
 ### `/list [PAGE]`
 List all saved sessions. Optional page number for pagination.
 
 ### `/session [NAME]`
-Switch to a different session by name. Without argument, shows current session info.
+- `/session` (no argument) creates a **new** session named `session_<unix_timestamp>`.
+- `/session <name...>` switches to a session with the given name, creating it if it does not exist. The name may contain spaces (all arguments are joined).
+
+This command does **not** display current session info — use [`/info`](#info) for that.
 
 ### `/clear`
 Clear the terminal screen.
@@ -72,7 +107,7 @@ port   127.0.0.1:<port> (loopback only)
 Use `/analyze` for ephemeral, private review of an in-flight session; use `/share` when you want a permanent link to send to someone else.
 
 ### `/model [MODEL]`
-Show or change the current model. Without argument, displays current model. With argument, switches to specified model in `provider:model` format.
+Show or change the current model. Without argument, displays the current model. With argument, switches to the specified model in `provider:model` format. The change is **runtime + saved to the session file** — it does not modify your global config.
 
 ```
 /model openai:gpt-4o
@@ -80,14 +115,23 @@ Show or change the current model. Without argument, displays current model. With
 ```
 
 ### `/role [ROLE]`
-Show or change the current role. Without argument, displays current role.
+Show or change the current role. Without argument, displays the current role.
+
+The argument is either:
+- a **plain role name** defined in your config's `[[roles]]` (validated up front; an unknown name is rejected with `Invalid role`), or
+- a **tap agent tag** in `domain:spec` form (e.g. `developer:general`), which resolves the manifest, INPUT/ENV placeholders, and dependency scripts.
+
+On success the session is saved; on failure the previous role/model/temperature are reverted.
 
 ```
 /role assistant
-/role developer
+/role developer:general
 ```
+
+> The default config ships the roles `assistant`, `task_refiner`, `task_researcher`, and `reduce`. There is no built-in `developer` role — `developer:general` above is a tap agent tag.
+
 ### `/effort [LEVEL]`
-Show or change the reasoning effort level. Without argument, displays current level. With argument, sets the effort to one of: `low`, `medium`, `high`, `xhigh`, `max`.
+Show or change the reasoning effort level. Without argument, displays the current level. With argument, sets the effort to one of: `low`, `medium`, `high`, `xhigh`, `max`. The change is **saved to the session file** (not global config) and is ignored by non-thinking models.
 
 ```
 /effort high
@@ -95,7 +139,7 @@ Show or change the reasoning effort level. Without argument, displays current le
 ```
 
 ### `/loglevel [LEVEL]`
-Change the log level. Options: `none`, `info`, `debug`.
+Change the log level. Options: `none`, `info`, `debug`. This is **runtime-only** — it is never written to disk.
 
 ```
 /loglevel debug
@@ -109,7 +153,10 @@ View session context (message history). Filters:
 - `assistant` -- Only assistant messages
 - `user` -- Only user messages
 - `tool` -- Only tool calls and results
-- `large` -- Only messages exceeding a token threshold
+- `system` -- Only system messages
+- `large` -- Only messages whose content exceeds 1000 bytes
+
+An unrecognized filter value silently falls back to `all`.
 
 ```
 /context
@@ -117,24 +164,28 @@ View session context (message history). Filters:
 /context large
 ```
 
+## Lifecycle
+
 ### `/done`
-Mark the current task as complete. Triggers:
-- Plan completion (if a plan is active)
-- Force context compression (preserves only env-loaded skills, drops manually activated ones)
-- Lesson extraction and storage (when `[learning]` is enabled — see [Learning Guide](../usage/13-learning.md))
+Force-compress the conversation context **bypassing all automatic threshold, cooldown, and cost guards**, then (when `[learning].enabled`) spawn fire-and-forget lesson extraction. Use it to manually reclaim context after finishing a unit of work.
+
+- The forced compression preserves only env-loaded skills, dropping manually activated ones.
+- Lesson extraction runs in the background and stores lessons for the current role + project — see [Learning Guide](../usage/13-learning.md).
+- It does **not** touch any active plan, write to memory, or auto-commit.
 
 ## Media
 
-### `/image <PATH>`
-Attach an image for AI analysis. Supports PNG, JPEG, GIF, WebP.
+### `/image [PATH]`
+Attach an image for AI analysis. With a path, attaches the image file at that path; without a path, attaches an image from the clipboard (no-op if the clipboard holds no image). Requires a vision-capable model.
 
 ```
 /image screenshot.png
 /image /path/to/diagram.jpg
+/image            # attach from clipboard
 ```
 
-### `/video <PATH>`
-Attach a video for AI analysis.
+### `/video [PATH]`
+Attach a video for AI analysis. A path is required — invoking `/video` with no argument is a no-op.
 
 ```
 /video demo.mp4
@@ -145,24 +196,28 @@ Copy the last assistant response to the clipboard.
 
 ## MCP & Tools
 
-### `/mcp [ACTION] [ARGS]`
-Manage MCP servers at runtime.
+### `/mcp [ACTION]`
+Inspect MCP servers and their tools. The session `/mcp` command is **read-only**; it has exactly these six subcommands:
 
 | Action | Description |
 |--------|-------------|
-| `/mcp` or `/mcp list` | List all MCP servers with status |
-| `/mcp info` | Detailed server information |
-| `/mcp health` | Force health check on all servers |
-| `/mcp validate` | Validate MCP configuration |
-| `/mcp add <name> <url>` | Add HTTP server dynamically |
-| `/mcp enable <name>` | Enable a registered server |
-| `/mcp disable <name>` | Disable a server |
-| `/mcp remove <name>` | Remove a server |
+| `/mcp` or `/mcp info` | Default: server status plus tools with short descriptions |
+| `/mcp list` | Tool names grouped by server |
+| `/mcp full` | Full tool details, including parameters |
+| `/mcp health` | Force a health check on all servers |
+| `/mcp dump` | Dump all tools with name, description, and parameter schemas |
+| `/mcp validate` | Validate tool parameter schemas |
+
+Any other subcommand returns `Invalid MCP subcommand`.
+
+> Runtime server management — adding, enabling, disabling, or removing servers — is done by the `mcp` **MCP tool** (which the model can call), not by this slash command.
 
 ## Commands
 
 ### `/run [COMMAND]`
-Execute a custom command defined in `[[commands]]` config section. Without argument, lists available commands.
+Execute a custom command defined in the `[[commands]]` config section. Without argument, lists available commands.
+
+Before executing, `/run` checks both the **session** and **request** spending thresholds; if either is breached (or the check itself errors), execution is declined.
 
 ```
 /run reduce
@@ -171,7 +226,7 @@ Execute a custom command defined in `[[commands]]` config section. Without argum
 
 > **Multi-step workflows** are no longer a session command. Use the external CLI instead: `octomind workflow <file.toml>` — see [Workflows](../usage/09-workflows.md).
 ### `/prompt [NAME]`
-Inject a prompt template defined in `[[prompts]]` config section. Without argument, lists available prompts.
+Inject a prompt template defined in the `[[prompts]]` config section into the session inbox; it is delivered **verbatim** as a user message on the next loop iteration. Without argument, lists available prompts. There is currently no template variable substitution.
 
 ```
 /prompt review
@@ -188,7 +243,7 @@ Manage the structured task plan.
 
 **Note**: The `/plan` slash command only displays the current plan. To create, modify, or clear a plan, use the `plan` MCP tool directly with these commands:
 
-- `plan(command="start", title="...", tasks=[...])` — Create a new plan
+- `plan(command="start", content="<plan goal/title>", tasks=[{title, description}, ...])` — Create a new plan. The plan title comes from `content` (defaults to `Active Plan` if omitted); each task object requires non-empty `title` and `description`.
 - `plan(command="next", content="...")` — Mark current task complete, advance to next
 - `plan(command="step", content="...")` — Add progress note to current task
 - `plan(command="reset")` — **Clear/reset the current plan**
@@ -198,8 +253,8 @@ Manage skills from taps. Skills are reusable instruction packs that inject domai
 
 | Usage | Description |
 |-------|-------------|
-| `/skill` | List all skills (active first, then alphabetical) |
-| `/skill <name>` | Toggle a skill on/off |
+| `/skill` | List all skills (active first, then alphabetical), 15 per page |
+| `/skill <name>` | Toggle the skill: enable it if inactive (`use`), disable it if active (`forget`). Unknown names return `Skill not found`. |
 | `/skill <page>` | Show page N of the skill list |
 | `/skill *pattern*` | Filter skills by glob pattern |
 
@@ -209,7 +264,7 @@ Direct control over the built-in `schedule` MCP tool — schedule a message to b
 | Usage | Description |
 |-------|-------------|
 | `/schedule` or `/schedule list` | List all pending entries with IDs, trigger times, and countdown |
-| `/schedule remove <id>` | Cancel a scheduled entry |
+| `/schedule remove <id>` | Cancel a scheduled entry (aliases: `rm`, `delete`, `del`) |
 | `/schedule add message="<text>"` | Schedule a one-shot for the next idle (default `when="idle"`) |
 | `/schedule add when="<when>" message="<text>" [every="<interval>"] [description="<label>"]` | Schedule a new entry |
 | `/schedule edit <id> [when="..."] [message="..."] [every="..."] [description="..."]` | Update an existing entry (use `every="none"` to clear a repeat) |
@@ -231,10 +286,22 @@ Examples:
 
 ### `/learning [ACTION]`
 
-Manage the cross-session learning system. See [Learning Guide](../usage/13-learning.md) for full details.
+Browse and manage the lessons stored for the current role + project by the cross-session learning system. See [Learning Guide](../usage/13-learning.md) for full details.
 
 | Usage | Description |
 |-------|-------------|
-| `/learning` or `/learning status` | Show learning system status and statistics |
-| `/learning extract` | Force lesson extraction from current session |
-| `/learning inject` | Force inject relevant lessons into current session |
+| `/learning` or `/learning list` | List lessons for the current role + project, 15 per page |
+| `/learning list <page>` | Show page N of the lesson list |
+| `/learning list *pattern*` | Glob-filter lessons by content, title, or tags (combinable with a page number) |
+| `/learning delete <index>` | Delete the lesson at the 1-based `<index>` from the last list (aliases: `rm`, `remove`) |
+| `/learning clear` | Delete **all** lessons for the current role + project |
+
+Any other subcommand returns `unknown subcommand — use: list, delete, clear`.
+
+```
+/learning
+/learning list 2
+/learning list *commit*
+/learning delete 3
+/learning clear
+```

--- a/doc/reference/03-config-reference.md
+++ b/doc/reference/03-config-reference.md
@@ -11,25 +11,28 @@ All values shown match `config-templates/default.toml`. Fields marked **(require
 | `version` | u32 | `1` | Config version. Do not modify. Used for automatic upgrades. |
 | `log_level` | string | `"info"` | Logging verbosity: `"none"`, `"info"`, `"debug"` |
 | `model` | string | `"openrouter:anthropic/claude-sonnet-4"` | Default model in `provider:model` format |
-| `default` | string | `"assistant:concierge"` | Default tag when no TAG passed to `octomind run` |
+| `default` | string | `"assistant:concierge"` | Default tag when no TAG passed to `octomind run`. See note below. |
 | `max_tokens` | u32 | `16384` | Global max tokens for all operations |
 | `custom_instructions_file_name` | string | `"INSTRUCTIONS.md"` | File auto-loaded as user message in new sessions. Empty string to disable. |
 | `custom_constraints_file_name` | string | `"CONSTRAINTS.md"` | File appended to each request in `<constraints>` tags. Empty string to disable. |
 | `sandbox` | bool | `false` | Restrict filesystem writes to working directory. Also available as `--sandbox` CLI flag. |
 | `auto_capabilities` | bool | `true` | Enable automatic capability activation on user messages. Disable to require manual `capability(action="enable")` calls. |
+| `system` | string (optional) | _none_ | Legacy global system-prompt override. When set, it applies as a fallback system prompt for roles that define none. Shown commented-out in `default.toml`; prefer per-role `system` instead. |
+
+> **About the `default` value:** `"assistant:concierge"` is a **tap agent** addressed as `category:variant`, shipped by the built-in default tap `muvon/tap` (which resolves to the GitHub repo `github.com/muvon/octomind-tap`) — *not* a role defined in this config file. If you search this file for a `concierge` role you will not find one. A bare tag without a colon (e.g. `"developer"`) resolves against your local `[[roles]]`; a `category:variant` tag resolves against installed taps.
 
 ## Performance & Limits
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mcp_response_tokens_threshold` | u32 | `20000` | Hard limit on MCP response tokens. Responses truncated when exceeded. `0` = unlimited. |
-| `max_session_tokens_threshold` | u32 | `200000` | Max tokens per session before truncation. `0` = disabled. |
+| `mcp_response_tokens_threshold` | usize | `20000` | Hard limit on MCP response tokens. Responses truncated when exceeded. `0` = unlimited. |
+| `max_session_tokens_threshold` | usize | `200000` | Max tokens per session before truncation. Also acts as the **hard compression ceiling** and the denominator for context-pressure hints (see `[compression]`). `0` = disabled. Validation fails if `> 2,000,000`. |
 | `max_retries` | u32 | `1` | Retry attempts for API calls. |
 | `retry_timeout` | u32 | `30` | Base timeout in seconds for exponential backoff. |
 | `request_timeout_seconds` | u32 | `300` | Per-request HTTP timeout in seconds. Hard limit on LLM provider API calls. `0` = no timeout. |
-| `reasoning_effort` | enum | `"medium"` | Thinking model effort: `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`. Non-thinking models ignore it. |
-| `cache_keepalive_enabled` | bool | `false` | Keep prompt cache warm with periodic pings while session idles. Provider-aware (only pings providers that support refresh-on-read). |
-| `cache_keepalive_max_idle_seconds` | u64 | `1800` | Stop pinging this many seconds after last user activity. `0` = ping until session ends. |
+| `reasoning_effort` | enum | `"medium"` | Thinking model effort: `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`. Non-thinking models ignore it. Mirrored at runtime by the `/effort <level>` session command. |
+| `cache_keepalive_enabled` | bool | `false` | Keep prompt cache warm with periodic pings while the session idles. Provider-aware: currently **only Anthropic** is pinged, and the ping interval comes from the provider's cache TTL (1h), not from this config. |
+| `cache_keepalive_max_idle_seconds` | u64 | `1800` | Stop pinging this many seconds after last user activity. `0` = ping until session ends. Validation fails if `> 86400` (24h). |
 ## User Interface
 
 | Field | Type | Default | Description |
@@ -60,13 +63,12 @@ Map of tap agent tag to model override. Set a preferred model for specific tap a
 "octomind:assistant" = "openai:gpt-4o"
 ```
 
-**Priority:** CLI `--model` > taps override > role.model > config.model
-When you run `octomind run developer:general`, the model is resolved in this order:
+**Priority (highest wins):** CLI `--model` > the active role's `model` > root `config.model` (resolved in `src/session/chat/session/core.rs`). For a tap agent, a `[taps]` entry overrides the `config.model` tier:
 1. `--model` CLI flag (if provided)
-2. `[taps]` override for `"developer:general"` (if configured)
-3. Global `model` in config
+2. The `model` the agent's role/manifest declares (for `developer:general`, the manifest's role model)
+3. Global `model` in config — which a `[taps]` entry for `"developer:general"` replaces when set
 
-Empty by default. Only applies to tap agents (tags with `:`). Plain role names use role.model or config.model.
+`[taps]` only applies to tap agents (tags with `:`); it acts at the `config.model` tier, so it takes effect only when neither `--model` nor the agent's role sets a model. Plain role names use their `[[roles]]` `model` if set, otherwise `config.model`.
 
 ## `[[roles]]`
 
@@ -101,7 +103,7 @@ system = """
 You are helpful and knowledgeable assistant.
 Working directory: {{CWD}}
 """
-welcome = "Hello! Ready to help. Working in {{CWD}} (Role: {{ROLE}})"
+welcome = "Hello! Ready to code. Working in {{CWD}} (Role: {{ROLE}})"
 
 [roles.mcp]
 server_refs = ["core", "runtime", "filesystem", "agent"]
@@ -122,11 +124,13 @@ MCP server definitions. Three types supported: `builtin`, `http`, `stdio`.
 
 **Builtin servers** (always available, no external process):
 
-| `core` | `plan`, `tap` | High-level planning and agent management |
+| Server | Tools | Description |
+|--------|-------|-------------|
+| `core` | `plan`, `tap` | High-level planning and tap (agent registry) management |
 | `runtime` | `mcp`, `agent`, `skill`, `schedule`, `capability` | Harness reconfiguration and scheduling |
 | `agent` | `agent_<name>` per `[[agents]]` entry | ACP sub-agent dispatch |
 
-`filesystem` is no longer a builtin — it's an external `stdio` server backed by `octofs`. See [MCP Tools](../usage/07-mcp-tools.md) for the tool surface.
+> **`filesystem` is not declared here.** Default roles reference a `filesystem` server in their `server_refs`, but it is **not** a builtin and is **not** defined in this config file's `[[mcp.servers]]`. It is an external `stdio` server backed by `octofs`, provided by the built-in tap. Its tools are `view`, `text_editor`, `batch_edit`, `extract_lines`, `shell`, `ast_grep`, `list_files`, and `workdir`. See [MCP Tools](../usage/07-mcp-tools.md) for the full surface.
 
 #### Common Fields
 
@@ -134,7 +138,7 @@ MCP server definitions. Three types supported: `builtin`, `http`, `stdio`.
 |-------|------|----------|-------------|
 | `name` | string | yes | Unique server identifier |
 | `type` | string | yes | `"builtin"`, `"http"`, or `"stdio"` |
-| `timeout_seconds` | u32 | no | Response timeout (default: 30) |
+| `timeout_seconds` | u64 | no | Response timeout (default: 30) |
 | `tools` | string[] | no | Tool filter. Empty = all tools. Supports wildcards: `"github_*"` |
 | `auto_bind` | string[] | no | Role names to auto-include this server for |
 
@@ -163,7 +167,7 @@ Webhook HTTP listeners that pipe payloads through scripts and inject output into
 | `name` | string | required | Unique hook identifier |
 | `bind` | string | required | HTTP server address (e.g., `"0.0.0.0:9876"`) |
 | `script` | string | required | Path to executable script |
-| `timeout` | u32 | `30` | Script timeout in seconds (1-3600) |
+| `timeout` | u64 | `30` | Script timeout in seconds (1-3600) |
 
 ```toml
 [[hooks]]
@@ -185,10 +189,12 @@ Reusable ACP-invocable units used by `[[commands]]`. Layers delegate to roles vi
 | `name` | string | required | Layer identifier |
 | `description` | string | required | Human-readable description (used in help, MCP) |
 | `command` | string | required | ACP command to execute: `"octomind acp <role_name>"` |
-| `workdir` | string | `"."` | Working directory (relative to session workdir) |
-| `input_mode` | string | no | How input is fed: `"last"`, `"all"`, `"summary"` |
-| `output_mode` | string | no | How output affects session: `"none"`, `"append"`, `"replace"`, `"last"`, `"restart"` |
-| `output_role` | string | no | Role for output messages: `"assistant"`, `"user"` |
+| `workdir` | string | `"."` | Working directory (relative to session workdir). The only optional field. |
+| `input_mode` | string | **required** | How input is fed: `"last"`, `"all"`, `"summary"` |
+| `output_mode` | string | **required** | How output affects session: `"none"`, `"append"`, `"replace"`, `"last"`, `"restart"` |
+| `output_role` | string | **required** | Role for output messages: `"assistant"`, `"user"` |
+
+> `input_mode`, `output_mode`, and `output_role` have **no default** — config loading fails if any is omitted. Only `workdir` is optional.
 
 ```toml
 [[layers]]
@@ -202,17 +208,7 @@ output_role = "assistant"
 
 ## `[[commands]]`
 
-Custom session commands triggered with `/run <name>`. Uses the same schema as `[[layers]]`.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | string | required | Command identifier (used as `/run <name>`) |
-| `description` | string | required | Human-readable description (shown in help text) |
-| `command` | string | required | ACP command to execute: `"octomind acp <role_name>"` |
-| `workdir` | string | `"."` | Working directory (relative to session workdir) |
-| `input_mode` | string | no | How input is fed: `"last"`, `"all"`, `"summary"` |
-| `output_mode` | string | no | How output affects session: `"none"`, `"append"`, `"replace"`, `"last"`, `"restart"` |
-| `output_role` | string | no | Role for output messages: `"assistant"`, `"user"` |
+Custom session commands triggered with `/run <name>`. **Uses the exact same schema as `[[layers]]`** (same `LayerConfig` struct) — see the field table above, including the required `input_mode` / `output_mode` / `output_role` fields. The only difference is invocation: `[[commands]]` entries are run manually from a session via `/run <name>`, while `[[layers]]` are orchestration units invoked over ACP. For `[[commands]]`, `name` is the token you type after `/run`.
 
 ```toml
 [[commands]]
@@ -284,6 +280,8 @@ validation_timeout = 60
 max_retries = 3
 ```
 
+> **`auto_validation` scope:** this flag gates only the `validate` scripts declared inside `SKILL.md` files. It does **not** gate the separate guardrail `[[validator]]` system in `.agents/guardrails.toml` — those end-of-turn validators run unconditionally regardless of this setting.
+
 ## `[compression]`
 
 Automatic context compression system.
@@ -292,13 +290,16 @@ Automatic context compression system.
 |-------|------|---------|-------------|
 | `hints_enabled` | bool | `true` | Enable compression system |
 | `hints_pressure_threshold` | f64 | `0.7` | Context pressure threshold (0.0-1.0) to start showing hints |
-| `hints_min_interval` | u32 | `5` | Minimum tool executions between hints |
-| `knowledge_retention` | u32 | `10` | Max critical knowledge entries retained across compressions |
+| `hints_min_interval` | usize | `5` | Minimum tool executions between hints |
+| `knowledge_retention` | usize | `10` | Max critical knowledge entries retained across compressions |
+
+> **Disabling compression:** if `[[compression.pressure_levels]]` is empty, compression is disabled entirely and the compression-model validation is skipped. Independently, `max_session_tokens_threshold` (see Performance & Limits) acts as a hard token ceiling separate from these pressure levels.
 
 ### `[[compression.pressure_levels]]`
 
 | Field | Type | Description |
-| `threshold` | u64 | Token count threshold to trigger compression |
+|-------|------|-------------|
+| `threshold` | usize | Token count threshold to trigger compression |
 | `target_ratio` | f64 | Compression strength (2.0 = 50% reduction, 4.0 = 75%, 8.0 = 87.5%) |
 
 Default pressure levels:
@@ -320,7 +321,7 @@ Model used for compression decisions and summary generation.
 | `top_p` | f64 | `1.0` | Nucleus sampling |
 | `top_k` | u32 | `0` | Top-k (0 = disabled) |
 | `max_retries` | u32 | `1` | Retry attempts |
-| `retry_timeout` | u32 | `30` | Retry backoff base |
+| `retry_timeout` | u64 | `30` | Retry backoff base (seconds) |
 | `ignore_cost` | bool | `false` | When true, compression cost is not tracked |
 
 ```toml
@@ -362,8 +363,8 @@ Cross-session adaptive learning. Extracts lessons from sessions and injects them
 | `enabled` | bool | `true` | Enable the learning system |
 | `model` | string | `"anthropic:claude-haiku-4-5"` | Model for extraction and retrieval LLM calls |
 | `backend` | string | `"file"` | Backend: `"file"` or `"mcp"` |
-| `min_messages_for_intermediate` | u32 | `3` | Min user messages before intermediate learning triggers |
-| `max_inject` | u32 | `5` | Max lessons injected into system prompt |
+| `min_messages_for_intermediate` | usize | `3` | Min user messages before intermediate learning triggers |
+| `max_inject` | usize | `5` | Max lessons injected into system prompt |
 
 ### `[learning.store]` (MCP backend only)
 
@@ -388,9 +389,33 @@ min_messages_for_intermediate = 3
 max_inject = 5
 ```
 
+## `[registry]`
+
+Controls caching of agent manifests fetched from taps. Registry sources themselves are managed with `octomind tap <url> [path]` / `octomind untap <name>`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cache_ttl_hours` | u64 | `24` | How long a fetched tap manifest is cached before re-checking. |
+
+Fetched manifests are cached at `<data>/agents/<category>/<variant>.toml`. Within the TTL the cached manifest is served immediately; once stale, the cached copy is still served (stale-serve) while a background refresh fetches the latest version. See [Tap System](../integration/04-tap-system.md) for the registry behavior.
+
+```toml
+[registry]
+cache_ttl_hours = 24
+```
+
 ## Guardrails (`.agents/guardrails.toml`)
 
-Project-level guardrails are configured in `.agents/guardrails.toml` in the working directory, not in the main config file. See [Guardrails](../usage/18-guardrails.md) for full documentation.
+Project-level guardrails are configured in `.agents/guardrails.toml` in the working directory, **not** in the main config file. That file holds four distinct mechanisms — `[[guard]]`, `[[hook]]`, `[[validator]]`, and `[[pipe]]`. Only `[[pipe]]` is detailed below; see [Guardrails](../usage/18-guardrails.md) for the full reference.
+
+> **Do not confuse** the guardrail `[[hook]]` (a post-result script in `.agents/guardrails.toml`) with the top-level `[[hooks]]` config above (webhook HTTP listeners for daemon mode). They are entirely separate concepts.
+
+| Table | Purpose |
+|-------|---------|
+| `[[guard]]` | Pre-call deny rule — blocks a tool call before it runs. |
+| `[[hook]]` | Post-result script run after a tool call (`on = "success"` or `"failure"`). |
+| `[[validator]]` | End-of-turn script run on the new call-log slice (cursor-based), with optional role filter. Runs regardless of `[skills].auto_validation`. |
+| `[[pipe]]` | Pre-model input transform (detailed below). |
 
 ### `[[pipe]]` — Pre-Model Input Transform
 
@@ -438,7 +463,7 @@ This mechanism is used by the `mcp persist` command, which writes to `<config_di
 
 ## Template Variables
 
-Available in `system` and `welcome` fields:
+These variables are substituted in role `system` and `welcome` fields at prompt-expansion time:
 
 | Variable | Description |
 |----------|-------------|
@@ -451,6 +476,7 @@ Available in `system` and `welcome` fields:
 | `{{GIT_STATUS}}` | Git repository status |
 | `{{GIT_TREE}}` | Project file tree |
 | `{{README}}` | Contents of README.md in project root |
-| `{{HOME}}` | User's home directory path |
 | `{{CONTEXT}}` | Session context (for layers) |
 | `{{SYSTEM}}` | Parent system prompt (for layers) |
+
+> **`{{HOME}}` is not substituted here.** It is only resolved by the `octomind vars` command listing, not in `system`/`welcome` prompts. Using `{{HOME}}` in a role prompt leaves the literal text in place — use an absolute path or `{{CWD}}` instead.

--- a/doc/reference/04-environment-variables.md
+++ b/doc/reference/04-environment-variables.md
@@ -2,30 +2,78 @@
 
 ## API Keys
 
-All API keys are read from environment variables for security. Never put API keys in config files.
+All API keys are read from environment variables for security. **Never put API keys in config files** — the `octomind config --api-key provider:key` command is intentionally rejected at runtime ("API keys can no longer be set in config file for security reasons") and tells you to export the matching environment variable instead.
+
+Provider authentication is delegated to the underlying LLM layer (octolib). The tables below are a curated view of the most common providers; the [Providers guide](../usage/04-providers.md) documents the complete set. The general rule: **any provider prefix authenticates via its uppercased `<PREFIX>_API_KEY` environment variable** (for example, the `groq:` prefix reads `GROQ_API_KEY`).
+
+### Common providers
 
 | Variable | Provider | Description |
 |----------|----------|-------------|
-| `OPENROUTER_API_KEY` | OpenRouter | OpenRouter API key ([openrouter.ai](https://openrouter.ai/)) |
+| `OPENROUTER_API_KEY` | OpenRouter | OpenRouter API key ([openrouter.ai](https://openrouter.ai/)). Recommended one-key-many-models entry point. |
 | `OPENAI_API_KEY` | OpenAI | OpenAI API key ([platform.openai.com](https://platform.openai.com/)) |
 | `ANTHROPIC_API_KEY` | Anthropic | Anthropic API key ([console.anthropic.com](https://console.anthropic.com/)) |
 | `DEEPSEEK_API_KEY` | DeepSeek | DeepSeek API key ([platform.deepseek.com](https://platform.deepseek.com/)) |
-| `GOOGLE_APPLICATION_CREDENTIALS` | Google | Path to Google Cloud credentials JSON file |
-| `AWS_ACCESS_KEY_ID` | Amazon | AWS access key for Bedrock |
-| `AWS_SECRET_ACCESS_KEY` | Amazon | AWS secret key for Bedrock |
-| `AWS_REGION` | Amazon | AWS region for Bedrock |
-| `CLOUDFLARE_API_TOKEN` | Cloudflare | Cloudflare Workers AI token |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Google (Vertex) | Path to a Google Cloud service-account JSON file |
+| `GOOGLE_CREDENTIAL_FILE` | Google (Vertex) | Alternative path to the service-account JSON (tried first, preferred over `GOOGLE_APPLICATION_CREDENTIALS`) |
+| `GOOGLE_CLOUD_PROJECT_ID` | Google (Vertex) | GCP project ID used for Vertex routing |
+| `GOOGLE_CLOUD_LOCATION` | Google (Vertex) | Vertex region/location (used to build the endpoint) |
+| `AWS_BEARER_TOKEN_BEDROCK` | Amazon (Bedrock) | Bedrock service-specific API key. **These are NOT regular AWS access keys** — generate a Bedrock API key, not SigV4 credentials. |
+| `AWS_BEDROCK_REGION` | Amazon (Bedrock) | Bedrock region (defaults to `us-east-1` if unset) |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare (Workers AI) | Cloudflare Workers AI API token |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare (Workers AI) | Cloudflare account ID — **required** alongside `CLOUDFLARE_API_TOKEN`; the provider fails without it. |
 
-Octomind also loads `.env` files from the current directory via `dotenvy`. Variables in `.env` override system environment variables.
+### Additional providers
+
+Each of these authenticates with its own `<PREFIX>_API_KEY` variable:
+
+| Variable | Provider prefix | Notes |
+|----------|-----------------|-------|
+| `CEREBRAS_API_KEY` | `cerebras` | |
+| `GROQ_API_KEY` | `groq` | |
+| `TOGETHER_API_KEY` | `together` | |
+| `FIREWORKS_API_KEY` | `fireworks` | |
+| `NVIDIA_API_KEY` | `nvidia` | |
+| `MINIMAX_API_KEY` | `minimax` | |
+| `MOONSHOT_API_KEY` | `moonshot` | The `kimi` prefix is an alias for `moonshot`. |
+| `ZAI_API_KEY` | `zai` | |
+| `BYTEPLUS_API_KEY` | `byteplus` | |
+| `FEATHERLESS_API_KEY` | `featherless` | |
+| `OCTOHUB_API_KEY` | `octohub` | |
+| `OLLAMA_API_KEY` | `ollama` | Optional — local Ollama typically needs no key. |
+| `LOCAL_API_KEY` | `local` | Optional — for self-hosted OpenAI-compatible endpoints. |
+
+> The `cli:` meta-provider (for example `cli:codex/...`) runs a local CLI-backed model and requires **no API key** — credential validation is bypassed for `cli`.
+
+> Some providers also accept an OAuth token as an alternative to an API key: `OPENAI_OAUTH_ACCESS_TOKEN` + `OPENAI_OAUTH_ACCOUNT_ID` (OpenAI) and `ANTHROPIC_OAUTH_ACCESS_TOKEN` (Anthropic). When set, these are used in place of the matching `*_API_KEY`.
+
+### CLI meta-provider (`cli:`) backend variables
+
+The `cli:` provider shells out to a local coding-agent CLI, tuned via backend-specific variables. For the `codex` backend:
+
+| Variable | Description |
+|----------|-------------|
+| `CODEX_COMMAND` | Path/name of the CLI binary to invoke (default `codex`) |
+| `CODEX_REASONING_EFFORT` | Reasoning effort for the codex backend: `low`, `medium`, or `high` |
+| `CODEX_SKIP_GIT_CHECK` | Skip codex's git-repo safety check (`true`/`false`) |
+
+(The `CLI_CODEX_*` variants are also recognized.) See [Providers → Local CLI-backed models](../usage/04-providers.md).
+
+### Custom endpoints (API URL overrides)
+
+Most providers accept a `<PREFIX>_API_URL` variable to point at a custom or self-hosted endpoint, including `OPENROUTER_API_URL`, `OPENAI_API_URL`, `ANTHROPIC_API_URL`, `GOOGLE_API_URL`, `AWS_BEDROCK_API_URL`, and `CLOUDFLARE_API_URL`. Leave these unset to use each provider's default endpoint.
+
+Octomind also loads `.env` files from the current directory (see [.env File Support](#env-file-support) below). Variables in `.env` override system environment variables.
 
 ## Octomind Configuration
 
 | Variable | Description |
 |----------|-------------|
-| `OCTOMIND_CONFIG_PATH` | Override config directory path (default: `~/.local/share/octomind/config/`) |
+| `OCTOMIND_CONFIG_PATH` | Override the config **file** path used at load. The value is the path to the primary config TOML; its parent directory becomes the config directory for multi-file merge (all `*.toml` files there are merged). Default file: `~/.local/share/octomind/config/config.toml` (Linux/macOS) or `%LOCALAPPDATA%\octomind\config\config.toml` (Windows). |
 | `OCTOMIND_SKILLS` | Comma-delimited skill names to preload at session start (e.g., `programming-rust,git-workflow`). Skills are activated permanently without evaluating declarative rules. |
 | `OCTOMIND_CAPABILITIES` | Comma-delimited capability names to force-enable at session start (e.g., `cron,docker`). Bypasses the auto-activation embedding pipeline; capabilities are loaded deterministically regardless of intent matching. Already-active entries are no-ops. |
 | `OCTOMIND_SHARE_URL` | Base URL of the web viewer used by `/share` (upload endpoint) and `/analyze` (viewer link). Defaults to `https://octomind.run`. Override only when pointing at a self-hosted instance or a local dev server. |
+| `RUST_LOG` | Tracing filter (standard `tracing`/`env_logger` syntax, e.g. `RUST_LOG=debug` or `RUST_LOG=octomind=debug`). In CLI mode, setting it turns on the stderr tracing subscriber (unset = only the colored log macros, no tracing emitted). In ACP/WebSocket/daemon modes it overrides the `log_level`-derived filter for the per-mode debug log file. |
 
 ## Installation Script
 
@@ -40,14 +88,20 @@ Variables used by `install.sh` for automated/CI environments.
 
 ## OpenRouter-Specific
 
+These attribution headers control how OpenRouter identifies and ranks the app.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENROUTER_APP_TITLE` | `"Octomind"` | Application title sent to OpenRouter |
 | `OPENROUTER_HTTP_REFERER` | `"https://octomind.run"` | HTTP referer sent to OpenRouter |
 
+You normally do not set these yourself: Octomind auto-sets them to the listed defaults at startup (during the `.env` load step, which runs unconditionally even when no `.env` file is present) **only if they are not already defined**. Export your own value to override the default.
+
 ## Template Variables
 
-Available in `system` and `welcome` config fields. Use `octomind vars` to see current values.
+### Substituted in role `system` and `welcome` prompts
+
+These placeholders are resolved by the role prompt processor when a role's `system` or `welcome` text is rendered:
 
 | Variable | Description |
 |----------|-------------|
@@ -60,9 +114,16 @@ Available in `system` and `welcome` config fields. Use `octomind vars` to see cu
 | `{{GIT_STATUS}}` | Git repository status (branch, changes) |
 | `{{GIT_TREE}}` | Project file tree |
 | `{{README}}` | Contents of `README.md` in project root |
-| `{{HOME}}` | User's home directory path |
 | `{{CONTEXT}}` | Session context (for layer system prompts) |
 | `{{SYSTEM}}` | Parent system prompt (for layer system prompts) |
+
+### Shown only by `octomind vars`
+
+`octomind vars` lists current placeholder values for inspection. It exposes the prompt placeholders above **except** `{{ROLE}}` (which the role prompt processor substitutes but `vars` does not list), **plus** the following, which the role prompt processor does **not** substitute (placing `{{HOME}}` in a `system`/`welcome` field leaves it literal):
+
+| Variable | Description |
+|----------|-------------|
+| `{{HOME}}` | User's home directory path |
 
 ## Webhook Hook Environment Variables
 
@@ -80,7 +141,7 @@ Available to hook scripts when processing incoming webhooks.
 
 ## .env File Support
 
-Octomind automatically loads `.env` files from the working directory. This is useful for project-specific API keys:
+Octomind automatically loads a `.env` file from the working directory at startup, as an alternative to exporting variables in your shell. This is useful for project-specific API keys:
 
 ```bash
 # .env
@@ -88,4 +149,8 @@ OPENROUTER_API_KEY=sk-or-v1-...
 ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-The `EnvTracker` system tracks whether each variable came from the system environment or `.env` file, which can be seen in debug mode.
+Key behaviors:
+
+- **`.env` overrides the system environment.** When a variable is defined in both, the `.env` value wins.
+- **Empty values are treated as "not set."** A variable whose value is empty (or only whitespace) is reported as `NotFound` for API-key source detection — so leaving `OPENROUTER_API_KEY=` empty is the same as not defining it.
+- **Source tracking.** The `EnvTracker` records whether each variable came from the system environment (`System`) or the `.env` file (`DotEnv`); this source is shown in debug mode.

--- a/doc/troubleshooting/01-common-issues.md
+++ b/doc/troubleshooting/01-common-issues.md
@@ -31,16 +31,31 @@ Download the correct binary for your platform. Use `uname -m` to check:
 
 ### Key Not Found
 
+If a provider has no credentials, the run fails before the first request. You may
+see an error similar to (the exact wording comes from the provider layer):
+
 ```
-API key not found for provider 'openrouter'
+missing API key for provider 'openrouter'
 ```
 
-Set the environment variable:
+Set the matching environment variable. The general pattern is `<PROVIDER>_API_KEY`:
 ```bash
-export OPENROUTER_API_KEY="your_key"
+export OPENROUTER_API_KEY="your_key"   # openrouter
+export OPENAI_API_KEY="your_key"       # openai
+export ANTHROPIC_API_KEY="your_key"    # anthropic
+export DEEPSEEK_API_KEY="your_key"     # deepseek
 ```
 
-Add to shell profile for persistence. Or use a `.env` file in your project.
+A few providers use non-standard variables:
+- Google (Vertex): `GOOGLE_APPLICATION_CREDENTIALS` (path to a service-account JSON)
+- Amazon (Bedrock): `AWS_BEARER_TOKEN_BEDROCK` (a Bedrock service-specific API key — **not** standard AWS access keys / SigV4 credentials); set `AWS_BEDROCK_REGION` for non-`us-east-1` models
+- Cloudflare (Workers AI): `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
+
+For the full per-provider list see [Environment Variables](../reference/04-environment-variables.md).
+The `cli:` meta-provider (e.g. local CLI-backed models) needs no API key.
+
+Add to your shell profile for persistence, or use a `.env` file in your project
+(it is loaded from the current directory and overrides the process environment).
 
 Check current config:
 ```bash
@@ -49,8 +64,10 @@ octomind config --show
 
 ### Invalid Model Format
 
+Setting a model without a provider prefix is rejected, for example:
+
 ```
-Invalid model format. Expected 'provider:model'
+model must be in provider:model format (e.g., openrouter:anthropic/claude-3.5-sonnet)
 ```
 
 Always use `provider:model` format:
@@ -71,7 +88,14 @@ octomind config --validate
 Common issues:
 - Missing required fields (check against `config-templates/default.toml`)
 - Invalid TOML syntax (check brackets, quotes, commas)
-- Invalid field values (temperature > 2.0, negative thresholds)
+- Out-of-range field values. The validator enforces:
+  - role `temperature` between `0.0` and `2.0`
+  - role `top_p` between `0.0` and `1.0`
+  - role `top_k` between `1` and `1000`
+  - `max_session_tokens_threshold` at most `2,000,000` (`0` disables)
+  - `cache_keepalive_max_idle_seconds` at most `86400` (24h; `0` = unbounded)
+  - each MCP/webhook hook `timeout` between `1` and `3600` seconds
+  - `compression.decision.model` must resolve to a configured provider
 
 ### Config Not Loading
 
@@ -82,56 +106,106 @@ octomind config --show
 
 Default: `~/.local/share/octomind/config/config.toml`
 
-Override with:
+Octomind merges `config.toml` with every other `*.toml` file in the same
+directory (`mcp-*.toml` files are applied last as overrides), so a stray `.toml`
+left in that directory can change what gets loaded.
+
+Override the config file path (this is a full path to a `.toml` file, not a
+directory — its parent directory is then used to merge sibling `*.toml` files):
 ```bash
-export OCTOMIND_CONFIG_PATH="/custom/path/"
+export OCTOMIND_CONFIG_PATH="/custom/path/config.toml"
+```
+
+If the config was written by an older Octomind version, migrate it to the
+current schema:
+```bash
+octomind config --upgrade
 ```
 
 ## MCP Tools
 
 ### Tool Not Found
 
-Ensure the server is configured and the role has access:
+A tool is only available if its MCP server is configured *and* the active role
+references that server. The shipped config declares three built-in servers
+(`core`, `runtime`, `agent`); the `filesystem` server (the `octofs` companion)
+is provided by the default tap, not by a hand-written block. To confirm what is
+loaded, run `/mcp list` in a session.
+
+To wire up your own stdio server and grant a role access:
 
 ```toml
-# Server must be defined
+# Define the server (this stdio example is from default.toml)
 [[mcp.servers]]
-name = "filesystem"
+name = "octocode"
 type = "stdio"
-command = "octofs"
-timeout_seconds = 30
+command = "octocode"
+args = ["mcp", "--path=."]
+timeout_seconds = 240
 
-# Role must reference it
+# Reference it from an existing role (assistant ships in default.toml)
 [[roles]]
-name = "developer"
+name = "assistant"
 [roles.mcp]
-server_refs = ["core", "filesystem"]
-allowed_tools = ["core:*", "filesystem:*"]
+server_refs = ["core", "runtime", "filesystem", "agent", "octocode"]
+allowed_tools = ["core:*", "runtime:*", "filesystem:*", "agent:*", "octocode:*"]
 ```
+
+`server_refs` controls which servers the role can see; `allowed_tools` then
+filters individual tools. A server must appear in both to be usable.
 
 ### Server Not Responding
 
-Check health:
+Inspect the MCP layer. `/mcp` accepts these subcommands:
+`info` (the default), `list`, `full`, `health`, `dump`, and `validate`.
+
 ```
-/mcp health
+/mcp health     # connection status per server
+/mcp list       # confirm the server's tools are registered
+/mcp validate   # check tool parameter schemas
 ```
 
-Check logs:
+Turn on detailed logging to see startup/handshake errors:
 ```
 /loglevel debug
 ```
 
-For stdio servers, verify the command is on PATH:
+For stdio servers, verify the command is on PATH (substitute your server's
+binary):
 ```bash
-which octofs
+which octocode
 ```
 
 ### Tool Permission Denied
 
 Check `allowed_tools` in your role config. Patterns:
-- `"core:*"` -- all core tools
-- `"filesystem:view"` -- specific tool
-- `[]` -- all tools (no restrictions)
+- `"core:*"` -- all tools from the `core` server
+- `"filesystem:view"` -- one specific tool
+- `[]` -- empty list means no filtering (every tool from the referenced servers is allowed)
+
+## Taps and Agents
+
+### Agent Not Found
+
+Tap agents are addressed as `category:variant` (for example `developer:general`).
+If a tag is not found, list the taps that are active and confirm the category
+and variant exist:
+```bash
+octomind tap            # list active taps (no URL = list mode)
+```
+The built-in default tap (`muvon/tap`) is always present as the last fallback,
+so `developer:general` resolves out of the box. Add or remove taps with:
+```bash
+octomind tap <org>/<repo>     # add a tap (clones github.com/<org>/<repo>)
+octomind untap <name>         # remove a tap
+```
+
+### Manifest Placeholder Prompts
+
+The first time you run a tap agent, its manifest may prompt for `{{INPUT:KEY}}`
+values. Answers are persisted to `~/.local/share/octomind/inputs.toml` and reused.
+`{{ENV:KEY}}` placeholders read from the environment (with `.env` fallback), and
+`{{CWD}}` is the runtime working directory.
 
 ## Sessions
 
@@ -147,6 +221,12 @@ Resume by name:
 octomind run --resume my-session
 ```
 
+If you do not remember the name, resume the most recent session for the current
+working directory:
+```bash
+octomind run --resume-recent
+```
+
 ### High Token Usage
 
 Monitor with:
@@ -157,7 +237,7 @@ Monitor with:
 Reduce context:
 ```
 /done               # Force compression and start a fresh task boundary
-/run reduce         # Custom reduce command (if configured)
+/run reduce         # Built-in command: compress session history (ships in default.toml)
 ```
 Automatic compression also runs in the background once token thresholds are reached — see [Compression Guide](../usage/08-compression.md).
 
@@ -165,17 +245,57 @@ Enable automatic compression in config. See [Compression](../usage/08-compressio
 
 ### Spending Limit Hit
 
+When the cost since the last checkpoint crosses
+`max_session_spending_threshold`, Octomind warns and (interactively) prompts to
+continue. You may see output similar to:
+
 ```
-Session spending threshold exceeded
+⚠️  SPENDING THRESHOLD REACHED ⚠️
+Threshold: $5.00000
+Do you want to continue? (y/N):
 ```
+
+Declining prints `✗ Session cancelled by user due to spending threshold.`. In
+non-interactive mode the run auto-declines and stops with `Spending threshold
+reached but automatically declining in non-interactive mode. Stopping execution.`
 
 Adjust or disable:
 ```toml
-max_session_spending_threshold = 10.0   # Increase limit
-max_session_spending_threshold = 0.0    # Disable limit
+max_session_spending_threshold = 10.0   # Raise the limit
+max_session_spending_threshold = 0.0    # Disable the check (<= 0.0 disables)
+```
+
+### Cannot Send to a Running Session
+
+`octomind send -n NAME "message"` talks to a session over a Unix domain socket
+(`~/.local/share/octomind/run/<name>.sock`; a named pipe `\\.\pipe\octomind-<name>`
+on Windows). If you get an error like:
+
+```
+no running session named 'NAME' (socket not found ...)
+```
+
+the target session is not running, or you used the wrong name. The target must
+be a session started with `octomind run --daemon` (or a named interactive
+session). Note that `--daemon` implies non-interactive mode and therefore needs
+`--format` — a plain `octomind run --daemon` with no `--format` will not behave
+as a message-receiving daemon:
+```bash
+octomind run --daemon --format jsonl -n my-daemon
 ```
 
 ## Platform-Specific
+
+The sandbox (`--sandbox` flag or `sandbox` in config) applies to the `run`,
+`server`, and `acp` commands only. It restricts filesystem writes to the current
+working directory (plus `~/.local/share` for MCP state) — credential directories
+such as `~/.ssh` and `~/.aws` are always write-protected. There is a
+platform difference in read behavior:
+- **macOS** (Seatbelt): also *blocks reads* of credential dirs (`~/.ssh`,
+  `~/.gnupg`, `~/.aws`, `~/.kube`, `~/.config/gcloud`, `~/.azure`, `~/.config/op`).
+- **Linux** (Landlock): the whole filesystem stays *readable*; only writes are
+  denied. True read isolation is not possible with Landlock v1-v3, so credential
+  dirs are write-protected but not read-protected.
 
 ### Linux: Sandbox Not Working
 
@@ -183,14 +303,20 @@ Landlock requires kernel 5.13+:
 ```bash
 uname -r  # Check kernel version
 ```
+On older kernels the sandbox runs in best-effort mode and logs a warning instead
+of failing.
 
 ### macOS: Sandbox Permissions
 
-Seatbelt may block certain operations. Check Console.app for sandbox violations.
+Seatbelt may block certain operations (including reads of the credential dirs
+listed above). Check Console.app for sandbox violations.
 
 ### Windows: Path Issues
 
-Use `%LOCALAPPDATA%/octomind/` for data directory. Ensure backslashes in paths are escaped in config.
+The data root is `%LOCALAPPDATA%\octomind` (falls back to
+`%USERPROFILE%\AppData\Local\octomind` when `LOCALAPPDATA` is unset). The config
+file therefore lives at `%LOCALAPPDATA%\octomind\config\config.toml`. Ensure
+backslashes in paths are escaped in TOML strings (or use forward slashes).
 
 ## Debug Mode
 
@@ -210,3 +336,10 @@ Log locations:
 - WebSocket: `~/.local/share/octomind/logs/websocket-debug.log`
 - ACP: `~/.local/share/octomind/logs/acp-debug.log`
 - ACP errors: `~/.local/share/octomind/logs/acp-errors.jsonl`
+
+## See Also
+
+- [Environment Variables](../reference/04-environment-variables.md) -- full per-provider API-key list
+- [MCP Tools](../usage/07-mcp-tools.md) -- configuring MCP servers and tools
+- [Local Tools](../usage/17-local-tools.md) -- the built-in filesystem (octofs) tools
+- [Compression](../usage/08-compression.md) -- how automatic context compression works

--- a/doc/troubleshooting/02-migration-guide.md
+++ b/doc/troubleshooting/02-migration-guide.md
@@ -1,5 +1,7 @@
 # Migration Guide
 
+> **Read this first:** every structural change in this guide is **manual**. `octomind config --upgrade` only bumps the config schema version field (the current schema is version `1`, and the only migration is `v0 → v1`); it does **not** reshape legacy `[role_name]`, `[[layers]]`, `[mcp]`, or filesystem sections for you. See [Automatic Upgrade](#automatic-upgrade) for exactly what it touches.
+
 ## Provider Format
 
 **Old format:**
@@ -12,7 +14,13 @@ model = "anthropic/claude-sonnet-4"
 model = "openrouter:anthropic/claude-sonnet-4"
 ```
 
-All models require `provider:model` format. The provider prefix tells Octomind which API to use.
+All models require `provider:model` format. The provider prefix tells Octomind which API to use. The canonical default model is `openrouter:anthropic/claude-sonnet-4` (OpenRouter is the recommended one-key-many-models entry point).
+
+When migrating a bare model name, pick the provider prefix that matches where you actually call the model. Common prefixes: `openrouter`, `openai`, `anthropic`, `google` (Vertex), `amazon` (Bedrock), `cloudflare`, `deepseek`, `ollama`, `local`, and the special `cli` meta-provider for locally CLI-backed models. There are 20 network providers plus `cli` in total — see [doc/usage/04-providers.md](../usage/04-providers.md) for the full list and which prefix to choose.
+
+### API keys are environment-only
+
+API keys are **no longer** read from config. If your legacy config has `[providers]`, `[openrouter]`, or similar blocks carrying an `api_key`, **delete them** — keys come from environment variables only (for example `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). `octomind config --api-key` is always rejected; set the environment variable instead. See [doc/usage/04-providers.md](../usage/04-providers.md) for the per-provider variable names.
 
 ## MCP Configuration
 
@@ -62,13 +70,18 @@ allowed_tools = ["core:*", "runtime:*", "filesystem:*", "agent:*"]
 ```
 
 Key changes:
-- Roles use `[[roles]]` array format (not `[role_name]` sections)
+- Roles use `[[roles]]` array format (not `[role_name]` sections); every role is a top-level `[[roles]]` entry with a `name` field
 - `enabled` field removed (roles are always available if defined)
 - `enable_layers` removed (legacy in-session workflow system is gone — use external `octomind workflow` instead)
+- Per-role `max_tokens` removed — if a legacy role config carries `max_tokens`, drop it
 - Tool permissions use `allowed_tools` patterns
-- `runtime` builtin server is new — see "Runtime Namespace Move" below
+- `runtime` builtin server is new — see [Runtime Namespace Move](#runtime-namespace-move) below
+
+The default tag used when no `TAG` is passed to `octomind run` (or `acp`/`server`) is `assistant:concierge` (the `default` field in the root config). It can be a role name (e.g. `developer`) or a tap agent (e.g. `octomind:assistant`).
 
 ## Layer Configuration
+
+> The old-format fields below (`builtin`, `enabled`, `enable_tools`) belong to the pre-v1 in-session layer system. If your config still has them, it predates the current schema and needs the manual reshaping shown here.
 
 **Old format:**
 ```toml
@@ -82,13 +95,15 @@ enable_tools = true
 **Current format:**
 ```toml
 [[layers]]
-name = "task_refiner"
-description = "Refines and clarifies user requests"
-command = "octomind acp task_refiner"
-input_mode = "last"
-output_mode = "none"
+name = "reduce"
+description = "Compress session history for cost optimization during ongoing work"
+command = "octomind acp reduce"
+input_mode = "all"
+output_mode = "replace"
 output_role = "assistant"
 ```
+
+The example above is the `reduce` command that ships in the default config (declared as a `[[commands]]` entry — layers and commands share the same fields). The layer's `name` is arbitrary; the `command` is what references an actual role via `octomind acp <role>`.
 
 Key changes:
 - `builtin`, `enabled`, `enable_tools`, `model`, `max_tokens` fields removed
@@ -104,11 +119,13 @@ If you previously had `workflow = "..."` on a role, drop the field. To port an e
 
 ## Config File Location
 
-**Old location:** `~/.config/octomind/config.toml` or `~/.octomind/config.toml`
+**Current location (the only path the code reads):** `~/.local/share/octomind/config/config.toml` (macOS and Linux; `%LOCALAPPDATA%\octomind\config\config.toml` on Windows).
 
-**Current location:** `~/.local/share/octomind/config/config.toml`
+Override: `OCTOMIND_CONFIG_PATH` environment variable. There are no other legacy fallback paths — if your config lives somewhere else from an older install, move it here or point `OCTOMIND_CONFIG_PATH` at it.
 
-Override: `OCTOMIND_CONFIG_PATH` environment variable.
+### Splitting a monolithic config
+
+The config directory merges **all** `*.toml` files it contains, not just `config.toml`. Files named `mcp-*.toml` are loaded **last** as overrides. This is handy when migrating a large config: you can split MCP server definitions into a separate `mcp-servers.toml` (loaded after, so it wins on conflicts) instead of keeping everything in one file.
 
 ## Automatic Upgrade
 
@@ -116,7 +133,9 @@ Override: `OCTOMIND_CONFIG_PATH` environment variable.
 octomind config --upgrade
 ```
 
-This attempts to migrate your config to the latest version. Review the result and adjust manually if needed.
+This bumps the config **schema version field** to the latest version. The current schema is version `1`, and the only migration that exists is `v0 → v1`, which simply sets (or inserts) `version = 1` at the top of the file. Before writing, it copies your config to `<config>.toml.backup`.
+
+It does **not** rewrite any legacy section layouts — `[role_name]` → `[[roles]]`, the filesystem builtin → external, the `core`/`runtime` split, `[mcp]` reshaping, and every other change in this guide must be applied **by hand**. `--upgrade` only touches the `version` line.
 
 ## Runtime Namespace Move
 
@@ -156,21 +175,20 @@ If you have a hand-rolled config without it, add the block.
 
 Roles that don't call `mcp`/`agent`/`skill`/`schedule`/`capability` (most roles) don't need `"runtime"` at all — drop it from `server_refs` to keep the tool surface tighter.
 
+> **`agent` appears in two places.** The `runtime` server hosts the `agent` **management** tool (shown in the table above). A separate `agent` **builtin** server (a third builtin in the default config, alongside `core` and `runtime`) hosts the dynamically generated `agent_<name>` **execution** tools. If you use dynamic agents, keep both `"runtime"` and `"agent"` in `server_refs`.
+
 ## Filesystem Is Now External
 
-`filesystem` is no longer a builtin server. It's served by an external `octofs` process configured as a `stdio` server. The default config already wires this:
+`filesystem` is no longer a builtin server. It is provided as an external `octofs` stdio server — **but you do not declare it yourself**. The built-in default tap (`muvon/tap`) and the runtime overlay supply it. Your local `config.toml` only declares three builtin servers (`core`, `runtime`, `agent`); it does **not** contain a `filesystem`/`octofs` entry, and the default roles simply reference it:
 
 ```toml
-[[mcp.servers]]
-name = "filesystem"
-type = "stdio"
-command = "octofs"
-args = ["mcp", "--path={{CWD}}"]
-timeout_seconds = 30
-tools = []
+[roles.mcp]
+server_refs = ["core", "runtime", "filesystem", "agent"]
 ```
 
-If your config still declares `filesystem` as `type = "builtin"`, switch it to the stdio block above. `octomind config --upgrade` does this automatically.
+> **Do not paste an octofs stdio block.** Because the tap/overlay already provides `filesystem`, hand-rolling a `[[mcp.servers]]` block for it is unnecessary and can cause conflicts. Only add one if you intentionally self-host `octofs`.
+
+If you have a hand-rolled config that declares `filesystem` as `type = "builtin"`, **remove that block** — the tap/overlay supplies the server; just keep `"filesystem"` in your roles' `server_refs`. This is a manual edit: `octomind config --upgrade` will **not** do it for you.
 
 ## MCP Server Type
 

--- a/doc/usage/01-installation.md
+++ b/doc/usage/01-installation.md
@@ -11,24 +11,40 @@
 curl -fsSL https://raw.githubusercontent.com/muvon/octomind/master/install.sh | bash
 ```
 
-This detects your OS and architecture, downloads the latest release, and installs to `/usr/local/bin/`.
+This detects your OS and architecture, downloads the latest release, and installs to `~/.local/bin/` (override with `OCTOMIND_INSTALL_DIR`). If `~/.local/bin` is not on your `PATH`, the script prints a warning and tells you to add it:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Add that line to your shell profile (`~/.bashrc`, `~/.zshrc`, `~/.profile`, etc.) so it persists.
 
 ## Manual Installation
 
-Download the appropriate binary from [GitHub Releases](https://github.com/muvon/octomind/releases):
+Download the archive for your platform from [GitHub Releases](https://github.com/muvon/octomind/releases). Assets are versioned and named by Rust target triple (replace `<version>` with the release you want, e.g. `0.29.0`):
 
-| Platform | Binary |
-|----------|--------|
-| Linux x86_64 | `octomind-linux-amd64` |
-| Linux ARM64 | `octomind-linux-arm64` |
-| macOS Intel | `octomind-darwin-amd64` |
-| macOS Apple Silicon | `octomind-darwin-arm64` |
-| Windows x86_64 | `octomind-windows-amd64.exe` |
+| Platform | Asset |
+|----------|-------|
+| Linux x86_64 | `octomind-<version>-x86_64-unknown-linux-musl.tar.gz` |
+| Linux ARM64 | `octomind-<version>-aarch64-unknown-linux-musl.tar.gz` |
+| macOS Intel | `octomind-<version>-x86_64-apple-darwin.tar.gz` |
+| macOS Apple Silicon | `octomind-<version>-aarch64-apple-darwin.tar.gz` |
+| Windows x86_64 | `octomind-<version>-x86_64-pc-windows-msvc.zip` |
+| Windows ARM64 | `octomind-<version>-aarch64-pc-windows-msvc.zip` |
+
+The `.tar.gz`/`.zip` archive contains a single `octomind` binary (`octomind.exe` on Windows). Extract it, then move it onto your `PATH`:
 
 ```bash
 # Example: macOS Apple Silicon
-chmod +x octomind-darwin-arm64
-sudo mv octomind-darwin-arm64 /usr/local/bin/octomind
+tar xzf octomind-0.29.0-aarch64-apple-darwin.tar.gz
+chmod +x octomind
+mv octomind ~/.local/bin/octomind        # or: sudo mv octomind /usr/local/bin/octomind
+```
+
+```powershell
+# Example: Windows x86_64 (PowerShell)
+Expand-Archive octomind-0.29.0-x86_64-pc-windows-msvc.zip -DestinationPath .
+# Then move octomind.exe to a directory on your PATH
 ```
 
 ## Package Managers
@@ -39,14 +55,16 @@ sudo mv octomind-darwin-arm64 /usr/local/bin/octomind
 cargo install octomind
 ```
 
-Requires Rust 1.95+. See [Building from Source](../dev/01-building-from-source.md) for development setup.
+This builds from source and requires the Rust toolchain (Rust 1.95+). It is the path for Rust users; the recommended install for everyone else is the install script or the GitHub release archives above. See [Building from Source](../dev/01-building-from-source.md) for development setup.
 
 ## API Key Setup
 
-Set at least one provider API key as an environment variable:
+API keys are read **only** from environment variables (or a `.env` file in your project directory). There is no config field for them — `octomind config --api-key provider:key` is intentionally rejected and points you to the corresponding env var instead.
+
+Set at least one provider API key. Common providers:
 
 ```bash
-# OpenRouter (recommended -- access to many providers)
+# OpenRouter (recommended -- one key, access to many models)
 export OPENROUTER_API_KEY="your_key"
 
 # Or use a specific provider
@@ -55,9 +73,22 @@ export ANTHROPIC_API_KEY="your_key"
 export DEEPSEEK_API_KEY="your_key"
 ```
 
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) for persistence. Or use a `.env` file in your project directory.
+Some providers use differently named credentials rather than `<PROVIDER>_API_KEY`:
 
-See [Environment Variables](../reference/04-environment-variables.md) for all supported variables.
+```bash
+# Google Vertex AI -- path to a service-account JSON file
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
+
+# Amazon Bedrock
+export AWS_BEARER_TOKEN_BEDROCK="your_token"
+
+# Cloudflare Workers AI
+export CLOUDFLARE_API_TOKEN="your_token"
+```
+
+Add the relevant exports to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) for persistence, or put them in a `.env` file in your project directory.
+
+See [Environment Variables](../reference/04-environment-variables.md) for the complete list of supported providers and variables.
 
 ## Shell Completions
 
@@ -75,6 +106,9 @@ octomind completion fish > ~/.config/fish/completions/octomind.fish
 
 # PowerShell
 octomind completion powershell > octomind.ps1
+
+# Elvish
+octomind completion elvish > ~/.config/elvish/lib/octomind.elv
 ```
 
 For Zsh, ensure `~/.zfunc` is in your `fpath`:
@@ -82,6 +116,8 @@ For Zsh, ensure `~/.zfunc` is in your `fpath`:
 echo 'fpath=(~/.zfunc $fpath)' >> ~/.zshrc
 echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
 ```
+
+> Note: `bash`, `zsh`, and `fish` completions include dynamic agent/role TAG completion for `octomind run` (driven by `octomind complete run` at runtime). `powershell` and `elvish` completions are static — they complete subcommands and flags but not agent/role tags.
 
 ## CI/CD Installation
 
@@ -93,11 +129,20 @@ The install script supports environment variables for automated environments whe
 | `OCTOMIND_INSTALL_DIR` | Override installation directory (default: `~/.local/bin/`) |
 | `OCTOMIND_VERSION` | Install a specific version instead of latest |
 
+`GH_TOKEN` is accepted as an alternative to `GITHUB_TOKEN`.
+
 ```bash
 # CI example
 GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-  OCTOMIND_VERSION="0.23.1" \
+  OCTOMIND_VERSION="0.29.0" \
   curl -fsSL https://raw.githubusercontent.com/muvon/octomind/master/install.sh | bash
+```
+
+The script also accepts flags when piped, which override the environment variables (`--target` is useful for cross-platform installs):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/muvon/octomind/master/install.sh | \
+  bash -s -- --version 0.29.0 --target aarch64-apple-darwin --install-dir /opt/bin
 ```
 
 ## Verification
@@ -113,4 +158,4 @@ octomind config
 octomind run
 ```
 
-Configuration is stored at `~/.local/share/octomind/config/config.toml`. See [Configuration](03-configuration.md) for details.
+Configuration is stored at `~/.local/share/octomind/config/config.toml` on macOS and Linux (on Windows: `%LOCALAPPDATA%\octomind\config\config.toml`). See [Configuration](03-configuration.md) for details.

--- a/doc/usage/02-quickstart.md
+++ b/doc/usage/02-quickstart.md
@@ -32,6 +32,8 @@ octomind run
 
 You're now in an interactive AI session with full tool access. The AI can read files, edit code, run commands, and manage your project.
 
+With no tag, `octomind run` uses the configured default tag `assistant:concierge` -- a tap agent from the built-in default tap `muvon/tap` -- on the default model `openrouter:anthropic/claude-sonnet-4`. The first run clones that tap (a one-time `git` fetch over the network), so the very first session needs connectivity.
+
 ## What You Can Do
 
 **Ask questions about your code:**
@@ -61,15 +63,25 @@ Run the test suite and fix any failures
 | `/help` | Show all commands |
 | `/info` | Token usage and costs |
 | `/image <path>` | Attach image for AI analysis |
-| `/exit` | Exit session |
+| `/done` | Finalize the current task: compress context, run learning extraction, and produce a summary |
+| `/clear` | Clear the terminal screen |
+| `/copy` | Copy the last response to the clipboard |
+| `/exit` | Exit session (or press `Ctrl+D`) |
+
+`/done` is the most useful command for a productive first session: when you finish a task, it summarizes what happened and compresses the context so the next task starts clean.
 
 ## Session Modes
 
+The tag you pass to `octomind run` can be one of two things:
+
+- **A plain name** (e.g. `assistant`) -- a local role defined in your `config.toml`. Resolved offline, no network access.
+- **A `category:variant` tag** (e.g. `developer:general`) -- a tap agent fetched from the registry. The first use clones the tap over the network.
+
 ```bash
-# Default: interactive with tools
+# Default: interactive with the assistant:concierge tap agent
 octomind run
 
-# Chat-only (assistant role)
+# Built-in local "assistant" role (full tool access -- reads, edits, runs commands)
 octomind run assistant
 
 # Named session (resume later)
@@ -78,23 +90,29 @@ octomind run --name my-feature
 # Resume a session
 octomind run --resume my-feature
 
-# Tap agent (fetches specialized config)
-octomind run octomind:developer
+# Tap agent (fetches a specialized config from the registry)
+octomind run developer:general
 ```
+
+The built-in `assistant` role is NOT chat-only -- it ships with full MCP tool access (core, runtime, filesystem, agent). If you want a chat-only experience, use the tap agent `octomind:assistant` instead (see [Roles](06-roles.md)). For more on tap agents and the registry, see the [Tap System](../integration/04-tap-system.md).
 
 ## Non-Interactive Mode
 
-Pipe a message via stdin and get a response:
+`--format` is available only on `octomind run`. Passing any `--format` value forces non-interactive mode: the prompt is read from stdin and the result is printed to stdout. The only accepted values are `plain` and `jsonl`.
+
+Pipe a message via stdin and get a plain-text response:
 
 ```bash
-echo "Explain the auth module" | octomind run developer --format plain
+echo "Explain the auth module" | octomind run developer:general --format plain
 ```
 
-Structured JSON output for pipelines:
+Structured line-delimited JSON output for pipelines:
 
 ```bash
-echo "List TODO items" | octomind run developer --format jsonl
+echo "List TODO items" | octomind run developer:general --format jsonl
 ```
+
+> Use a resolvable tag here. A bare `developer` is treated as a local role name; since the default config has no such role, it logs `Unknown role` and silently falls back to another role -- so always use the tap form `developer:general` (or a real local role like `assistant`).
 
 ## Next Steps
 

--- a/doc/usage/03-configuration.md
+++ b/doc/usage/03-configuration.md
@@ -2,6 +2,8 @@
 
 Octomind uses TOML configuration files stored in a platform-specific data directory.
 
+This page covers the config file format, where it lives, and how settings resolve. Deeper topics live in their own docs: [Roles and Permissions](06-roles.md), [Compression](08-compression.md), [Providers](04-providers.md), and [Learning](13-learning.md).
+
 ## File Locations
 
 | Platform | Data Directory | Config File |
@@ -16,14 +18,15 @@ Full directory structure:
   config/
     config.toml           # Main configuration
     *.toml                # Additional config files (merged)
-  sessions/               # Session history
+  sessions/               # Saved sessions
   logs/                   # Debug and error logs
   cache/                  # Cached data
-  run/                    # Unix sockets and PID files
-  taps/                   # Registry taps
+  run/                    # Per-session Unix sockets and PID files (used by `send` / --daemon)
+  learning/               # Cross-session adaptive learning (lessons), scoped by project/role
+  agents/                 # Cached tap agent manifests (<category>/<variant>.toml)
 ```
 
-Override config directory with `OCTOMIND_CONFIG_PATH` environment variable.
+Override the config location with the `OCTOMIND_CONFIG_PATH` environment variable. It points to a config **file**; its parent directory becomes the merge directory (all `*.toml` files there are loaded — see [Multi-File Configuration](#multi-file-configuration)).
 
 ## Getting Started
 
@@ -33,28 +36,31 @@ Generate a default configuration:
 octomind config
 ```
 
-This creates `config.toml` from the built-in template (`config-templates/default.toml`).
+On first run this writes `config.toml` to `~/.local/share/octomind/config/`. The template is **embedded in the binary** at build time (the repo's `config-templates/default.toml` is the source of truth — it is not a file on your machine). After first launch, the on-disk file is authoritative: edits you make there are what Octomind loads.
 
-Verify your configuration:
+Verify and maintain your configuration:
 
 ```bash
-octomind config --show      # Display current settings
+octomind config --show      # Display the effective (merged) settings
 octomind config --validate  # Check for errors
+octomind config --upgrade   # Migrate an old config to the current version
 ```
 
-## Configuration Hierarchy
+`--upgrade` migrates an existing config to the latest version and writes a backup to `config.toml.backup`. Upgrades also run automatically on load whenever the file's `version` is older than the current one.
 
-Settings are resolved in order (first match wins):
+## How Settings Resolve
+
+Two separate mechanisms decide the effective configuration: how the **files** merge, and how the **model** is chosen.
+
+**File merge (last wins).** All `*.toml` files in the config directory are merged into one config. `config.toml` loads first, then the rest alphabetically, with `mcp-*.toml` files loaded **last** as overrides (see [Multi-File Configuration](#multi-file-configuration)). When two files set the same scalar, the later file wins; arrays of tables (`[[mcp.servers]]`, `[[roles]]`) are concatenated and same-name entries are deduplicated keeping the last occurrence. There is no separate runtime "defaults" tier — the embedded template is copied to disk once on first run, after which the on-disk file *is* the config.
+
+**Model selection (precedence chain).** The model is the one field with a real precedence order:
 
 ```
-Environment Variables (API keys, OCTOMIND_CONFIG_PATH)
-    |
-Role-specific config ([[roles]])
-    |
-Global config (root level, [mcp])
-    |
-Template defaults (config-templates/default.toml)
+CLI --model  >  role.model  >  config.model (root)
 ```
+
+A plain `[[roles]]` entry's `model` is honored directly — `octomind run <role>` uses it over the root `config.model` (CLI `--model` still wins). For a tap agent (`category:variant`), a `[taps]` entry for that tag overrides the `config.model` tier, so it applies only when neither `--model` nor the agent's own role sets a model. See [Tap Model Overrides](#tap-model-overrides). (Resolution happens in `src/session/chat/session/core.rs`: `CLI --model ?? role.model ?? config.model`.)
 
 ## Core Settings
 
@@ -74,9 +80,16 @@ default = "assistant:concierge"
 # Global max tokens
 max_tokens = 16384
 
+# Reasoning effort hint for thinking-capable models (ignored by others)
+reasoning_effort = "medium"  # low | medium | high | xhigh | max
+
 # Sandbox mode: restrict writes to working directory
 sandbox = false
 ```
+
+The default tag `assistant:concierge` is a **tap agent** (`category:variant`) provided by the built-in default tap `muvon/tap`, not the local `[[roles]]` `assistant` definition.
+
+`reasoning_effort` is a system-wide hint mapped by each provider to its native thinking knob (effort string, budget tokens, etc.); models without thinking support silently ignore it. You can also change it per-session at runtime with the `/effort` command, which persists the choice in the session file.
 
 ## Custom Instructions
 
@@ -102,6 +115,14 @@ mcp_response_tokens_threshold = 20000
 # Max tokens per session before truncation (0 = disabled)
 max_session_tokens_threshold = 200000
 
+# Prompt-cache keepalive (Anthropic-only, opt-in): ping the provider while the
+# session idles so the next turn still hits the cache. Each ping costs cache-read tokens.
+cache_keepalive_enabled = false
+cache_keepalive_max_idle_seconds = 1800  # 0 = ping until session ends
+
+# Automatically activate capabilities whose triggers match the user message
+auto_capabilities = true
+
 # Retry configuration
 max_retries = 1
 retry_timeout = 30
@@ -109,6 +130,15 @@ retry_timeout = 30
 # Per-request HTTP timeout (0 = no timeout)
 request_timeout_seconds = 300
 ```
+
+Cache keepalive only applies to providers whose API supports refresh-on-read (today, Anthropic). Other providers are skipped, so enabling it does no harm but has no effect for them. Set `auto_capabilities = false` to require explicit `capability(action="enable")` calls instead of automatic matching.
+
+**Validation limits** (`octomind config --validate` enforces these):
+
+- `max_session_tokens_threshold` <= 2,000,000
+- `cache_keepalive_max_idle_seconds` <= 86400 (24h), or 0 for unbounded
+- MCP server and webhook hook timeouts must be > 0 and <= 3600 seconds
+- `model` and `markdown_theme` must be non-empty; role `temperature` 0.0-2.0, `top_p` 0.0-1.0, `top_k` 1-1000
 
 ## User Interface
 
@@ -134,9 +164,15 @@ Configure MCP tool servers in the `[mcp]` section:
 [mcp]
 allowed_tools = []  # Global restrictions (empty = none)
 
-# Built-in servers
+# Built-in servers (always available)
 [[mcp.servers]]
 name = "core"
+type = "builtin"
+timeout_seconds = 30
+tools = []
+
+[[mcp.servers]]
+name = "runtime"
 type = "builtin"
 timeout_seconds = 30
 tools = []
@@ -165,6 +201,8 @@ timeout_seconds = 30
 tools = []
 ```
 
+The three built-in servers shipped in the default config are `core` (hosts `plan`, `tap`), `runtime` (hosts `mcp`, `agent`, `skill`, `schedule`, `capability`), and `agent`. Omitting `runtime` would lose all of its tools — keep it in the list.
+
 See [MCP Tools Reference](07-mcp-tools.md) for complete tool documentation.
 
 ## Roles
@@ -181,8 +219,8 @@ system = "You are a helpful assistant. Working directory: {{CWD}}"
 welcome = "Hello! Working in {{CWD}}"
 
 [roles.mcp]
-server_refs = ["core", "filesystem", "agent"]
-allowed_tools = ["core:*", "filesystem:*", "agent:*"]
+server_refs = ["core", "runtime", "filesystem", "agent"]
+allowed_tools = ["core:*", "runtime:*", "filesystem:*", "agent:*"]
 ```
 
 See [Roles and Permissions](06-roles.md) for detailed role configuration.
@@ -193,9 +231,10 @@ All `*.toml` files in the config directory are merged:
 
 1. `config.toml` loaded first
 2. Other files loaded alphabetically
-3. Array entries (`[[mcp.servers]]`, `[[roles]]`, etc.) are concatenated
-4. Same-name entries are deduplicated (last wins)
-5. Scalar values are overridden by later files
+3. Files matching `mcp-*.toml` are loaded **last** (as overrides), regardless of alphabetical order, so they win on same-name `[[mcp.servers]]` entries (e.g. to add `auto_bind` to a server defined earlier). Note: `mcp.toml` (no dash) is a regular file loaded in normal alphabetical order.
+4. Array entries (`[[mcp.servers]]`, `[[roles]]`, etc.) are concatenated
+5. Same-name entries are deduplicated (last wins)
+6. Scalar values are overridden by later files
 
 This lets you organize by concern:
 ```
@@ -214,7 +253,7 @@ For tap agents, override which provider handles specific capabilities:
 codesearch = "octocode"
 ```
 
-This maps to `capabilities/codesearch/octocode.toml` within the tap.
+Each key is a capability name and the value is the provider to use. It resolves to `capabilities/<capability>/<provider>.toml` within the tap — so the example maps to `capabilities/codesearch/octocode.toml`. When no override is given for a capability, the provider defaults to `default` (i.e. `capabilities/<capability>/default.toml`).
 
 ## Tap Model Overrides
 
@@ -226,11 +265,11 @@ This maps to `capabilities/codesearch/octocode.toml` within the tap.
 
 **Model resolution priority:**
 1. CLI `--model` flag
-2. `[taps]` override (for tap agents only)
-3. Role's `model` field
-4. Global `model` in config
+2. The active role's `model` field (a plain `[[roles]]` entry, or a tap agent's manifest role)
+3. Global `model` in config — which a `[taps]` entry overrides for a tap agent's tag
 
-Only applies to tap agents (tags with `:` like `developer:general`). Plain role names use role.model or config.model.
+A plain `[[roles]]` entry's `model` is honored directly. The `[taps]` override only applies to tap agents (tags with `:` like `developer:general`) and acts at the `config.model` tier — it takes effect when the agent's own role does not set a model.
+
 ## Template Variables
 
 System prompts and welcome messages support variables:
@@ -238,16 +277,27 @@ System prompts and welcome messages support variables:
 | Variable | Description |
 |----------|-------------|
 | `{{CWD}}` | Current working directory |
-| `{{ROLE}}` | Active role name |
-| `{{DATE}}` | Current date |
+| `{{ROLE}}` | Active role name (`unknown` when no role is set) |
+| `{{DATE}}` | Current date (with timezone) |
 | `{{SHELL}}` | User's shell |
 | `{{BINARIES}}` | Available binaries in PATH |
 | `{{OS}}` | Operating system |
-| `{{GIT_STATUS}}` | Git status |
-| `{{GIT_TREE}}` | Project file tree |
-| `{{README}}` | Project README.md contents |
 | `{{HOME}}` | User's home directory path |
-Use `octomind vars` to see all current values.
+| `{{GIT_STATUS}}` | Git status (empty outside a git repo) |
+| `{{GIT_TREE}}` | Project file tree (empty outside a git repo) |
+| `{{README}}` | Project README.md contents (empty if absent) |
+| `{{SYSTEM}}` | Combined system info block: date, shell, OS, binaries, CWD |
+| `{{CONTEXT}}` | Combined project context block: README + git status + git tree (empty outside a git repo) |
+
+`{{SYSTEM}}` and `{{CONTEXT}}` are the composites the default `task_refiner`/`task_researcher`/`reduce` roles rely on. The git/README variables (and `{{CONTEXT}}`) resolve to an **empty string** when the project has no git repo or no README, so prompts that use them stay valid either way.
+
+Inspect actual values with the `vars` command at three verbosity levels:
+
+```bash
+octomind vars            # list variable names
+octomind vars --preview  # 3-line preview of each value (-p)
+octomind vars --expand   # full expanded values (-e)
+```
 
 ## Further Reading
 

--- a/doc/usage/04-providers.md
+++ b/doc/usage/04-providers.md
@@ -1,13 +1,10 @@
 # AI Providers
 
-Octomind supports 7 AI providers through a unified interface. Provider support is implemented in [octolib](https://github.com/muvon/octolib) -- new providers are added there and automatically become available in Octomind.
+Octomind talks to language models through a unified interface implemented in [octolib](https://github.com/muvon/octolib). octolib wires **20 network providers plus a special `cli` meta-provider** (21 prefixes total), so you can switch models without changing how Octomind works. New providers are added in octolib and automatically become available here.
 
-All provider types are re-exported from `src/providers.rs`:
-- `AiProvider` (trait), `ProviderFactory`
-- `OpenRouterProvider`, `OpenAiProvider`, `AnthropicProvider`, `GoogleVertexProvider`
-- `AmazonBedrockProvider`, `CloudflareWorkersAiProvider`, `DeepSeekProvider`
-- `GenericToolCall`, `StructuredOutputRequest` — tool/schema types
-- `ModelPricing`, `ProviderExchange`, `ThinkingBlock`, `TokenUsage` — metadata types
+You pick a model with the `provider:model` format and supply that provider's API key via an **environment variable** (or a `.env` file). That is all most setups need.
+
+> Quick check: run `octomind config --show` at any time to see which provider keys Octomind has detected and where they came from (system environment vs `.env` file).
 
 ## Model Format
 
@@ -20,7 +17,29 @@ model = "anthropic:claude-sonnet-4"
 model = "deepseek:deepseek-chat"
 ```
 
+## API Keys Are Environment-Only
+
+API keys can **only** be provided through environment variables (or a `.env` file in the current working directory). You cannot put keys in the config file — that was removed for security, and `octomind config --api-key ...` is always rejected with a message telling you to `export <PROVIDER>_API_KEY=...` instead.
+
+The general pattern is `<PROVIDER>_API_KEY`, with an optional `<PROVIDER>_API_URL` to override the base URL. See the per-provider sections below and [doc/reference/04-environment-variables.md](../reference/04-environment-variables.md) for the complete list.
+
+### Using a `.env` file
+
+Instead of `export`-ing variables, you can drop a `.env` file in your working directory:
+
+```bash
+# .env
+OPENROUTER_API_KEY=your_key
+ANTHROPIC_API_KEY=your_key
+```
+
+Octomind loads `.env` on startup and it **overrides** the process environment. An **empty** value is treated as "not set", so a blank `KEY=` line will not satisfy a required key. `octomind config --show` reports whether each detected key came from the system environment or from `.env`.
+
 ## Supported Providers
+
+The most common providers are documented in detail below. The full set of provider prefixes octolib recognizes is:
+
+`openrouter`, `openai`, `anthropic`, `google`, `amazon`, `cloudflare`, `deepseek`, `cerebras`, `groq`, `together`, `fireworks`, `nvidia`, `minimax`, `moonshot` (alias `kimi`), `zai`, `byteplus`, `featherless`, `octohub`, `ollama`, `local` — plus the special `cli` meta-provider for local CLI-backed models.
 
 ### OpenRouter (recommended)
 
@@ -37,6 +56,8 @@ model = "openrouter:google/gemini-2.5-flash-preview"
 ```
 
 Get a key at [openrouter.ai](https://openrouter.ai/).
+
+> When Octomind starts, it sets two OpenRouter attribution headers if they are not already defined: `OPENROUTER_APP_TITLE=Octomind` and `OPENROUTER_HTTP_REFERER=https://octomind.run`. These identify the app to OpenRouter for ranking/attribution; override them by exporting your own values.
 
 ### OpenAI
 
@@ -69,28 +90,35 @@ model = "anthropic:claude-haiku-4-5"
 Gemini models via Google Cloud.
 
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS="/path/to/credentials.json"
+# Preferred: point at a service-account JSON file
+export GOOGLE_CREDENTIAL_FILE="/path/to/service-account.json"
+# Standard Google fallback (also accepted)
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+# Optional project / region overrides
+export GOOGLE_CLOUD_PROJECT_ID="your-project"
+export GOOGLE_CLOUD_LOCATION="us-central1"
 ```
 
 ```toml
 model = "google:gemini-2.5-flash-preview"
 ```
 
-Requires a Google Cloud project with Vertex AI API enabled.
+octolib reads `GOOGLE_CREDENTIAL_FILE` first, then falls back to `GOOGLE_APPLICATION_CREDENTIALS`. Requires a Google Cloud project with the Vertex AI API enabled.
 
 ### Amazon (Bedrock)
 
-AWS-hosted models.
+AWS-hosted models. Bedrock uses a **service-specific API key**, not your regular AWS access keys.
 
 ```bash
-export AWS_ACCESS_KEY_ID="your_key"
-export AWS_SECRET_ACCESS_KEY="your_secret"
-export AWS_REGION="us-east-1"
+export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
+export AWS_BEDROCK_REGION="us-east-1"   # optional, defaults to us-east-1
 ```
 
 ```toml
 model = "amazon:anthropic.claude-v2"
 ```
+
+These are **not** standard AWS access keys (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` will not authenticate). Create a Bedrock API key in the AWS console under **IAM → Security credentials → Create service-specific credential → Amazon Bedrock**.
 
 ### Cloudflare (Workers AI)
 
@@ -98,15 +126,18 @@ Edge inference with low latency.
 
 ```bash
 export CLOUDFLARE_API_TOKEN="your_token"
+export CLOUDFLARE_ACCOUNT_ID="your_account_id"
 ```
 
 ```toml
 model = "cloudflare:@cf/meta/llama-3.1-8b-instruct"
 ```
 
+octolib's Cloudflare provider reads `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
+
 ### DeepSeek
 
-Cost-effective models.
+Cost-effective models with context caching.
 
 ```bash
 export DEEPSEEK_API_KEY="your_key"
@@ -116,17 +147,59 @@ export DEEPSEEK_API_KEY="your_key"
 model = "deepseek:deepseek-chat"
 ```
 
+### Other providers
+
+The following providers also work via the same `<PROVIDER>_API_KEY` pattern. Each accepts an optional `<PROVIDER>_API_URL` base-URL override unless noted.
+
+| Provider | Format | Env var(s) |
+|----------|--------|------------|
+| Cerebras | `cerebras:model` | `CEREBRAS_API_KEY` |
+| Groq | `groq:model` | `GROQ_API_KEY` |
+| Together | `together:model` | `TOGETHER_API_KEY` |
+| Fireworks | `fireworks:model` | `FIREWORKS_API_KEY` |
+| NVIDIA | `nvidia:model` | `NVIDIA_API_KEY` |
+| MiniMax | `minimax:model` | `MINIMAX_API_KEY` |
+| Moonshot (Kimi) | `moonshot:model` / `kimi:model` | `MOONSHOT_API_KEY` |
+| Z.AI | `zai:model` | `ZAI_API_KEY` |
+| BytePlus | `byteplus:model` | `BYTEPLUS_API_KEY` |
+| Featherless | `featherless:model` | `FEATHERLESS_API_KEY` |
+| OctoHub | `octohub:model` | `OCTOHUB_API_KEY` |
+| Ollama (local) | `ollama:model` | `OLLAMA_API_KEY` (optional; defaults to local endpoint) |
+| Local / custom | `local:model` | `LOCAL_API_KEY`, `LOCAL_API_URL` |
+
+`moonshot` and `kimi` are aliases for the same provider.
+
+### Local CLI-backed models (`cli`)
+
+The special `cli` meta-provider runs a **local command-line agent** instead of calling a network API. The model string is `cli:<backend>/<model>`, where `<backend>` is one of `codex`, `claude`, `cursor`, `gemini`, or a generic command.
+
+```toml
+model = "cli:codex/gpt-5"
+```
+
+Because the model runs through a local CLI, **no API key is required** — Octomind skips credential validation entirely for the `cli` provider. Behavior is tuned with backend-specific environment variables, for example for the codex backend:
+
+```bash
+export CODEX_COMMAND="codex"            # path/name of the CLI binary
+export CODEX_REASONING_EFFORT="medium"  # low | medium | high
+export CODEX_SKIP_GIT_CHECK="false"
+```
+
 ## Provider Comparison
+
+Capability flags below come directly from octolib's provider implementations. "Caching" means the provider reports prompt-cache support; "Structured Output" means it advertises structured/JSON output.
 
 | Provider | Format | Caching | Vision | Structured Output |
 |----------|--------|---------|--------|-------------------|
-| OpenRouter | `openrouter:provider/model` | Yes (model-dependent) | Yes | Model-dependent |
-| OpenAI | `openai:model` | No | Yes (GPT-4o+) | Yes |
-| Anthropic | `anthropic:model` | Yes (Claude 3.5+) | Yes (Claude 3+) | Yes (tool-based) |
-| Google | `google:model` | No | Yes (Gemini 1.5+) | No |
-| Amazon | `amazon:model` | No | Yes (Claude models) | No |
-| Cloudflare | `cloudflare:model` | No | Limited | No |
-| DeepSeek | `deepseek:model` | No | No | No |
+| OpenRouter | `openrouter:provider/model` | Model-dependent | Model-dependent | Model-dependent (defaults to Yes for unknown models) |
+| OpenAI | `openai:model` | Yes (automatic, model-dependent) | Yes (GPT-4o+) | Yes |
+| Anthropic | `anthropic:model` | Yes (all Claude models) | Yes (Claude 3 and Claude 4) | Model-dependent (via octolib reference capabilities) |
+| Google | `google:model` | Yes (Gemini 2.5+/3) | Yes (Gemini) | Yes |
+| Amazon | `amazon:model` | Model-dependent | Yes (Claude models) | Model-dependent |
+| Cloudflare | `cloudflare:model` | No | Limited | Yes |
+| DeepSeek | `deepseek:model` | Yes | No | Yes |
+
+OpenAI caching is automatic (server-side, no client cache markers) for most text models; the pro-tier and audio variants (`gpt-5-pro`, `gpt-5.2-pro`, `gpt-audio`) are excluded.
 
 ## Model Selection Strategy
 
@@ -134,18 +207,54 @@ model = "deepseek:deepseek-chat"
 |----------|-------------|-----|
 | Main development | `anthropic:claude-sonnet-4` | Best coding, caching support |
 | Fast queries / layers | `openai:gpt-4o-mini` | Fast, cheap |
-| Compression decisions | `anthropic:claude-haiku-4-5` | 10x cheaper than Sonnet |
+| Compression decisions | `openai:gpt-5-mini` | Current default for `[compression.decision].model` |
 | Research / exploration | `openrouter:google/gemini-2.5-flash-preview` | Large context, fast |
 | Cost-effective | `deepseek:deepseek-chat` | Lowest cost |
 
+The compression-decision model is configured separately from your main model under `[compression.decision].model`. The shipped default is `openai:gpt-5-mini`; `anthropic:claude-haiku-4-5` is a fine cheaper alternative. See [doc/usage/08-compression.md](08-compression.md) for details.
+
+## Model Resolution
+
+When several places specify a model, Octomind resolves which one actually runs in this priority order:
+
+1. CLI override — `octomind run -m provider:model`
+2. The `model` declared by the active role/agent definition (a plain `[[roles]]` entry, or a tap agent's manifest role)
+3. The root config `model` — which a `[taps]` entry replaces for a tap agent's tag
+
+> A plain `[[roles]]` entry's `model` is honored directly for `octomind run <role>` (CLI `--model` still wins). A `[taps]` override applies only to tap agents and acts at the `config.model` tier. See [Configuration](03-configuration.md).
+
+## Request Tuning
+
+A few root-config knobs control how Octomind makes provider calls (defaults shown):
+
+```toml
+request_timeout_seconds = 300   # per-request timeout
+max_retries = 1                 # retry attempts on transient failures
+retry_timeout = 30              # seconds between retries
+```
+
+The compression sub-pipeline has its own `max_retries`/`retry_timeout`; see [doc/reference/03-config-reference.md](../reference/03-config-reference.md).
+
 ## Prompt Caching
 
-Providers with caching support can reduce costs by caching repeated context:
+Providers that support caching can reduce cost by reusing repeated context (system prompt, tool definitions, prior turns):
 
-- **Anthropic**: Automatic for Claude 3.5+ models. Cache write at 1.25x, read at 0.1x cost.
-- **OpenRouter**: Depends on underlying model.
+- **Anthropic**: caching for all Claude models. The system prompt and tool definitions are marked with the 1h cache TTL; cache writes cost ~1.25x and reads ~0.1x of normal input tokens.
+- **OpenAI / Google / DeepSeek**: automatic, server-side caching that the client cannot control (no TTL or cache markers are sent).
+- **OpenRouter**: depends on the underlying model (Anthropic models routed via OpenRouter use the same 1h cache markers).
 
-Caching is always-on for supporting providers — the cache marker is moved to the latest message on every turn and uses the provider's long (1h) TTL. No configuration required.
+For Anthropic, no configuration is required — caching is always on. The 1h TTL only takes effect for Anthropic (and Anthropic-routed OpenRouter); other providers' caching is server-side regardless of client settings.
+
+### Idle cache keepalive (Anthropic-only, opt-in)
+
+For long-running or idle sessions, Octomind can ping the provider to keep an idle prompt cache warm so the next message still hits the cache:
+
+```toml
+cache_keepalive_enabled = false          # opt-in; default off
+cache_keepalive_max_idle_seconds = 1800  # stop pinging after this many idle seconds (cap 86400)
+```
+
+This is **Anthropic-only**. The ping interval is provider-driven (about 54 minutes for the 1h cache TTL), not configurable here. Keepalive pings consume tokens, and their cost is folded into the session cost.
 
 ## Cost Tracking
 
@@ -180,8 +289,16 @@ octomind run -m anthropic:claude-sonnet-4
 
 **"Invalid model format"**: Must be `provider:model`. Example: `openrouter:anthropic/claude-sonnet-4`.
 
-**"API key not found"**: Set the provider's environment variable. Use `octomind config --show` to check.
+**"API key not found"** / credentials missing: API keys come only from environment variables or `.env` — they cannot be set in the config file (`octomind config --api-key` is rejected). Set the provider's `<PROVIDER>_API_KEY` and run `octomind config --show` to confirm Octomind detects it. Remember `cli:` models need no key.
 
-**"Provider does not support structured output"**: Not all providers support structured output. Use OpenAI or Anthropic for structured output.
+**"Provider does not support structured output for model ..."**: Most providers support structured output — OpenAI, Google, DeepSeek, and Cloudflare always do; OpenRouter and Anthropic depend on the specific model (resolved via octolib reference capabilities). If you hit this error, switch to a model octolib recognizes as structured-output capable.
 
-**Google Vertex AI issues**: Ensure `GOOGLE_APPLICATION_CREDENTIALS` points to a valid JSON file and the Vertex AI API is enabled.
+**Amazon Bedrock auth failures**: Bedrock needs `AWS_BEARER_TOKEN_BEDROCK` (a service-specific Bedrock API key), not `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. Set `AWS_BEDROCK_REGION` if your models are outside `us-east-1`.
+
+**Google Vertex AI issues**: Ensure `GOOGLE_CREDENTIAL_FILE` (or `GOOGLE_APPLICATION_CREDENTIALS`) points to a valid service-account JSON file and the Vertex AI API is enabled for your project.
+
+## See Also
+
+- [doc/usage/03-configuration.md](03-configuration.md) — config file structure and roles
+- [doc/reference/04-environment-variables.md](../reference/04-environment-variables.md) — complete environment-variable reference
+- [doc/usage/08-compression.md](08-compression.md) — compression and the compression-decision model

--- a/doc/usage/05-sessions.md
+++ b/doc/usage/05-sessions.md
@@ -5,21 +5,23 @@ All interaction with Octomind happens through sessions. A session is a conversat
 ## Starting Sessions
 
 ```bash
-# Default role
+# Default tag (assistant:concierge)
 octomind run
 
-# Specific role
-octomind run developer
+# A built-in role from your config (assistant, task_refiner, task_researcher, reduce)
+octomind run assistant
 
-# Tap agent
-octomind run octomind:assistant
+# A tap agent from the registry, addressed as category:variant
 octomind run developer:general
+
 # Named session
 octomind run --name feature-auth
 
 # Model override
 octomind run -m anthropic:claude-sonnet-4
 ```
+
+With no argument, `octomind run` uses the configured default tag, which is `assistant:concierge` out of the box. Bare role names like `assistant` refer to the built-in roles shipped in the default config; `category:variant` names like `developer:general` are **tap agents** installed from a registry (see [Roles](06-roles.md) and the tap registry). If you run a tap agent without installing its tap first, Octomind will not find it.
 
 ## Resuming Sessions
 
@@ -44,40 +46,52 @@ Switch session mid-conversation:
 
 ## Output Formats
 
-| Format | Use Case |
-|--------|----------|
-| Interactive (default) | Terminal with colors, markdown, animations |
-| `--format plain` | Piped output, scripts |
-| `--format jsonl` | Structured JSON Lines for automation |
+| Mode | Behavior |
+|------|----------|
+| Interactive (no `--format`, TTY) | Terminal session with colors, markdown, and animations |
+| `--format plain` | Runs **non-interactively**, reading the prompt from stdin. Output is still styled (colors, markdown) when attached to a TTY and unstyled when piped. |
+| `--format jsonl` | Runs non-interactively and always emits structured JSON Lines, regardless of TTY. Ideal for automation. |
+
+The key effect of passing **any** `--format` value is that the session runs once, non-interactively, reading its prompt from stdin instead of the terminal. `plain` does not strip formatting by itself; piping does.
 
 ## Daemon Mode
 
-Keep a session alive in the background:
+Keep a session alive in the background so other processes can inject messages into it:
 
 ```bash
 octomind run --name ci-watcher --daemon --format jsonl
 ```
 
-Send messages to it:
+Send messages to it with `octomind send`:
 ```bash
 echo "Check build status" | octomind send --name ci-watcher
 ```
+
+Daemon mode is meant to run non-interactively. Pair it with `--format jsonl` (or pipe stdin) so the session reads injected messages rather than the terminal. The `--format` pairing is a recommendation, not a hard requirement: a `--daemon` run attached to a TTY with no `--format` starts with an empty initial input and stays interactive-capable.
 
 See [Daemon and Hooks](../integration/03-daemon-and-hooks.md) for webhook integration.
 
 ## Session Commands
 
-All 27 commands available at the session prompt. See [Session Commands Reference](../reference/02-session-commands.md) for details.
+Commands typed at the session prompt control the session without sending a message to the model. The grouped list below covers the full command surface; see the [Session Commands Reference](../reference/02-session-commands.md) for every flag and subcommand.
 
-**Monitoring:** `/info`, `/report`, `/model`, `/role`, `/loglevel`
+**Session lifecycle:** `/help` (alias `/?`), `/exit` (alias `/quit`), `/clear`, `/list`, `/session`
 
-**Context:** `/context`, `/done`
+**Monitoring:** `/info`, `/report`, `/context`, `/loglevel`
+
+**Model & behavior:** `/model`, `/role`, `/effort`, `/prompt`
+
+**Context & compression:** `/done`, `/context`
 
 **Media:** `/image`, `/video`, `/copy`
 
-**MCP & tools:** `/mcp`
+**MCP, tools & capabilities:** `/mcp`, `/run`, `/plan`, `/skill`, `/schedule`
 
-**Commands & workflows:** `/run`, `/workflow`, `/prompt`, `/plan`
+**Learning & sharing:** `/learning`, `/share`, `/analyze`
+
+`/share` uploads the current session log and opens a receipt URL; `/analyze` instead starts a localhost bridge and opens the octomind.run viewer pointed at your machine, so the log never leaves it.
+
+There is no `/workflow` session command. Multi-step workflows run from the external CLI instead: `octomind workflow <file.toml>`.
 
 ## Cost Monitoring
 
@@ -90,14 +104,24 @@ Track token usage and spending:
 Shows:
 - Token counts (input, output, cached, reasoning)
 - Cost per request and cumulative
-- Cache savings
-- Compression statistics
+- Estimated cache savings
+- Per-tool, per-response, per-request (input), and per-compression token averages (each shown only when nonzero)
+- Cache marker stats (system / tool / content markers, non-cached tokens)
+- Compression statistics (when any compression has happened)
 
 Set spending limits in config:
 ```toml
 max_session_spending_threshold = 5.0   # USD per session
 max_request_spending_threshold = 1.0   # USD per request
 ```
+
+### Adjusting model and behavior mid-session
+
+A few commands change runtime settings without touching your global config:
+
+- `/model <provider:model>` switches the active model and **saves it into the session file**, so resuming restores it. It does not change your global config.
+- `/effort <level>` sets the reasoning effort for the session (`low`, `medium`, `high`, `xhigh`, `max`) and also saves it to the session file. It mirrors the `reasoning_effort` config field and is ignored by non-thinking models. See [Configuration](03-configuration.md).
+- `/loglevel <none|info|debug>` changes logging verbosity for the running session only. It is **never** saved to the session file or global config.
 
 ## Multimodal (Vision)
 
@@ -106,14 +130,19 @@ Attach images for AI analysis:
 ```
 /image screenshot.png
 /image /path/to/diagram.jpg
+/image                       # no argument: attach an image from the system clipboard
 ```
 
-Supported formats: PNG, JPEG, GIF, WebP. Vision support depends on the current model. Use `/model` to check or switch to a vision-capable model.
+Supported image formats: PNG, JPEG, GIF, WebP, BMP. Images larger than 5 MB are rejected, and images are automatically resized to fit within 1568x1568.
 
 Attach videos:
 ```
 /video demo.mp4
 ```
+
+`/video` requires a path; it has no clipboard support (running it with no argument is a no-op). Supported video formats: mp4, mov, avi, webm, mkv, m4v, 3gp. Videos larger than 100 MB are rejected.
+
+Attachments are queued onto your **next** message rather than sent immediately, and vision/video support depends on the active model. Use `/model` to check or switch to a vision-capable model.
 
 ## Context Management
 
@@ -122,10 +151,17 @@ As sessions grow, manage context to control costs:
 | Command | Effect |
 |---------|--------|
 | `/done` | Complete task with cleanup, forced compression, and summary |
-| `/context` | View current context |
-| `/context large` | Show only large messages |
+| `/context` | View current context (same as `/context all`) |
+| `/context all` | Show all messages |
+| `/context assistant` | Show only assistant messages |
+| `/context user` | Show only user messages |
+| `/context tool` | Show only tool messages |
+| `/context system` | Show only system messages |
+| `/context large` | Show only large messages (content longer than 1000 characters) |
 
-Automatic compression is also available. See [Compression](08-compression.md).
+An unrecognized filter silently falls back to showing all messages.
+
+Automatic compression also runs as sessions grow. See [Compression](08-compression.md).
 
 ## Custom Instructions
 
@@ -142,4 +178,8 @@ custom_constraints_file_name = "CONSTRAINTS.md"
 
 ## Session Storage
 
-Sessions are stored in `~/.local/share/octomind/sessions/`. Each session is a JSON file containing the full conversation history, tool calls, and metadata.
+Sessions are stored in `~/.local/share/octomind/sessions/` (on Windows, `%LOCALAPPDATA%\octomind\sessions\`). Each session is an append-only, zstd-compressed JSONL log file named `<session_name>.jsonl.zst`. Every line is an independent zstd frame recording conversation messages, tool calls, cost and token snapshots, and compression markers — so the file grows as the session continues rather than being rewritten.
+
+Auto-generated session names follow the pattern `YYMMDD-<project-basename>-HHMM-<uuid>`, where `<uuid>` is the first 4 characters of a UUID. A `--name` you pass replaces this generated name.
+
+Because the file is compressed, `cat` or `jq` will show binary, not text. To inspect a session, resume it (`octomind run --resume <name>`), use `/share` to upload it for viewing, or `/analyze` to open it in the local viewer.

--- a/doc/usage/06-roles.md
+++ b/doc/usage/06-roles.md
@@ -8,20 +8,35 @@ Every session runs with a role. The role determines:
 - **System prompt** -- instructions for the AI
 - **MCP server access** -- which tool servers are available
 - **Tool permissions** -- which specific tools can be used
-- **Model parameters** -- temperature, top_p, top_k
+- **Model parameters** -- `temperature`, `top_p`, `top_k` (and an optional `model` override)
 
-## Built-in Roles
+> **Role vs. tap agent.** A **role** is a plain `[[roles]]` entry in your config, addressed by its bare name (e.g. `assistant`). A **tap agent** is a ready-made manifest published in a tap (a registry of agents), addressed by a `category:variant` **tag** (e.g. `developer:general`). Any tag containing `:` is resolved through the registry, fetching the manifest and merging it on top of your config. See [Tap System](../integration/04-tap-system.md) for details.
 
-Octomind's default tap (`muvon/octomind-tap`) provides production-ready roles:
+## Shipped Config Roles vs. Tap Agents
+
+It helps to know what actually exists out of the box. The default config ships four plain roles, and the default tap (`muvon/tap`, which resolves to the GitHub repo `github.com/muvon/octomind-tap`) provides tap agents addressed by tag:
+
+| Kind | Identifier | What it is |
+|------|------------|------------|
+| Config role | `assistant` | Full-tool built-in role (core/runtime/filesystem/agent, `*:*`) |
+| Config role | `task_refiner` | Lightweight, tool-free query refinement |
+| Config role | `task_researcher` | Tool-free research helper |
+| Config role | `reduce` | Tool-free summarization/reduction |
+| Tap agent | `assistant:concierge` | Default tag in the shipped config (chat-style concierge) |
+| Tap agent | `developer:general` | Full development agent from the `developer` tap category |
+| Tap agent | `assistant:*` | Chat-oriented variants (e.g. the chat-only `octomind:assistant`) |
 
 ```bash
-octomind run octomind:assistant    # Chat-only with tools
-octomind run octomind:developer    # Full development tools
+octomind run assistant:concierge   # Tap agent (default tag in shipped config)
+octomind run developer:general     # Full development tap agent
+octomind run assistant             # Plain config role with full tool access
 ```
+
+> The bare `assistant` config role is **not** chat-only — it has full tool access. The chat-only variant is the tap agent `octomind:assistant`.
 
 ## Defining Custom Roles
 
-Define roles in `[[roles]]` config sections. Custom roles override tap-provided roles with the same name.
+Define roles in `[[roles]]` config sections (always `[[roles]]` — never `[role_name]`). If a tap manifest's `[[roles]]` entry has the same `name` as a config role, the **config role wins** and the manifest role is skipped (see [Role Priority](#role-priority)).
 
 ```toml
 [[roles]]
@@ -42,15 +57,30 @@ allowed_tools = ["core:*", "runtime:*", "filesystem:*", "agent:*"]
 
 ### Role Fields
 
+> **Every field except `model` is mandatory.** `system`, `welcome`, `temperature`, `top_p`, and `top_k` have no defaults — a `[[roles]]` entry missing any of them fails to parse with a deserialization error. Only `model` is optional.
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | yes | Role identifier |
-| `model` | string | no | Model override (`provider:model` format) |
-| `system` | string | no | System prompt (supports [template variables](../reference/04-environment-variables.md#template-variables)) |
-| `welcome` | string | no | Welcome message on session start |
-| `temperature` | f64 | no | Sampling temperature (0.0-2.0) |
-| `top_p` | f64 | no | Nucleus sampling (0.0-1.0) |
-| `top_k` | u32 | no | Top-k token limit (1-1000) |
+| `model` | string | no | Model override (`provider:model` format) — only field that may be omitted |
+| `system` | string | yes | System prompt (supports [template variables](../reference/04-environment-variables.md#template-variables)) |
+| `welcome` | string | yes | Welcome message on session start |
+| `temperature` | f32 | yes | Sampling temperature (0.0-2.0) |
+| `top_p` | f32 | yes | Nucleus sampling (0.0-1.0) |
+| `top_k` | u32 | yes | Top-k token limit (1-1000) |
+
+**Validation ranges (enforced at config load).** Values outside these bounds abort loading with an error like `Role '<name>' temperature must be between 0.0 and 2.0`:
+- `temperature` — `0.0` to `2.0`
+- `top_p` — `0.0` to `1.0`
+- `top_k` — `1` to `1000`
+
+**Model resolution priority.** When more than one source sets a model, the effective model is chosen in this order (highest first):
+
+```
+CLI --model  >  role.model  >  config.model
+```
+
+A role's `model` (whether a plain `[[roles]]` entry or a tap agent's manifest role) is honored directly over the root `config.model`; CLI `--model` still wins. For a tap agent (`category:variant`), a `[taps]` override for that tag replaces the `config.model` tier. For the full model-selection story see [Providers](04-providers.md).
 
 > **Multi-step AI workflows** are no longer bound to roles. Use the external `octomind workflow <file.toml>` CLI instead — see [Workflows](09-workflows.md).
 
@@ -65,6 +95,10 @@ allowed_tools = ["core:*", "runtime:*", "filesystem:*", "agent:*"]
 server_refs = ["core", "filesystem"]  # Only core and filesystem servers
 ```
 
+> **Empty `server_refs = []` disables MCP for the role entirely** — it gets no tool servers at all. This is how the tool-free roles (`task_refiner`, `task_researcher`, `reduce`) run. Internally `RoleMcpConfig::is_enabled()` returns `false` when `server_refs` is empty.
+
+A `server_refs` entry that names a server not present in the global registry is **silently dropped** (it only produces a debug log: `referenced by role but not found in global registry`). See the note on `filesystem` below.
+
 ### Allowed Tools
 
 `allowed_tools` controls which tools within those servers are available:
@@ -74,22 +108,28 @@ server_refs = ["core", "filesystem"]  # Only core and filesystem servers
 server_refs = ["core", "runtime", "filesystem", "agent"]
 allowed_tools = [
   "core:*",              # plan, tap
-  "runtime:mcp",         # only the mcp tool from runtime (skip agent / skill)
+  "runtime:mcp",         # only the mcp tool from runtime (skip agent / skill / schedule / capability)
   "filesystem:view",     # Only view from filesystem
   "filesystem:shell",    # Only shell from filesystem
-  "agent:*",             # All agent_* sub-agent tools
+  "agent:*",             # All agent_<name> sub-agent tools on the agent server
 ]
 ```
 
-**Builtin servers:**
+**Builtin (config-declared) servers** — only these three are declared as `[[mcp.servers]]` in the default config:
 - `core` -- high-level day-to-day tools: `plan`, `tap`.
 - `runtime` -- low-level harness control: `mcp` (register servers), `agent` (register dynamic agents), `skill` (load skills), `schedule`, `capability`. Most roles don't need this.
 - `agent` -- dispatches to `[[agents]]`-defined ACP sub-agents (`agent_<name>` per entry).
 
+> **`filesystem` is not a built-in declared server.** The filesystem tools (`view`, `text_editor`, `batch_edit`, `extract_lines`, `shell`, `ast_grep`, `list_files`, `workdir`) come from the **octofs** companion server supplied by the tap/capability layer, not from a `[[mcp.servers]]` entry. If you copy the examples below into a bare standalone config that has no tap/capability providing `filesystem`, the reference is silently dropped and no filesystem tools appear. To see exactly which tools a server exposes, run `/mcp list` (or `/mcp full`) in a session.
+
 **Pattern syntax:**
-- `"server:*"` -- all tools from a server
-- `"server:tool_name"` -- specific tool
+- `"server:*"` -- all tools from a server (e.g. `agent:*` grants every `agent_<name>` execution tool on the `agent` server)
+- `"server:prefix_*"` -- prefix match within a server (e.g. `filesystem:text_*` matches `text_editor`)
+- `"server:tool_name"` -- one specific tool
+- `"tool_name"` (no colon) -- backward-compat form: matches that tool name across **all** referenced servers
 - Empty array `[]` -- all tools from all referenced servers
+
+> Some tap manifests use a bare-glob form like `agent_*` (no colon) instead of `agent:*`. Both work, via different matching mechanisms; prefer the `server:*` form for clarity and consistency.
 
 ### Global Fallback
 
@@ -102,17 +142,22 @@ allowed_tools = []  # No global restrictions (default)
 
 ## Example Roles
 
+> These examples reference `filesystem`, which (as noted above) is provided by the tap/capability layer. They work when a tap or capability supplies the `filesystem` (octofs) server; in a bare standalone config the `filesystem` references are silently dropped.
+
 ### Full Developer Access
 
 ```toml
 [[roles]]
 name = "developer"
 temperature = 0.3
+top_p = 0.7
+top_k = 20
 system = """
 You are an expert software developer.
 Working directory: {{CWD}}
 Git status: {{GIT_STATUS}}
 """
+welcome = "Developer role ready in {{CWD}}"
 
 [roles.mcp]
 server_refs = ["core", "runtime", "filesystem", "agent"]
@@ -125,7 +170,10 @@ allowed_tools = ["core:*", "runtime:*", "filesystem:*", "agent:*"]
 [[roles]]
 name = "analyst"
 temperature = 0.2
+top_p = 0.7
+top_k = 20
 system = "You analyze code and provide insights. Do not modify files."
+welcome = "Analyst role ready (read-only)."
 
 [roles.mcp]
 server_refs = ["filesystem"]
@@ -139,7 +187,10 @@ allowed_tools = ["filesystem:view"]
 name = "docs"
 model = "openrouter:openai/gpt-4o"
 temperature = 0.4
+top_p = 0.7
+top_k = 20
 system = "You write clear documentation."
+welcome = "Docs role ready."
 
 [roles.mcp]
 server_refs = ["filesystem"]
@@ -152,30 +203,36 @@ allowed_tools = ["filesystem:view", "filesystem:text_editor"]
 ### Starting a Session
 
 ```bash
-# Use default role (from config `default` field)
+# Use the default tag (config `default` field).
+# In the shipped config this is `assistant:concierge` — a TAP AGENT
+# resolved via the registry, not a plain [[roles]] entry.
 octomind run
 
-# Specify role by name
-octomind run developer
-octomind run assistant
+# Specify a plain config role by name
+octomind run assistant            # full-tool built-in role
 
-# Use tap agent
-octomind run octomind:developer
-octomind run developer:general
+# Use a tap agent by category:variant tag
+octomind run developer:general    # full development tap agent
+octomind run assistant:concierge  # chat concierge tap agent
 ```
+
+> There is no plain `developer` role in the default config. `developer` exists only as a tap **category** (variants include `general`, `doc`, `spec`, `readme`, …). Use the tag form `developer:general`. Running `octomind run developer` (a bare, unknown role name) does **not** error — see the caution under [Role Priority](#role-priority).
 
 ### Switching Roles Mid-Session
 
 ```
 /role analyst
-/role developer
+/role assistant
 ```
 
 ### Role Priority
 
-When a role name matches both a config-defined role and a tap agent:
-1. Config-defined `[[roles]]` take priority
-2. Tap agents are used as fallback
+Two distinct cases — don't conflate them:
+
+1. **Manifest vs. config name collision.** When a tap manifest contains a `[[roles]]` entry whose `name` duplicates a role already defined in your base config, the **base (config) role wins** and the manifest's same-named role is skipped (manifest merge dedups by name, base-wins).
+2. **A `category:variant` tag is always a tap agent.** A tag containing `:` (e.g. `developer:general`) is resolved directly through the registry and merged on top of your config — it never contends with a same-prefixed local role. There is no precedence "contest" for tags.
+
+> **Unknown plain role names do not error.** If you pass a bare role name that isn't in your config (e.g. `octomind run developer`), the session does **not** fail — `get_role_config` logs a loud error and falls back to the **first role in the config** (HashMap order, effectively arbitrary) to keep the session alive. Only a `category:variant` tap tag errors, and only if its manifest cannot be fetched. Always spell role names exactly to avoid silently running the wrong role.
 
 ## Auto-Bind Servers
 
@@ -187,7 +244,12 @@ name = "octocode"
 type = "stdio"
 command = "octocode"
 args = ["mcp", "--path=."]
-auto_bind = ["developer"]  # Automatically available in developer role
+auto_bind = ["assistant"]  # Automatically available in the assistant role
 ```
 
-The server is automatically added to the role's `server_refs` even if not explicitly listed.
+`auto_bind` matches the role tag by **exact** string (`"developer"` ≠ `"developer:general"`).
+
+The bound server is automatically added to the role's `server_refs` even if not explicitly listed. There is a second, easy-to-miss half:
+
+- If the role uses a **restricted** `allowed_tools` (a non-empty list), auto-bind also appends `"<server>:*"` to `allowed_tools`, so the bound server's tools are actually permitted. Without this, an auto-bound server in a restricted role would have zero usable tools.
+- If `allowed_tools` is **empty** (unrestricted), no patch is needed — everything from the bound server is already allowed.

--- a/doc/usage/07-mcp-tools.md
+++ b/doc/usage/07-mcp-tools.md
@@ -4,7 +4,7 @@ Octomind uses the Model Context Protocol (MCP) to provide AI models with externa
 
 ## Architecture
 
-Octomind ships with five MCP servers:
+Octomind ships **three builtin MCP servers** declared in the default config (`core`, `runtime`, `agent`), plus an auto-discovered `local` server for project scripts:
 
 | Server | Type | Description |
 |--------|------|-------------|
@@ -12,23 +12,12 @@ Octomind ships with five MCP servers:
 | `runtime` | builtin | Low-level harness reconfiguration: register MCP servers, manage dynamic agents, load skills, schedule, capability |
 | `agent` | builtin | Delegates tasks to configured ACP sub-agents (each `[[agents]]` entry exposes an `agent_<name>` tool) |
 | `local` | builtin | Project-local shebang-script tools auto-discovered from `<workdir>/.agents/tools/`. See [Local Tools](17-local-tools.md). |
-| `filesystem` | stdio (`octofs`) | File operations, shell commands, code analysis |
+
+The filesystem tools (`view`, `text_editor`, `shell`, `ast_grep`, …) are **not** a builtin server. They are served by a separate `octofs` MCP server (a stdio subprocess: command `octofs`, args `["mcp"]`) that is **not declared in the default config**. It is delivered through the built-in default tap [`muvon/tap`](../integration/04-tap-system.md)'s capabilities `filesystem-read` and `filesystem-write`, and roles reach it via `server_refs`/capabilities under the `filesystem` capability name — never a hardcoded `[[mcp.servers]]` block named `filesystem`. See [Filesystem Server Tools (octofs)](#filesystem-server-tools-octofs) below for the prerequisites.
 
 `core` and `runtime` are the two split halves of what used to be a single `core` server. The split separates "what the agent uses to do work" (`core`) from "what reconfigures the harness mid-session" (`runtime`).
 
 Additional servers can be added via `[[mcp.servers]]` config as `http` or `stdio` types.
-
-### Why two builtin servers
-
-The split exists for two reasons: a clearer mental model, and a lower default token tax.
-
-**The taxonomy.** `runtime` answers *"what am I?"* — its tools mutate the agent's identity: register a new MCP server, define a dynamic-agent class, load a skill instruction-pack. `core` answers *"how do I get this done?"* — planning a multi-step task, deferring work, growing the toolset on intent, delegating to a specialist. Most roles always want the second. Only specialized harness-authoring roles want the first.
-
-**The token cost.** Every always-on tool is schema text the model stares at every turn, even when irrelevant. Splitting `runtime` out lets a typical role (`lawyer:sg`, `doctor:blood`, `developer:general`) drop those three tools from its surface entirely — they're never reached for during normal work, and exposing them just adds noise.
-
-**Where new tools go.** When adding a tool, ask: *does it change what the agent **is**, or help the agent **work**?* Identity-change → `runtime`. Work-help → `core`. If neither fits cleanly, it's probably a [capability](#capability----discover-and-activate-domain-bundles) — a domain bundle activated on demand rather than a built-in.
-
-**Direction of travel.** Even `core` is moving toward capability-gated rather than always-on. Today the essentials (`capability`, `tap`, `plan`) are always exposed because they're the bootstrap layer — `capability` loads everything else, `tap` is foundational delegation, `plan` is meta-cognition every role benefits from. Auxiliaries like `schedule`, and the entirety of `runtime`, are good candidates to migrate behind opt-in capability bundles authored in taps. The auto-activation pipeline already handles this for external capabilities; extending it to builtin tools is a tap-side authoring task.
 
 ## Core Server Tools
 
@@ -41,77 +30,23 @@ Break down large objectives into steps with progress tracking.
 
 | Command | Required Params | Description |
 |---------|----------------|-------------|
-| `start` | `title`, `tasks` (array of `{title, description}`) | Begin a new plan |
-| `step` | `content` | Add progress notes to current step |
-| `next` | `content` | Mark current step complete, advance |
-| `list` | -- | Show all steps with status |
-| `done` | `content` (optional) | Complete plan, trigger cleanup |
+| `start` | `content` (plan goal/title), `tasks` (array of `{title, description}`) | Begin a new plan (errors if a plan already exists — `done` or `reset` first) |
+| `step` | `content` | Add progress notes to current task (does not advance it) |
+| `next` | `content` | Mark current task done, advance |
+| `list` | -- | Show all tasks with status |
+| `done` | `content` | Complete plan, trigger cleanup |
 | `reset` | -- | Abort and clear plan |
 
+The plan title comes from the `content` parameter on `start` — there is **no** `title` property on the tool itself (only inside each `tasks` entry). The schema sets `additionalProperties: false`, so a stray top-level `title` key is rejected.
+
 ```json
-{"command": "start", "title": "Implement Auth", "tasks": [
+{"command": "start", "content": "Implement Auth", "tasks": [
   {"title": "Design API", "description": "Create endpoints"},
   {"title": "Write tests", "description": "Unit and integration"}
 ]}
 {"command": "next", "content": "API designed, moving to tests"}
 {"command": "done", "content": "Feature complete"}
 ```
-
-### `schedule` -- Scheduled Message Injection
-
-Schedule messages for future injection into the session — fire at a specific time, or the next time the session becomes idle. Also exposed as the [`/schedule`](../reference/02-session-commands.md#schedule-subcommand-args) slash command for direct user control.
-
-**Parameters:**
-- `command` (string, required): `"add"`, `"list"`, `"remove"`, `"edit"`
-- `message` (string, required for `add`): exact text injected as a user message when the entry fires
-- `when` (string, optional for `add`): when to fire. Defaults to `"idle"` when both `when` and `every` are omitted.
-- `every` (string, optional): repeat interval — entry re-schedules itself after each firing until removed
-
-**`when` formats** (local timezone):
-- `"idle"` — fires the next time the session becomes idle (no running taps, no running background jobs)
-- `"now"` (fires immediately on the next scheduler tick)
-- Relative: `"in 5m"`, `"in 2h"`, `"in 1h30m"`, `"in 90s"`
-- Time today: `"15:30"`, `"3:30pm"`, `"9am"` (past times fire tomorrow)
-- Exact: `"2026-03-22 15:30"`
-
-**`every` format** (omit for one-shot):
-- `"idle"` — fires on every idle transition (pairs with `when="idle"` or omitted)
-- Same syntax as relative `when` without the `in` prefix — `"10m"`, `"1h"`, `"1h30m"`
-- Pass `"none"` (or `"off"`) in `edit` to clear an existing interval
-
-| Command | Required Params | Description |
-|---------|----------------|-------------|
-| `add` | `message` | Schedule a message. `when` defaults to `"idle"`. `description` and `every` optional. |
-| `list` | -- | Show pending entries with countdown |
-| `remove` | `id` | Cancel entry by ID |
-| `edit` | `id` | Update `when`, `message`, `description`, or `every` (time formats only — switch to/from idle by remove + add) |
-
-One-shot entries fire once and are removed; repeating entries (`every` set) re-schedule automatically after each firing. Idle entries fire only when the response loop is idle AND no tap-runs or background-agent jobs are running, so messages cannot interrupt in-flight work. Jobs cancelled on session exit.
-
-### `capability` -- Discover and Activate Domain Bundles
-
-Activate MCP server bundles ("capabilities") on demand. Capabilities are TOML-defined groups of MCP servers and tool filters distributed via taps (`<tap>/capabilities/<name>/<provider>.toml`).
-
-**Parameters:**
-- `action` (string, required): `"list"`, `"discover"`, `"enable"`, `"disable"`
-- `name` (string): Capability name (required for `enable` and `disable`)
-- `intent` (string): Free-text intent for `discover` (e.g., `"I need to query a database"`)
-
-| Action | Description |
-|--------|-------------|
-| `list` | Show every installed capability with active marker |
-| `discover` | Semantic search by intent — top 5 by trigger similarity |
-| `enable` | Register and connect a capability's MCP servers |
-| `disable` | Disconnect and unregister a capability's tools |
-
-```json
-{"action": "list"}
-{"action": "discover", "intent": "I need to query a Postgres database"}
-{"action": "enable", "name": "database-postgres"}
-{"action": "disable", "name": "database-postgres"}
-```
-
-**Auto-activation.** Capabilities also auto-activate before each API call when the user's message strongly matches a capability's hand-authored triggers (semantic match via local embedding, no LLM in the loop). Active set is bounded by an LRU eviction policy (soft cap of 4). Multiple capabilities can safely share the same MCP server — eviction is per-(capability, server, tools), and the underlying server is only stopped when no other active capability references it. See [Token Efficiency](16-token-efficiency.md) for the algorithm and constants.
 
 ### `tap` -- Run Specialist Roles from Taps
 
@@ -128,10 +63,10 @@ Delegate work to a specialist role installed via a tap (e.g. `developer:general`
 
 | Action | Description |
 |--------|-------------|
-| `run` | Launch a role (or resume one). Foreground blocks for the reply; background returns the run id and injects the reply later. |
+| `run` | Launch a role (or resume one via `session`). Foreground blocks for the reply; background returns the run id and injects the reply later. Resuming a run that is still executing a prior turn is rejected with a busy error — wait for it to finish or `stop` it first. |
 | `list` | Show every run in this session: id, role, workdir, status (`running` / `done` / `failed` / `cancelled`), start time. |
 | `stop` | Cancel a running role by id. Sends a watch-channel signal; the run aborts at its next checkpoint. |
-| `discover` | Semantic match free-text intent against installed roles' `# Title:` / `# Description:` headers. Returns top 5. |
+| `discover` | Semantic match free-text intent against installed roles' titles/descriptions. Requires the local embedding model (errors if not ready). Returns roles scoring above 0.2 cosine, top 5. |
 
 ```json
 {"action": "discover", "intent": "review a Singapore employment contract"}
@@ -161,10 +96,10 @@ Manage MCP servers at runtime without editing config.
 |--------|-------------|
 | `list` | Show all servers with status and persistence info |
 | `add` | Register a new server (does not connect yet) |
-| `enable` | Connect and activate a registered server's tools |
+| `enable` | Connect and activate a registered server's tools. Accepts an optional `tools` array to apply a per-enable filter (overrides the registered filter; empty/omitted = all registered tools). |
 | `disable` | Deactivate server tools (config stays) |
 | `remove` | Unregister entirely |
-| `persist` | Save server to config directory |
+| `persist` | Save server config to config dir. If the server is enabled, auto-binds it to the current role (`auto_bind = [role]`); if disabled, clears `auto_bind` (file persists but won't auto-load). |
 | `unpersist` | Remove persisted config file |
 
 **Add parameters:**
@@ -174,7 +109,7 @@ Manage MCP servers at runtime without editing config.
 - `args` (array): Arguments (for stdio)
 - `url` (string): Endpoint (for http)
 - `timeout_seconds` (number): Timeout (default: 60)
-- `tools` (array): Tool filter (empty = all, supports wildcards like `"github_*"`)
+- `tools` (array): Tool filter (empty = all, supports wildcards like `"github_*"`). Also accepted by `enable` for a per-enable filter.
 
 ### `agent` -- Dynamic Agent Management
 
@@ -190,7 +125,7 @@ Manage in-process AI agents at runtime. Each registered agent becomes a tool pre
 - `welcome` (string): Optional welcome message
 - `model` (string): Model override
 - `temperature`, `top_p`, `top_k`: Sampling parameters
-- `server_refs` (array): MCP server references
+- `server_refs` (array): MCP server references — validated at add-time against config-defined and dynamic servers. When left empty, the needed servers are auto-derived from the `allowed_tools` patterns.
 - `allowed_tools` (array): Tool filter (supports wildcards)
 - `workdir` (string): Working directory (default: `"."`)
 
@@ -212,9 +147,80 @@ Manage skills (reusable instruction packs) from taps.
 
 **Skill resources:** Skills can include `scripts/`, `references/`, and `assets/` subdirectories. When activated, a resource catalog with absolute paths is provided.
 
+> **Internal note:** the dispatcher also accepts a `use_silent` action used for silent / auto-activation (env-loaded skills, `/skill` activation). It is not part of the JSON schema enum — the user/AI-facing actions are only `list`, `use`, and `forget`.
+
+### `schedule` -- Scheduled Message Injection
+
+Schedule messages for future injection into the session — fire at a specific time, or the next time the session becomes idle. Also exposed as the [`/schedule`](../reference/02-session-commands.md#schedule-subcommand-args) slash command for direct user control.
+
+**Parameters:**
+- `command` (string, required): `"add"`, `"list"`, `"remove"`, `"edit"`
+- `message` (string, required for `add`): exact text injected as a user message when the entry fires
+- `when` (string, optional for `add`): when to fire. Defaults to `"idle"` when both `when` and `every` are omitted.
+- `every` (string, optional): repeat interval — entry re-schedules itself after each firing until removed
+
+**`when` formats** (local timezone):
+- `"idle"` — fires the next time the session becomes idle (no running taps, no running background jobs)
+- `"now"` (fires immediately on the next scheduler tick)
+- Relative: `"in 5m"`, `"in 2h"`, `"in 1h30m"`, `"in 90s"`
+- Time today: `"15:30"`, `"3:30pm"`, `"9am"` (past times fire tomorrow)
+- Exact: `"2026-03-22 15:30"`
+
+**`every` format** (omit for one-shot):
+- `"idle"` — fires on every idle transition (pairs with `when="idle"` or omitted)
+- Same syntax as relative `when` without the `in` prefix — `"10m"`, `"1h"`, `"1h30m"`
+- Pass `"none"` (or `"off"`) in `edit` to clear an existing interval
+
+| Command | Required Params | Description |
+|---------|----------------|-------------|
+| `add` | `message` | Schedule a message. `when` defaults to `"idle"`. `description` and `every` optional. |
+| `list` | -- | Show pending entries with countdown |
+| `remove` | `id` | Cancel entry by ID |
+| `edit` | `id` | Update `trigger_at` (via `when`), `message`, `description`, or interval (via `every`). Cannot switch an entry between idle and time modes — editing `when` on an idle entry has no firing effect (idle entries ignore `trigger_at`). Recreate the entry (remove + add) to change modes. |
+
+One-shot entries fire once and are removed; repeating entries (`every` set) re-schedule automatically after each firing. Idle entries fire only when the response loop is idle AND no tap-runs or background-agent jobs are running, so messages cannot interrupt in-flight work. Jobs cancelled on session exit.
+
+### `capability` -- Discover and Activate Domain Bundles
+
+Activate MCP server bundles ("capabilities") on demand. Capabilities are TOML-defined groups of MCP servers and tool filters distributed via taps (`<tap>/capabilities/<name>/<provider>.toml`).
+
+**Parameters:**
+- `action` (string, required): `"list"`, `"discover"`, `"enable"`, `"disable"`
+- `name` (string): Capability name (required for `enable` and `disable`)
+- `intent` (string): Free-text intent for `discover` (e.g., `"I need to query a database"`)
+
+| Action | Description |
+|--------|-------------|
+| `list` | Show every installed capability with active marker |
+| `discover` | Semantic search by intent — capabilities scoring above 0.2 cosine, top 5 returned |
+| `enable` | Register and connect a capability's MCP servers (domain-gated — see below) |
+| `disable` | Disconnect a capability's tools (refcount-aware — see below) |
+
+```json
+{"action": "list"}
+{"action": "discover", "intent": "I need to query a Postgres database"}
+{"action": "enable", "name": "database-postgres"}
+{"action": "disable", "name": "database-postgres"}
+```
+
+**`discover` requires the embedding model.** Semantic discovery embeds your intent with the local embedding model (muvon/octomind-embed). If that model is not yet initialized, `discover` returns an error rather than degrading — wait a moment after startup and retry. Results are filtered to cosine score > 0.2 and capped at the top 5.
+
+**`enable` is domain-gated.** A capability whose manifest binds it to specific domains can only be enabled when the session's current domain matches; enabling a cap bound to other domains is refused with an error. Capabilities with no `domains` list are universal and enable anywhere.
+
+**`disable` is refcount-aware.** When multiple active capabilities (or a role's static config) reference the same underlying MCP server, disabling one capability only strips *that* capability's tools — the server keeps running for its other consumers. The server process is fully shut down only when this was the last referencer and no static role config owns it.
+
+**Auto-activation.** Capabilities also auto-activate before each API call when the user's message strongly matches a capability's hand-authored triggers (semantic match via local embedding, no LLM in the loop). Activation uses a similarity threshold of 0.45 with a 0.08 abstain-on-tie margin and considers the top 3 trigger scores; the active set is bounded by an LRU eviction policy (soft cap of 4). See [Token Efficiency](16-token-efficiency.md#deterministic-auto-activation) for the full algorithm.
+
+**Boot-time forcing.** Set `OCTOMIND_CAPABILITIES=cap1,cap2` to force-enable specific capabilities at startup — useful for non-interactive runs that need a deterministic tool surface (e.g. `OCTOMIND_CAPABILITIES=cron,docker octomind run -r ...`). Forced capabilities are still domain-gated.
+
 ## Filesystem Server Tools (octofs)
 
-These tools are provided by the external `octofs` MCP server running as a stdio subprocess.
+These tools are provided by the external `octofs` MCP server (command `octofs mcp`) running as a stdio subprocess. They are **not** a builtin — to have them you need:
+
+1. The `octofs` binary on your `PATH`.
+2. The built-in default tap [`muvon/tap`](../integration/04-tap-system.md) present (auto-cloned on first use), which ships the `filesystem-read` / `filesystem-write` capabilities that declare the `octofs` server.
+
+A role references these tools through its `server_refs` / capabilities under the `filesystem` capability name (the default `assistant` role does this) — there is no hardcoded `[[mcp.servers]]` entry named `filesystem`. Without the tap and binary, these tools will not be present.
 
 ### `view` -- Read Files and Directories
 
@@ -232,6 +238,17 @@ Read files, view directories, and search file content.
 - `lines` (array): `[start, end]` line range
 - `pattern` (string): Search pattern within file/directory
 - `content` (string): Content search query
+
+### `list_files` -- List Directory Entries
+
+List files and directories at a path. Complements `view` (which reads content) when you only need the file listing.
+
+**Parameters:**
+- `path` (string): Directory to list (defaults to the current working directory)
+
+```json
+{"path": "src/"}
+```
 
 ### `text_editor` -- File Editing
 
@@ -443,6 +460,18 @@ This server will automatically be available for the `developer` role on next sta
 MCP servers are monitored automatically:
 - Health checks every 120 seconds for external servers (HTTP + stdio)
 - Builtin servers are always considered healthy
-- Failed servers auto-restart up to 3 times with 30-second cooldown
-- Failed servers reset after 5-minute cooldown period
+- A failed server auto-restarts up to 3 times, waiting 30 seconds between restart attempts
+- The failed-state flag is cleared after a 5-minute cooldown, allowing the server to be retried again (distinct from the 30-second between-attempt wait)
 - Use `/mcp health` to force a health check
+
+## Design Notes: Why Two Builtin Servers
+
+The `core`/`runtime` split exists for two reasons: a clearer mental model, and a lower default token tax.
+
+**The taxonomy.** `runtime` answers *"what am I?"* — its tools mutate the agent's identity: register a new MCP server, define a dynamic-agent class, load a skill instruction-pack. `core` answers *"how do I get this done?"* — planning a multi-step task, deferring work, growing the toolset on intent, delegating to a specialist. Most roles always want the second. Only specialized harness-authoring roles want the first.
+
+**The token cost.** Every always-on tool is schema text the model stares at every turn, even when irrelevant. Splitting `runtime` out lets a typical role (`lawyer:sg`, `doctor:blood`, `developer:general`) drop those three tools from its surface entirely — they're never reached for during normal work, and exposing them just adds noise.
+
+**Where new tools go.** When adding a tool, ask: *does it change what the agent **is**, or help the agent **work**?* Identity-change → `runtime`. Work-help → `core`. If neither fits cleanly, it's probably a [capability](#capability----discover-and-activate-domain-bundles) — a domain bundle activated on demand rather than a built-in.
+
+**Direction of travel.** Even `core` is moving toward capability-gated rather than always-on. Today the essentials (`capability`, `tap`, `plan`) are always exposed because they're the bootstrap layer — `capability` loads everything else, `tap` is foundational delegation, `plan` is meta-cognition every role benefits from. Auxiliaries like `schedule`, and the entirety of `runtime`, are good candidates to migrate behind opt-in capability bundles authored in taps. The auto-activation pipeline already handles this for external capabilities; extending it to builtin tools is a tap-side authoring task.

--- a/doc/usage/08-compression.md
+++ b/doc/usage/08-compression.md
@@ -7,13 +7,23 @@ Octomind automatically manages conversation context size through intelligent com
 As sessions grow, token costs increase and context windows fill up. The compression system:
 1. Monitors token usage against configurable thresholds
 2. Decides whether compression would save money (cache-aware economics)
-3. Compresses older exchanges while preserving recent context
+3. Drains older exchanges into an AI-generated summary while re-injecting the most recent intent
 4. Retains critical knowledge across compressions
+
+Two related safety nets sit on top of the pressure-level engine:
+- **`max_session_tokens_threshold`** (root config, default `200000`) — a hard ceiling that force-compresses unconditionally once exceeded (see [The Hard Ceiling](#the-hard-ceiling)).
+- **Cache keepalive** — an opt-in subsystem that keeps the prompt cache warm during idle time (see [Cache Keepalive](#cache-keepalive)).
+
+> **Hints are not the compression engine.** The `hints_*` fields below only control a cosmetic `/plan next` suggestion shown when an active plan exists. They do **not** gate automatic compression — the engine is driven solely by `pressure_levels` and `max_session_tokens_threshold`.
 
 ## Configuration
 
 ```toml
+# Root config field — the hard compression ceiling (0 = disabled)
+max_session_tokens_threshold = 200000
+
 [compression]
+# hints_* are cosmetic: they only drive the "/plan next" suggestion, NOT compression
 hints_enabled = true
 hints_pressure_threshold = 0.7
 hints_min_interval = 5
@@ -29,7 +39,7 @@ target_ratio = 4.0    # Medium: 75% reduction
 
 [[compression.pressure_levels]]
 threshold = 160000
-target_ratio = 8.0    # Aggressive: 87.5% reduction
+target_ratio = 8.0    # Aggressive: 87.5% reduction (clamped to 4.0x for automatic compression — see below)
 
 [compression.decision]
 model = "openai:gpt-5-mini"
@@ -48,26 +58,44 @@ See [Configuration Reference](../reference/03-config-reference.md#compression) f
 
 ### Token-Based Triggers
 
-Compression triggers when the full context (messages + system prompt + tool definitions + safety margin) exceeds a pressure level threshold. The highest matched threshold determines the **base** compression ratio, but the actual level used is **escalated** based on consecutive compressions (round-robin through levels). This prevents infinite loops when compress-all drops context hard and it grows back to the same threshold repeatedly.
+Compression triggers when the full context (messages + system prompt + tool definitions + safety margin) exceeds a pressure level threshold. The highest matched threshold determines the **base** compression ratio, but the level actually applied is **escalated** by the number of consecutive compressions, clamped at the highest level — it never wraps back to a lighter ratio under sustained pressure. This prevents infinite loops when compress-all drops context hard and it grows back to the same threshold repeatedly.
 
-| Token Count | Compression | Effect |
-|-------------|-------------|--------|
+| Token Count | Configured Ratio | Effect |
+|-------------|------------------|--------|
 | 60,000+ | 2.0x | 50% reduction |
 | 120,000+ | 4.0x | 75% reduction |
 | 160,000+ | 8.0x | 87.5% reduction |
 
+**Adaptive ratio.** The matched ratio is not used verbatim for automatic compression. It is scaled by recent session activity and then clamped to **[1.5, 4.0]**:
+
+- ×1.2 when an active plan exists (longer session expected → compress harder)
+- ×1.15 when tool density (`tool_calls / api_calls`) > 2.5 (heavy exploration)
+- ×1.0 when tool density > 1.0 (normal)
+- ×0.9 when tool density > 0.3 (winding down)
+- ×0.8 otherwise (session ending soon)
+
+Adaptive scaling only kicks in after the first 5 API calls; before that the base ratio is trusted as-is. Because the final value is clamped at 4.0, the configured **8.0 level effectively caps at 4.0x for automatic compression** — the full 8.0 ratio is never applied. (Forced `/done` compression skips adaptive scaling and uses the first level's ratio directly; see [Forced vs Automatic Compression](#forced-vs-automatic-compression).)
+
+### The Hard Ceiling
+
+`max_session_tokens_threshold` (root config, default `200000`) is the single most important compression control. When the full-context token count reaches this value, compression is **forced unconditionally** — it bypasses the exponential cooldown, the cache-aware cost analysis, the feasibility check, and the AI's veto (the decision model cannot decline). The ratio used is the **maximum `target_ratio` across all pressure levels**.
+
+This same value is the denominator for the `/plan next` hint pressure calculation. Setting it to `0` disables **both** the hard ceiling and the hints.
+
 ### Exponential Cooldown
 
-To prevent compression loops during tool-heavy operations, consecutive compressions (without a user message between them) require increasing token growth:
+To prevent compression loops during tool-heavy operations, each consecutive compression (without a user message between them) doubles the token growth required before the next compression is allowed. The required growth is `min(0.10 × 2ⁿ, 1.0)`, where `n` is the number of compressions already performed:
 
-| Consecutive Compressions | Required Growth Before Re-compression |
-|--------------------------|--------------------------------------|
-| 1st | 10% |
-| 2nd | 20% |
-| 3rd | 40% |
-| 4th+ | 80-100% (capped) |
+| After this many compressions | Required Growth Before Re-compression |
+|------------------------------|---------------------------------------|
+| 1st | 20% |
+| 2nd | 40% |
+| 3rd | 80% |
+| 4th+ | 100% (capped — context must double) |
 
-The cooldown resets when the user sends a new message. It also activates when the compression range is invalid (e.g., `start_idx >= end_idx`) or when compression won't bring context below the threshold — preventing futile re-analysis loops.
+The watermark check is inactive until the first compression sets `context_tokens_after_last_compression > 0`. The cooldown resets when escalation stops (a check that finds nothing to compress) and on forced `/done` compression.
+
+Two escape hatches set the **same** watermark (`context_tokens_after_last_compression = current_tokens`) to suppress re-analysis until context grows again — they are not a separate cooldown mechanism: (1) the chosen compression range is empty (`start_idx >= end_idx`), and (2) compression would not bring context below the threshold that fired. Both occur only inside the `net_benefit > 0` branch.
 
 ### Cache-Aware Economics
 
@@ -82,30 +110,47 @@ net_benefit =
 **If net_benefit > 0**: Compress (saves money).
 **If net_benefit <= 0**: Skip (would cost money).
 
-**Cost factors:**
-- Cache write cost: 1.25x base token cost
-- Cache read cost: 0.1x base token cost (90% savings on cached content)
-- Compression cost: AI decision + summarization (typically 2-3k tokens)
-- Cache invalidation: compression forces cache rewrite at 1.25x cost
+**Cost factors** use **per-model pricing fetched from the provider** (`ModelPricing`: input / output / cache-write / cache-read per 1M tokens). The cache-write and cache-read multipliers vary by provider; the figures below are illustrative Anthropic-typical values, not octomind constants:
 
-**Future turn estimation** uses velocity-based analysis:
-- Tracks actual calls/minute during the session
-- Accounts for session lifecycle (early sessions have more remaining time)
-- Applies velocity decay (sessions slow down over time)
-- Bounded: minimum 5 calls, maximum 2x current calls or 100
+- Cache write: ~1.25x base token cost (illustrative)
+- Cache read: ~0.1x base token cost (~90% savings on cached content; illustrative)
+- Compression cost: a single combined decision+summary LLM call (see below)
+- Cache invalidation: compression forces a cache rewrite of the surviving prefix
+
+Two short-circuits replace the cost math when pricing is unusable:
+- **Free/zero-priced session model** (e.g. local `ollama`): always compress, for context management (cost is irrelevant).
+- **Pricing unavailable**: skip compression — unless `ignore_cost = true`, which treats missing pricing as zero cost and compresses anyway.
+
+**One combined LLM call.** Compression is decided and summarized in a **single** request (`ask_ai_decision_and_summary`) that returns a typed `CompressionSummary` carrying both `should_compress` and the full narrative sections — there is no separate decision call followed by a summarization call. The call uses JSON-schema mode for providers that support structured output, and an XML-tagged prompt otherwise. If the model returns `should_compress = true` but every narrative field is empty, compression is **refused** (the substantive-summary gate) to avoid wiping context with a header-only summary.
+
+**Future turn estimation** uses no time or velocity signal. It is:
+
+```
+estimate    = min(headroom / growth_rate, api_calls_so_far)
+future_turns = max(estimate × accuracy, 5)
+```
+
+- `headroom` = tokens freed by this compression; `growth_rate` = output tokens per call (incremental since the last compression, else lifetime average).
+- `api_calls_so_far` is the symmetry estimate (work remaining ≈ work done). When there are no calls yet (cold start), the physical ceiling is capped at **100** instead.
+- `accuracy` is a self-tuning factor (actual ÷ predicted from the last cycle, clamped **[0.25, 4.0]**) that corrects systematic over/under-estimation.
+- The result is floored at **5**. There is no "calls per minute", velocity decay, or "2x current calls" cap.
 
 ### Forced vs Automatic Compression
 
 The `/done` command triggers **forced compression**, which behaves differently from automatic compression:
 
 | Behavior | Forced (`/done`) | Automatic |
-|----------|-------------------|-----------|
-| Minimum context threshold | Bypassed (20% floor ignored) | Respected |
-| Exponential cooldown | Resets counters | Applied normally |
-| Aggressiveness | More aggressive cleanup | Preserves more context |
+|----------|------------------|-----------|
+| Exponential cooldown | Bypassed | Applied |
+| Cost gate (`net_benefit`) | Bypassed | Enforced |
+| Feasibility check ("won't drop below threshold") | Bypassed | Enforced |
+| AI veto | Forced — AI cannot decline | AI may decline |
+| Min. conversation messages | 3 | 5 |
+| Compression ratio | First level's `target_ratio` (default 2.0), no adaptive scaling | Adaptive, clamped [1.5, 4.0] |
+| Cooldown counters after | Reset to 0 | `consecutive_compressions` incremented |
 | Purpose | Session boundary — clean slate | Mid-session cost optimization |
 
-Forced compression marks a task boundary. It resets cooldown counters so the next task starts fresh without accumulated compression debt.
+Note that `/done` is **less** aggressive on ratio than a high-pressure automatic compression: it uses the lightest configured level (default 2.0x) with no adaptive adjustment. Its "clean slate" character comes from bypassing the gates and resetting both `consecutive_compressions` and `context_tokens_after_last_compression` to 0, so the next task starts without accumulated compression debt — not from a higher ratio.
 
 ### Skill Preservation
 
@@ -123,65 +168,94 @@ Skills injected into context are handled differently depending on the compressio
 
 ### Context Preservation
 
-- Last 4 turns (2 exchanges) always remain uncompressed
-- Semantic grouping preserves related messages together
-- Importance weighting prioritizes recent and tool-related messages
-- Discourse flow maintains reasoning chains
+Range selection is purely structural — there is no semantic grouping, importance weighting, discourse-flow analysis, or "last N turns kept verbatim" carve-out. The engine:
+
+1. Picks an **anchor**: the latest `<instructions>` user message, or (if none) the first user message. The anchor is kept.
+2. **Drains everything** between the anchor and the end of the conversation (`anchor_idx + 1` through the last message).
+3. Re-inserts, in order: preserved active-skill messages, the AI-generated summary, then a synthetic `<continuation>` wrapper.
+
+The only recent context that survives is therefore carried by the **summary** and the **continuation wrapper** — not by uncompressed turns:
+
+- **Summary** — an AI-generated entry that begins with a `## USER TASKS` list of up to the **last 4 older user requests** (raw, not AI-rephrased, so intent is never lost), followed by the narrative sections. The current active plan (if any) is appended so the model needn't spend a turn recovering it.
+- **`<continuation>` wrapper** — a synthetic user message carrying the most recent real user intent inside a `<task>` tag. It signals an in-progress task (preventing "fresh start" hallucinations) and is tagged so the next compression cycle's USER TASKS list skips it.
+
+(For minimum-message gating, automatic compression needs at least 5 conversational messages after the anchor; forced `/done` lowers this to 3.)
 
 ### Knowledge Retention
 
-Each compression may extract critical knowledge (decisions, constraints, preferences). The last N entries (configurable via `knowledge_retention`, default: 10) are injected into every subsequent compression, ensuring the AI never loses essential context.
+Each compression may extract critical knowledge (decisions, constraints, preferences). New entries are appended and the list is FIFO-trimmed to the most recent N (configurable via `knowledge_retention`, default: 10) — the oldest are dropped when the limit is exceeded. The retained entries are injected into every subsequent compression so the AI never loses essential context.
+
+**Intermediate learning.** When `learning.enabled = true` and the conversation has at least `learning.min_messages_for_intermediate` user messages (default 3), each automatic compaction also fires a fire-and-forget lesson-extraction pass. This is asynchronous and never blocks compression. See [Learning](13-learning.md).
+
+### Cache Keepalive
+
+When you walk away after the AI replies, the prompt cache TTL counts down and the next turn may miss cache. Cache keepalive keeps it warm with minimal `max_tokens = 1` idle pings against a frozen snapshot of the conversation:
+
+```toml
+cache_keepalive_enabled = false          # opt-in (default false)
+cache_keepalive_max_idle_seconds = 1800  # stop pinging 30 min after last activity (0 = until session ends)
+```
+
+- **Anthropic-only** today. Only providers whose API supports refresh-on-read are pinged; others (OpenAI implicit cache, Gemini, DeepSeek) are skipped to avoid wasted requests.
+- The ping **interval comes from the provider**, not from config.
+- Pings only fire when the snapshot actually has a cached message (otherwise there is nothing to keep warm).
+- Each ping costs cache-read tokens; those costs are folded back into the session cost.
 
 ## Decision Model
 
-Use a fast, cheap model for compression decisions to minimize overhead:
+Use a fast, cheap model for compression decisions to minimize overhead. Relative cost ranking (the dollar figures are rough illustrative estimates, not measured guarantees):
 
-| Model | Cost per Decision | Recommendation |
-|-------|-------------------|----------------|
-| `openai:gpt-5-mini` | ~$0.0001 | Default (fast, cheap) |
-| `anthropic:claude-haiku-4-5` | ~$0.0003 | Alternative |
-| `anthropic:claude-sonnet-4` | ~$0.003 | 10x more expensive |
+| Model | Relative Cost | Recommendation |
+|-------|---------------|----------------|
+| `openai:gpt-5-mini` | cheapest | Default (fast, cheap) |
+| `anthropic:claude-haiku-4-5` | ~$0.0003 per decision | Alternative |
+| `anthropic:claude-sonnet-4` | ~$0.003 per decision (~10x Haiku) | More capable, more expensive |
+
 Set `ignore_cost = true` in `[compression.decision]` to exclude compression decision costs from session cost tracking.
 
 ## Monitoring
 
-Use `/info` to see compression statistics:
+Use `/info` to see compression statistics. The `compression` block shows:
 
 ```
-Compression Statistics:
-  Total compressions: 3
-  Average reduction: 72.5%
-  Total tokens saved: 45,000
-  Cost saved: $0.045
-
-  Last compression:
-    Before: 98,500 tokens
-    After: 24,625 tokens (4.0x compression)
-    Cost saved: $0.0225
+compression
+  conversation       3
+  messages removed   128
+  tokens saved       45,000
+  avg ratio          81.8%
 ```
+
+- `conversation` — count of conversation compressions (shown only when > 0).
+- `messages removed` — cumulative messages drained across all compressions.
+- `tokens saved` — cumulative tokens reclaimed.
+- `avg ratio` — a saturating heuristic, `tokens_saved / (tokens_saved + 10000)` rendered as a percentage, not a literal compression ratio.
+
+There is no per-compression before/after breakdown and no cost-saved figure in this block.
 
 ## Examples
+
+These illustrate the net-benefit logic with the default pressure levels. Numbers are rounded for clarity; the real engine uses provider-reported pricing and the estimation model described above.
 
 ### Profitable Compression
 
 ```
-Session: 95,000 tokens | Threshold: 100,000 (4.0x)
-Estimated remaining turns: 5
+Session: 125,000 tokens | Threshold 120,000 fired (adaptive ~4.0x)
+Estimated remaining turns: ~8 (many calls still ahead)
 
-Without compression: 5 * 95k * $0.003 = $1.425
-With compression:    cache invalidation + 5 * 24k * $0.003 = $0.594
-Net benefit: $0.831 --> COMPRESS
+Without compression: each future call re-reads ~125k cached tokens
+With compression:    one-time cache rewrite + future calls re-read ~31k
+Net benefit: positive --> COMPRESS
 ```
 
 ### Skipped Compression
 
 ```
-Session: 55,000 tokens | Threshold: 50,000 (2.0x)
-Estimated remaining turns: 1
+Session: 62,000 tokens | Threshold 60,000 fired (adaptive ~2.0x)
+Estimated remaining turns: 5 (floor — session winding down)
 
-Without compression: 1 * 55k * $0.003 = $0.165
-With compression:    cache invalidation + 1 * 28k * $0.003 = $0.220
-Net benefit: -$0.055 --> SKIP (would cost money)
+The cache-rewrite cost now plus a few cheap remaining calls
+outweighs the savings on those calls.
+Net benefit: negative --> SKIP (would cost money)
 ```
 
 ## Best Practices
@@ -189,15 +263,16 @@ Net benefit: -$0.055 --> SKIP (would cost money)
 1. **Monitor effectiveness** with `/info` to verify compression saves money
 2. **Use a cheap decision model** -- `openai:gpt-5-mini` is the default; `anthropic:claude-haiku-4-5` is a good alternative
 3. **Start conservative** with default thresholds, adjust based on workflow
-4. **Disable for short sessions** if sessions rarely exceed 50k tokens
+4. **Disable for short sessions** (empty `pressure_levels`) if sessions rarely reach the lowest threshold (60k by default)
 5. **Increase thresholds** if compression triggers too frequently
 
 ## Troubleshooting
 
 **Compression not triggering:**
-- Verify `hints_enabled = true`
-- Check `[[compression.pressure_levels]]` is not empty
-- Use `/info` to see current token count vs. thresholds
+- Check `[[compression.pressure_levels]]` is non-empty and a threshold is actually exceeded.
+- If you rely on the hard ceiling, confirm `max_session_tokens_threshold > 0`.
+- Use `/info` to see the current token count vs. your thresholds.
+- Note: `hints_enabled` does **not** control compression. It only gates the cosmetic `/plan next` hint (which additionally requires an active plan and a non-zero `max_session_tokens_threshold`). Changing it will not make compression trigger.
 
 **Compression too aggressive:**
 - Lower `target_ratio` values (e.g., 2.0 instead of 4.0)

--- a/doc/usage/09-workflows.md
+++ b/doc/usage/09-workflows.md
@@ -1,22 +1,23 @@
 # Workflows
 
-`octomind workflow <file.toml>` is an external orchestrator that chains multiple `octomind run` invocations into a multi-step process. Each step is an independent subprocess; outputs flow between steps by name; the final result goes to stdout — making workflows composable with shell pipes.
+`octomind workflow <file.toml>` is an external orchestrator that chains multiple `octomind run` invocations into a multi-step process. Each step is an independent subprocess; outputs flow between steps by name; everything you see — per-step responses, progress, costs, totals — is written to **stderr** for a human to watch.
+
+> **There is no machine-readable stdout result.** A real run prints nothing to stdout; stdout is used *only* by `--dry-run` to print the execution plan. Don't build shell pipelines that consume the workflow's stdout — they will get nothing. If you need a step's text downstream, read it from stderr or have the final step write to a file itself.
 
 > **In-session input preprocessing** via `[[pipe]]` in `.agents/guardrails.toml` runs before the model — see [Guardrails](18-guardrails.md#pipe--pre-model-input-transform). Workflows sit *above* sessions; pipes sit *inside* one.
 
 ## Concept
 
 ```
-stdin ─► octomind workflow file.toml ─► stdout (final step output)
+stdin ─► octomind workflow file.toml
                     │
                     ├── step "spec"      → octomind run (subprocess)
                     ├── step "developer" → octomind run (subprocess)  ─┐
                     └── step "tester"    → octomind run (subprocess)  ─┘  loop
-                                                                          │
-                                                                          ▼
-                                                              stderr: per-step
-                                                                progress, cost,
-                                                                tokens, totals
+                    │
+                    ▼
+        stderr: per-step responses + progress, cost, tokens, totals
+        stdout: (nothing — only --dry-run prints the plan here)
 ```
 
 A workflow file is a portable TOML document — no edits to `default.toml` or any role config are needed. Each step invokes `octomind run --format jsonl`, streams the JSONL event log, accumulates assistant text and cost/token totals, then hands the captured output to the next step.
@@ -30,8 +31,9 @@ echo "build a JSON-to-CSV CLI in Rust" | octomind workflow myflow.toml
 octomind workflow myflow.toml --dry-run
 ```
 
-- stdin is required (unless `--dry-run`); empty stdin is a hard error.
-- stderr receives each step's assistant message (rendered as markdown when enabled), progress lines, per-step stats, warnings, and the final total. stdout is unused.
+- The file is read, TOML-parsed, and fully validated **before** anything else — including before stdin is touched. `--dry-run` therefore never reads stdin.
+- stdin is required for a real run (not for `--dry-run`). Both a terminal stdin (nothing piped) and an empty piped stdin (empty after trimming) fail with the same error: `workflow requires input via stdin`.
+- stderr receives each step's assistant message (rendered as markdown when `enable_markdown_rendering` is on), progress lines, per-step stats, warnings, and the final total. **stdout carries nothing except the `--dry-run` plan.**
 
 ## File format
 
@@ -120,14 +122,38 @@ SCORE: <n>/10
 
 ## Variable substitution
 
-Anywhere in a prompt, `{{name}}` is substituted with:
+Every step prompt is resolved in **three passes**, in order, exactly like the interactive chat resolves user input:
+
+**Pass 1 — workflow variables.** Anywhere in a prompt, `{{name}}` is substituted with:
 
 | Variable           | Value                                                                  |
 |--------------------|------------------------------------------------------------------------|
-| `{{input}}`        | The raw stdin content                                                  |
+| `{{input}}`        | The raw stdin content (trimmed)                                        |
 | `{{step_name}}`    | The full text output of a previously completed step (by name)          |
 
-Forward references (`{{later}}` from an earlier step) are rejected at pre-flight validation. Step names must be unique across the entire file, including all sub-steps.
+An unknown `{{var}}` is left **untouched** in this pass so the next pass can claim it as a built-in.
+
+**Pass 2 — built-in placeholders.** The same canonical chat helper then expands these built-ins (no quotes, used bare in the prompt):
+
+| Placeholder      | Expands to                                              |
+|------------------|---------------------------------------------------------|
+| `{{DATE}}`       | Current date/time                                       |
+| `{{CWD}}`        | Project working directory                               |
+| `{{SHELL}}`      | Detected shell                                          |
+| `{{OS}}`         | Operating system                                        |
+| `{{BINARIES}}`   | Available developer binaries on PATH                    |
+| `{{ROLE}}`       | The resolved role name                                  |
+| `{{SYSTEM}}`     | System info summary                                     |
+| `{{CONTEXT}}`    | Project context bundle                                  |
+| `{{GIT_STATUS}}` | `git status` of the working directory                   |
+| `{{GIT_TREE}}`   | Git-tracked file tree                                   |
+| `{{README}}`     | Project README contents                                 |
+
+> **Caveat — built-in placeholders are rejected by pre-flight validation today.** Validation (run for every workflow, including `--dry-run`, in `src/workflow/validate.rs`) flags **any** `{{var}}` that is not `{{input}}` or a declared step name as an *unknown variable* and aborts before the step runs. The built-ins above are not step names, so a step prompt that contains one (e.g. `{{DATE}}`) fails validation and never reaches this expansion pass. In practice, only `{{input}}` and `{{step_name}}` references are usable in workflow step prompts; put date/context information into the step prompt text directly instead.
+
+**Pass 3 — context file inlining.** Any `<context>path</context>` or `<context>path:start:end</context>` block is replaced with the named file's contents rendered as XML (the same file-context path chat uses). Use `path:start:end` to inline only a line range. Because this runs on every step prompt, a step can also emit a `<context>...</context>` block in *its own* response and the next step that interpolates `{{that_step}}` will receive the file inlined.
+
+Forward references (`{{later}}` from an earlier step) are rejected at pre-flight validation — which rejects **any** `{{var}}` that is not `{{input}}` or an already-defined step name (see the caveat above). Step names must be unique across the entire file, including all sub-steps. `<context>` blocks use angle brackets rather than `{{ }}`, so they are not treated as variable references.
 
 ## Step types
 
@@ -146,6 +172,8 @@ Optional fields on any sequential step (including sub-steps inside parallel/loop
 ### Parallel (`parallel = true`)
 Sub-steps run concurrently via `tokio::join_all`. The next top-level step starts only after every sub-step completes. Sub-steps cannot reference each other; only outer scope.
 
+A `session = "continue"` field on a parallel sub-step is **silently ignored** — parallel sub-steps always run with a fresh session. Continue-session state only makes sense across the sequential iterations of a loop.
+
 ### Loop (`loop = true`)
 Sub-steps run sequentially within each iteration. Between iterations, `exit_when` is checked against the named step's output:
 
@@ -158,6 +186,8 @@ If `max_iterations` is reached without exit, the loop exits with the last iterat
 ### Conditional (`conditional = true`)
 `condition` tests a prior step output (same shape as `exit_when`). On match, the names in `on_match` run; otherwise `on_no_match` runs. Skipped sub-step names resolve to empty strings in later substitutions.
 
+Omitting `output` in the `condition` tests the most recently completed step. If **no** step has completed yet (the conditional is the first step), the workflow fails with `conditional step '<name>': no prior step output to test`.
+
 ## Session modes
 
 | Mode                          | Behaviour                                                              |
@@ -167,36 +197,54 @@ If `max_iterations` is reached without exit, the loop exits with the last iterat
 
 **Continue-session prompt rule:** on the *first* run of a continue-session, the templated prompt is sent. On *subsequent* runs, the templated prompt is **replaced** with the most recent prior step's raw output — the session already holds the full context, so it just needs the latest signal to react to. This is what makes the generator↔tester GAN pattern work without re-feeding the whole spec each iteration.
 
-Each step owns its own session ID. In a loop, `developer` and `tester` accumulate independent histories.
+Each step owns its own session ID. In a loop, `developer` and `tester` accumulate independent histories. The generated session name has the form `wf-<sanitized-workflow-name>-<step-name>-<short-uuid>` (workflow name sanitized to ASCII alphanumerics and `-`; short-uuid is the first segment of a UUIDv4). These sessions are ephemeral to one `octomind workflow` invocation and are not reused across runs.
 
 ## Retries and timeouts
 
 - `retries = N` — up to N additional attempts on failure (default 0 ≙ one attempt).
 - A step "fails" when the subprocess exits non-zero **or** produces no assistant output.
 - `timeout = S` — seconds before the subprocess is killed (default 0 ≙ no timeout). A timeout counts as a failure for retry logic.
-- All retries exhausted → workflow exits non-zero with `step '<name>' failed after <N> attempts`.
+- All retries exhausted → workflow exits non-zero with `step '<name>' failed after <N> attempts: <reason>`, where `<reason>` is the last attempt's failure — e.g. `failed exit code Some(1) (attempt N/N)`, `timed out after Ss (attempt N/N)`, `produced no assistant output (attempt N/N)`, or `spawn error: ...`.
 
 ## Progress output (stderr)
 
+All progress goes to **stderr**. The exact rendering depends on whether stderr is a terminal:
+
+- **Interactive (stderr is a TTY):** each step opens a `╭ <name>` box and, while it runs, a live spinner shows the latest stream event plus a dimmed running aggregate (elapsed · cost · ⚒tools). When the step finishes the spinner clears and the box closes with `╰ ✓ <name>  …stats`.
+- **Piped / redirected:** no spinner — each JSONL event is streamed as one line under a `│ ` rail. The events surfaced are `ToolUse` (`▸ tool · server` plus params), `Skill`, `Status`, `McpNotification`, and `Error`. Assistant text, thinking, and cost events are not rendered as rail lines; failed tool calls are surfaced separately via the `⚒N ✗F` count in the per-step and total stats.
+
+A complete run looks like this (color stripped):
+
 ```
-╭ workflow: my-workflow
-  ► spec           running...
-  ✓ spec           2.1s  $0.0042  1240 tok
-  ► refine [1/3]   developer    running...
-  ✓ refine [1/3]   developer    8.4s  $0.0156  3208 tok
-  ► refine [1/3]   tester       running...
-  ✓ refine [1/3]   tester       3.2s  $0.0078  1450 tok
-  ✓ exit condition matched at iteration 1
-  ► evaluator      running...
-  ✓ evaluator      1.8s  $0.0029  890 tok
-╰ Total: 15.5s  $0.0305  6788 tok
+workflow · my-workflow
+
+╭ spec
+│ ▸ shell · octofs
+╰ ✓ spec  2.1s  · $0.0042  · 1240 tok  · ⚒3
+
+╭ developer  [1/3] refine
+╰ ✓ developer  8.4s  · $0.0156  · 3208 tok  · ⚒12
+
+╭ tester  [1/3] refine
+╰ ✓ tester  3.2s  · $0.0078  · 1450 tok  · ⚒2
+· loop 'refine' exit at iteration 1
+
+╭ evaluator
+╰ ✓ evaluator  1.8s  · $0.0029  · 890 tok  · ⚒0
+
+total · 15.5s  · $0.0305  · 6788 tok  · ⚒17
 ```
 
-Stats come from the `cost` events in the JSONL stream emitted by `octomind run --format jsonl`. Cost (`session_cost`), input/output/cache/reasoning tokens, and wall-clock duration are aggregated per step and totalled at the end.
+- The header is `workflow · <name>` and the footer is `total · <dur>  · $<cost>  · <tok> tok  · ⚒<tools>`.
+- Inside a loop, the box title carries a `[i/max] <loop-name>` suffix.
+- A failed attempt closes with `╰ ✗ <name>  <reason>` instead of `╰ ✓ …`.
+- The `⚒N` glyph is the tool-call count; on failures it becomes `⚒N ✗F` (F = failed tool calls).
+
+**Where the numbers come from.** Stats are sourced from the JSONL stream emitted by `octomind run --format jsonl`: cost, token totals, and per-event tool tracking. Per-step `cost`, `input_tokens`, and `output_tokens` come from the `cost` event's payload, and the **token total shown is `session_tokens`** (the session-wide total reported by the run), *not* `input + output`. Tool counts are tallied live: `⚒N` increments on each `ToolUse` event and `✗F` increments on each failed `ToolResult`. Duration is wall-clock time of the subprocess. The footer sums duration, cost, tokens, and tool counts across every step.
 
 ## --dry-run
 
-`octomind workflow file.toml --dry-run` validates the file, resolves the execution graph, and prints the plan to stdout without spawning any `octomind run` processes or reading stdin. Use it to sanity-check a workflow before paying for tokens.
+`octomind workflow file.toml --dry-run` validates the file, resolves the execution graph, and prints the plan to **stdout** — the one and only thing a workflow ever writes to stdout. It spawns no `octomind run` processes and never reads stdin (validation runs before the stdin step, and `--dry-run` returns immediately after). Use it to sanity-check a workflow before paying for tokens.
 
 ## Validation
 
@@ -279,4 +327,4 @@ Intentionally not supported (use shell composition or call `octomind run` direct
 - Named workflow lookup by short name (explicit path only)
 - Cross-invocation session persistence for `continue` sessions
 - Step artifacts written to disk
-- Structured (JSON) output from the workflow command itself
+- Any machine-readable stdout result. Everything is human-facing on stderr; stdout only ever carries the `--dry-run` plan.

--- a/doc/usage/10-commands-and-layers.md
+++ b/doc/usage/10-commands-and-layers.md
@@ -1,6 +1,13 @@
 # Commands, Layers, Agents, and Prompts
 
-Octomind provides four mechanisms for extending AI capabilities beyond the base session.
+Octomind provides four mechanisms for extending AI capabilities beyond the base session:
+
+- **Layers** — orchestration stages invoked programmatically (`[[layers]]`).
+- **Commands** — the same thing as layers, but triggered interactively with `/run <name>` (`[[commands]]`).
+- **Agents** — specialized AI instances exposed as MCP tools (`[[agents]]`, plus runtime dynamic agents).
+- **Prompts** — reusable prompt templates queued with `/prompt <name>` (`[[prompts]]`).
+
+All of these are user-defined (or provided by a tap). Octomind does not ship any built-in `[[layers]]`; the default config ships one command (`reduce`) and one agent (`context_gatherer`).
 
 ## Layers
 
@@ -8,15 +15,19 @@ Layers execute via ACP (Agent Client Protocol). Model, system prompt, and MCP to
 
 ### Configuration
 
+The example below is an illustrative custom layer — it is not shipped by default and requires a matching `analysis` role in `[[roles]]` (see the role example below):
+
 ```toml
 [[layers]]
-name = "task_refiner"
-description = "Refines and clarifies user requests for better processing"
-command = "octomind acp task_refiner"
+name = "analysis"
+description = "Performs detailed analysis of code, systems, or requirements"
+command = "octomind acp analysis"
 input_mode = "last"
-output_mode = "none"
+output_mode = "append"
 output_role = "assistant"
 ```
+
+`input_mode`, `output_mode`, and `output_role` are **all mandatory** — they have no serde defaults, so omitting any of them is a TOML parse error. Only `workdir` defaults (to `"."`).
 
 ### Input Modes
 
@@ -24,7 +35,7 @@ How the layer receives conversation input:
 
 | Mode | Description |
 |------|-------------|
-| `"last"` | Only the last assistant/message from the session (default) |
+| `"last"` | The last assistant message from the session (falls back to the last user message if there are no assistant messages) |
 | `"all"` | Entire conversation history from the session |
 | `"summary"` | A summarized version of the conversation history |
 
@@ -39,14 +50,8 @@ How the layer's output affects the session:
 | `"replace"` | Replaces entire session content with layer output (reducer functionality) |
 | `"last"` | Append only the last response to session (ignore multiple outputs) |
 | `"restart"` | Replace session with only the last response (fresh start with last message) |
-### Built-in Layers
 
-The default configuration includes layers that reference built-in roles:
-
-| Layer | Command | Purpose |
-|-------|---------|---------|
-| `task_refiner` | `octomind acp task_refiner` | Query cleanup and initial file guessing |
-| `task_researcher` | `octomind acp task_researcher` | Context gathering via code analysis |
+> **No built-in layers.** The default config (`octomind config`) defines no `[[layers]]` at all — the layer block in the template is commented out as an `analysis` example. It ships one command (`[[commands]]` `reduce`) and one agent (`[[agents]]` `context_gatherer`). Names like `task_refiner`, `task_researcher`, `reduce`, and `assistant` are **roles** (`[[roles]]`), not layers; you reference them from a layer via the `command` field.
 
 ### Layer Fields
 
@@ -55,19 +60,21 @@ The default configuration includes layers that reference built-in roles:
 | `name` | string | yes | Layer identifier |
 | `description` | string | yes | Human-readable purpose (shown in help) |
 | `command` | string | yes | ACP command to execute: `octomind acp <role_name>` |
-| `workdir` | string | no | Working directory (default: `"."`) |
+| `workdir` | string | no | Working directory (the only field with a default: `"."`). Relative paths resolve against the session's working directory. |
 | `input_mode` | string | yes | `"last"`, `"all"`, or `"summary"` |
 | `output_mode` | string | yes | `"none"`, `"append"`, `"replace"`, `"last"`, `"restart"` |
-| `output_role` | string | no | `"assistant"` (default) or `"user"` — role for output messages |
+| `output_role` | string | yes | `"assistant"` or `"user"` — role for output messages. No default; must be set explicitly. |
+
+The mode fields (`input_mode`, `output_mode`, `output_role`) all use custom deserializers with no serde default, so each one must appear in every layer/command/agent. This is why the example values always set `output_role` explicitly.
 
 **Key Architecture**: Layers don't contain model/system/mcp config. Those live in `[[roles]]`. The `command` field references which role to spawn via ACP.
 
-Example role definition (in config or from taps):
+Example role definition (in config or from taps) that the `analysis` layer above would target:
 ```toml
 [[roles]]
-name = "task_refiner"
+name = "analysis"
 model = "openrouter:openai/gpt-4.1-mini"
-system = "You are a query processor..."
+system = "You are a code and systems analyst..."
 temperature = 0.3
 
 [roles.mcp]
@@ -95,16 +102,18 @@ output_role = "assistant"
 /run reduce       # Execute the reduce command
 ```
 
+`/run` always lists the global `[[commands]]` set — commands are not role-scoped, so the same list appears regardless of the active role.
+
 ### Layers vs Commands
+
+`[[layers]]` and `[[commands]]` deserialize into the **same** Rust struct (`LayerConfig`) with the **same** TOML field set — there are no schema differences between them. The only difference is how they are triggered:
 
 | Feature | Layer | Command |
 |---------|-------|---------|
-| Triggered by | Workflows, code | User via `/run` |
+| Triggered by | Code / orchestration | User via `/run` |
 | Config section | `[[layers]]` | `[[commands]]` |
 | Interactive | No | Yes |
 | Typical use | Pipeline stages | User-initiated actions |
-
-Both use identical configuration fields.
 
 ## Agents
 
@@ -145,29 +154,35 @@ Each agent tool accepts:
 
 ### Async Agents
 
-`async: true` returns immediately. Result appears as a user message when complete.
+`async: true` returns immediately. The result is injected into the conversation as a user message when complete, prefixed `[Async agent '<name>' completed]` (or `[Async agent '<name>' failed]` on error).
 
 Use async when:
 - Task takes 30+ seconds
 - You can continue other work
 - You don't need the result immediately
 
-Max concurrent async jobs is configurable. Jobs cancelled on session exit.
+Max concurrent async jobs is fixed at the machine's CPU core count (fallback `4` if it can't be detected); it is not configurable. Starting a job past that limit does not queue — the call returns an immediate `Async job limit reached (N/M active)...` error. All jobs are cancelled on session exit.
 
 ### Dynamic Agents
 
-Create agents at runtime using the `agent` MCP tool:
+Create agents at runtime using the `agent` MCP tool. Unlike config `[[agents]]` (which spawn an ACP subprocess), dynamic agents execute **in-process** using the session's own `ChatSession` infrastructure:
 
 ```json
 {"action": "add", "name": "reviewer", "description": "Code reviewer", "system": "You review code..."}
 {"action": "enable", "name": "reviewer"}
 ```
 
+`add` registers an agent but does **not** enable it — call `enable` to make `agent_<name>` available for execution. Actions: `add`, `enable`, `disable`, `remove`, `list`.
+
+The `add` action requires `name`, `system`, and `description`, and accepts these optional fields: `model`, `temperature`, `top_p`, `top_k`, `welcome`, `server_refs`, `allowed_tools`, and `workdir` (default `"."`). Without `server_refs` the agent runs with MCP disabled; if `allowed_tools` is given without `server_refs`, the matching servers are inferred automatically.
+
 See [MCP Tools Reference](07-mcp-tools.md#agent----dynamic-agent-management).
 
 ## Prompt Templates
 
-Reusable prompts injected into the session via `/prompt <name>`.
+Reusable prompts sent into the session via `/prompt <name>`. The prompt text is queued into the session inbox and picked up by the main loop as a normal **user message** on the next turn — so the AI responds to it as a fresh user turn, it is not silently appended. The template is sent verbatim: prompt-template variable substitution (`{role}`, `{model}`, etc.) is not currently implemented.
+
+The `description` field is optional; the examples below set it, but it can be omitted.
 
 ```toml
 [[prompts]]
@@ -196,5 +211,5 @@ prompt = """Please help create comprehensive tests:
 
 ```
 /prompt              # List available prompts
-/prompt review       # Inject the review prompt
+/prompt review       # Queue the review prompt as the next user message
 ```

--- a/doc/usage/11-structured-output.md
+++ b/doc/usage/11-structured-output.md
@@ -1,78 +1,108 @@
 # Structured Output
 
-Octomind supports enforcing structured JSON output via schemas. Useful for automation, CI/CD pipelines, and machine-readable responses.
+Octomind can emit its session activity as machine-readable JSON instead of human-formatted terminal text. This is what you use for automation, CI/CD pipelines, and any program that needs to parse what the agent did.
 
-> **Note:** Schema-based structured output is available programmatically via the WebSocket server and ACP protocol. It is not exposed as a CLI `--schema` flag.
+> **Heads up:** Octomind does **not** currently let you enforce a JSON Schema on the assistant's *answer*. There is no `--schema` CLI flag, and no WebSocket or ACP protocol message accepts a schema. If you came here looking for "make the model reply with exactly this JSON shape," that is not a user-accessible feature today — see [Schema Enforcement](#schema-enforcement-not-user-accessible) below for the full picture. What *is* available is a structured **event stream** (`--format jsonl` and the WebSocket/ACP servers), described next.
 
-## How It Works
+## The Automation Surface: `--format jsonl`
 
-When a schema is provided (via WebSocket/ACP protocol):
-1. Schema is loaded and validated as JSON
-2. Schema is passed to the provider using its native structured output API
-3. AI is constrained to respond with JSON matching the schema
-4. Response is returned as raw JSON (markdown rendering disabled)
-5. Strict mode is always enabled: non-conforming responses are rejected
+The `run` command takes a `--format` flag. It accepts exactly two values:
 
-## Usage
+- `plain` — human-formatted terminal output (the default).
+- `jsonl` — one JSON object per line (JSON Lines) on stdout.
 
-### Define a Schema
+Setting `--format jsonl` switches Octomind into non-interactive mode: it reads the prompt from **stdin** and streams the session as JSONL.
+
+```bash
+echo "Summarize recent changes" | octomind run --format jsonl
+```
+
+Omitting the tag uses the default agent. You can also target a real default role, for example:
+
+```bash
+echo "Summarize recent changes" | octomind run assistant --format jsonl
+```
+
+Notes:
+
+- `--format` only exists on the `run` subcommand. The `server` and `acp` subcommands stream structured output by their own protocols (see below); they have no `--format` flag.
+- When `--format` is set, input always comes from stdin — there is no interactive prompt.
+- The default tag is `assistant:concierge` (a tap agent from the built-in default tap `muvon/tap`); the stock config also ships the local roles `assistant`, `task_refiner`, `task_researcher`, and `reduce`. (See [CLI Reference](../reference/01-cli-reference.md) for the full flag set and [Roles](06-roles.md) for tags.)
+
+## What the JSONL Stream Contains
+
+Each line is a single JSON object with a `"type"` field that tells you which kind of event it is. These are the same `ServerMessage` variants the WebSocket server emits, serialized one-per-line. The variants are:
+
+| `type` | Meaning | Key fields |
+|--------|---------|-----------|
+| `assistant` | Assistant response text | `content`, `session_id` |
+| `thinking` | Model reasoning/thinking content (separate from the answer) | `content`, `session_id` |
+| `tool_use` | The agent is about to call a tool | `tool`, `tool_id`, `server`, `params`, `session_id` |
+| `tool_result` | Result of a tool call | `tool`, `tool_id`, `server`, `content`, `success`, `session_id` |
+| `cost` | Token/cost accounting | `session_tokens`, `session_cost`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `reasoning_tokens`, `session_id` |
+| `status` | Non-critical status/info (also carries command results in `data`) | `message`, `session_id?`, `data?` |
+| `error` | Error message | `message` |
+| `mcp_notification` | Notification forwarded from an MCP server | `server`, `method`, `params` |
+| `skill` | Skill lifecycle event (`activate` / `use` / `forget`) | `action`, `name`, `trigger?`, `session_id` |
+| `injected` | A non-user message injected into the loop (schedule, background agent, skill, webhook, …) | `source_kind`, `source_label`, `content`, `session_id` |
+
+Example of a few lines from a `jsonl` run (one object per physical line):
 
 ```json
-{
-  "type": "object",
-  "properties": {
-    "summary": { "type": "string" },
-    "issues": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "severity": { "type": "string", "enum": ["low", "medium", "high"] }
-  },
-  "required": ["summary", "issues", "severity"],
-  "additionalProperties": false
-}
+{"type":"status","message":"Session created: my-session","session_id":"my-session"}
+{"type":"tool_use","tool":"list_files","tool_id":"call_abc","server":"filesystem","params":{"directory":"src"},"session_id":"my-session"}
+{"type":"tool_result","tool":"list_files","tool_id":"call_abc","server":"filesystem","content":"src/main.rs\nsrc/lib.rs","success":true,"session_id":"my-session"}
+{"type":"assistant","content":"Recent changes refactored the session loop...","session_id":"my-session"}
+{"type":"cost","session_tokens":1234,"session_cost":0.0025,"input_tokens":1000,"output_tokens":200,"cache_read_tokens":30,"cache_write_tokens":4,"reasoning_tokens":0,"session_id":"my-session"}
 ```
 
-### Non-Interactive Mode (WebSocket/ACP)
+To get just the final answer text, filter for `assistant` lines, e.g. with `jq`:
 
 ```bash
-# Via WebSocket protocol — send schema in the session initialization message
-# See WebSocket server documentation for the protocol details
+echo "Summarize recent changes" | octomind run --format jsonl \
+  | jq -r 'select(.type == "assistant") | .content'
 ```
 
-### Interactive Session
+## Streaming Programmatically (WebSocket & ACP)
 
-Schema can be set programmatically via the WebSocket or ACP protocol during session initialization. It is not available as a CLI flag.
+If you want a live, bidirectional stream instead of a one-shot pipe, use one of the server modes:
 
-### Pipeline Integration
+- **WebSocket server** (`octomind server`) — emits the same `ServerMessage` event stream over a WebSocket. See [WebSocket Server](../integration/01-websocket-server.md) for the message protocol. Note that the session-init message (`session`) only carries an optional `session_id`; it does **not** accept a schema.
+- **ACP protocol** (`octomind acp`) — the Agent Client Protocol integration for editors/clients. See [ACP Protocol](../integration/02-acp-protocol.md).
 
-```bash
-# Use --format jsonl for structured JSON output in pipelines
-echo "Summarize recent changes" | octomind run developer --format jsonl
+Both stream the structured events listed above; neither accepts a schema on session creation.
+
+## Provider Compatibility (Structured Output Capability)
+
+Whether a provider *can* be asked for native structured output is exposed by each provider's `supports_structured_output(model)`. This capability is currently exercised internally (see [Schema Enforcement](#schema-enforcement-not-user-accessible)), not by a user-facing schema flag. For reference, against the active `octolib 0.21.6`:
+
+| Provider | `supports_structured_output` |
+|----------|------------------------------|
+| OpenAI | Yes (all models) |
+| Google (Vertex) | Yes |
+| Amazon (Bedrock) | Yes |
+| Cloudflare | Yes |
+| DeepSeek | Yes |
+| OpenRouter | Per model's reference capabilities, else Yes |
+| Anthropic | Trait default — per model's reference capabilities, else No |
+
+When code does request a schema from a provider that returns `false` for the given model, Octomind fails fast:
+
+```
+Provider 'anthropic' does not support structured output for model '<model-without-reference-capabilities>'. Remove the schema parameter or use a compatible provider.
 ```
 
-## Provider Compatibility
+## Schema Enforcement (Not User-Accessible)
 
-Not all providers support structured output. Octomind fails fast with a clear error if unsupported:
+There **is** a schema mechanism in the codebase, but it is not wired to any user entry point:
 
-```
-Provider 'cloudflare' does not support structured output for model 'llama-3.1-8b-instruct'.
-Remove the schema parameter or use a compatible provider.
-```
+- `ChatSession` has a `schema` field, but it is set to `None` at every construction site and the session-level `with_schema()` builder has no callers. In practice, per-session assistant output is **always** unconstrained — there is no CLI flag, WebSocket message, or ACP method that can populate it.
+- The `ProviderResponse.structured_output` field exists in the provider response type, but because no session sets a schema it is always `None` for normal sessions, and there is no display logic that prefers it over `content`.
 
-| Provider | Support | Notes |
-|----------|---------|-------|
-| OpenAI | Yes | `gpt-4o`, `gpt-4o-mini`, recent models |
-| Anthropic | Yes | Tool-based JSON mode |
-| OpenRouter | Varies | Depends on underlying model |
-| Google | No | |
-| Amazon | No | |
-| Cloudflare | No | |
-| DeepSeek | No | |
+The one place a schema is genuinely built and used today is **internal**: the conversation-compression decision call. When compression runs, it checks the *decision model's* provider via `supports_structured_output()`; if that returns true, it sends a generated compression schema (`build_compression_schema`) in strict mode to get a reliable decision/summary, otherwise it falls back to an XML-style prompt. This is invisible to your session output and uses the separate compression decision model, not your main model. (Default decision model: `openai:gpt-5-mini` — see [Context Compression](08-compression.md).)
 
-## Notes
+## Summary
 
-- Schema is used only for the top-level session response
-- Layers and compression always use `schema: None`
-- When structured output is present, it takes precedence over `content` for display
-- The `structured_output` field in provider response carries the parsed JSON value
+- For machine-readable output, use `--format jsonl` on `octomind run` (or the WebSocket/ACP servers for live streaming).
+- The JSONL/WebSocket/ACP streams emit typed `ServerMessage` events (`assistant`, `tool_use`, `tool_result`, `cost`, `status`, `error`, `mcp_notification`, `skill`, `injected`, `thinking`).
+- There is no user-facing way to enforce a JSON Schema on the assistant's answer. The internal schema mechanism is used only by the compression decision call.

--- a/doc/usage/12-editor-integration.md
+++ b/doc/usage/12-editor-integration.md
@@ -6,8 +6,11 @@ Octomind integrates with code editors via the ACP (Agent Client Protocol), provi
 
 - Full session management with tool access
 - Streaming tool execution with real-time feedback
-- Slash commands available in editor
-- MCP server injection from editor config
+- Slash commands available in the editor (advertised over ACP)
+- Image and video attachments (clients can attach images inline; video arrives as embedded blob resources)
+- MCP server injection from editor config (stdio and HTTP transports)
+- Cost and token-usage reporting via an ACP `_meta` side-channel
+- Background inbox monitor: scheduled messages, webhook injections, and async agent results appear mid-session
 - Role-based access control
 
 ## How It Works
@@ -18,11 +21,36 @@ Octomind runs as an ACP agent over stdio using JSON-RPC:
 octomind acp [TAG]
 ```
 
-The editor launches this as a subprocess and communicates via JSON-RPC messages on stdin/stdout.
+The editor launches this as a subprocess and communicates via JSON-RPC messages on stdin/stdout. Stderr is reserved for logging (it never carries protocol traffic).
+
+`TAG` is optional. When omitted, the agent uses the default role from your config (the shipped default is `assistant:concierge`). `TAG` can be:
+
+- A **local role name** from your config (e.g. `assistant`), or
+- A **tap agent** addressed as `category:variant` (e.g. `developer:general`).
+
+> `developer:general` is a tap-registry agent provided by the built-in default tap `muvon/tap`, not a local config role. The stock config ships the roles `assistant`, `task_refiner`, `task_researcher`, and `reduce`. If you point an editor at `developer:general`, make sure the tap is installed (it is the default tap), otherwise the agent will fail to resolve the tag. To stay fully local, omit the tag or use `assistant`.
+
+Each ACP session also spawns a background inbox monitor. It processes scheduled messages (`/schedule`), webhook injections, and background-agent results without waiting for a user prompt; these arrive in the editor as user-side message chunks. See the [ACP Protocol reference](../integration/02-acp-protocol.md) for the full handshake and session lifecycle.
+
+### `octomind acp` flags
+
+| Flag | Description |
+|------|-------------|
+| `TAG` | Agent tag (e.g. `developer:general`) or local role name. Omit for the config default. |
+| `--name`, `-n` | Preferred session name for the next `new_session` request |
+| `--resume`, `-r` | Resume a specific session by name on the next `new_session` |
+| `--resume-recent` | Resume the most recent session for the current working directory |
+| `--model`, `-m` | Override the model for all sessions started by this agent (priority: `--model` > `role.model` > `config.model`; a `[taps]` entry overrides `config.model` for tap agents) |
+| `--sandbox` | Restrict all filesystem writes to the current working directory |
+| `--hook` | Activate a webhook hook by name (defined in `[[hooks]]` config); repeatable |
 
 ## Neovim
 
-### CodeCompanion.nvim (recommended)
+> The editor-side snippets below are illustrative. Plugin configuration shapes change over time; confirm against each plugin's current docs.
+
+### CodeCompanion.nvim
+
+CodeCompanion does not ship a built-in `octomind` adapter, so you configure Octomind as a custom ACP adapter. Adjust to match the version of CodeCompanion you have installed.
 
 ```lua
 require("codecompanion").setup({
@@ -30,7 +58,7 @@ require("codecompanion").setup({
     octomind = function()
       return require("codecompanion.adapters").extend("octomind", {
         command = "octomind",
-        args = { "acp", "developer" },
+        args = { "acp", "developer:general" },
       })
     end,
   },
@@ -41,6 +69,8 @@ require("codecompanion").setup({
 })
 ```
 
+To stay fully local without the tap registry, use `args = { "acp", "assistant" }` (or `{ "acp" }` to use the config default).
+
 ### avante.nvim
 
 ```lua
@@ -49,7 +79,7 @@ require("avante").setup({
   vendors = {
     octomind = {
       command = "octomind",
-      args = { "acp", "developer" },
+      args = { "acp", "developer:general" },
     },
   },
 })
@@ -57,18 +87,20 @@ require("avante").setup({
 
 ## Zed
 
-Zed has native ACP support. Add to your Zed settings:
+Zed has native ACP support and configures external ACP agents under `agent_servers` with a `command` and `args`. Add to your Zed `settings.json`:
 
 ```json
 {
-  "language_models": {
-    "octomind": {
-      "binary": "octomind",
-      "args": ["acp", "developer"]
+  "agent_servers": {
+    "Octomind": {
+      "command": "octomind",
+      "args": ["acp", "developer:general"]
     }
   }
 }
 ```
+
+Replace `developer:general` with `assistant` (or drop the second arg) to use a local role instead of the tap agent. See Zed's external-agent configuration docs for the authoritative schema.
 
 ## JetBrains IDEs
 
@@ -76,38 +108,76 @@ Supported via the AI Assistant plugin. Configure an external ACP agent:
 
 1. Open **Settings > Tools > AI Assistant**
 2. Add external agent
-3. Set command: `octomind acp developer`
+3. Set command: `octomind acp developer:general` (or `octomind acp assistant` for a local role)
 
 ## MCP Server Injection
 
-Editors can inject additional MCP servers into the Octomind session. The servers are passed via the ACP initialization handshake.
+Editors can inject additional MCP servers into the Octomind session through the ACP `initialize` / `new_session` handshake. Behavior:
+
+- **Per-session scope**: injected servers are merged into a per-session config snapshot and added to the role's `server_refs` for that session only. Your base config is never mutated.
+- **Supported transports**: `stdio` and `HTTP` only. The agent advertises HTTP MCP support (`mcp_capabilities.http = true`) during initialization, so clients offer HTTP servers.
+- **Unsupported transports**: `SSE` and any unknown transport are skipped (logged, not connected).
+- **Timeout**: injected servers use a hardcoded 30-second timeout.
+
+The agent also advertises `load_session` support, so clients can resume sessions by ID.
 
 ## Available Slash Commands
 
-All 27 session commands are available via ACP:
+The ACP agent advertises **23 commands** during the session. Names are sent **without the leading `/`** — the client prepends it when displaying:
 
-`/help`, `/?`, `/exit`, `/quit`, `/copy`, `/clear`, `/list`, `/session`, `/info`, `/done`, `/loglevel`, `/model`, `/run`, `/mcp`, `/report`, `/image`, `/video`, `/context`, `/role`, `/prompt`, `/plan`, `/skill`, `/effort`, `/schedule`, `/learning`, `/share`, `/analyze`
+`help`, `role`, `model`, `done`, `info`, `clear`, `copy`, `context`, `list`, `session`, `run`, `workflow`, `mcp`, `plan`, `prompt`, `image`, `video`, `loglevel`, `report`, `skill`, `effort`, `schedule`, `exit`
+
+Notes:
+
+- This advertised set is a subset of the full CLI session commands. Commands like `/learning`, `/share`, and `/analyze` are not advertised over ACP.
+- `/done` is handled specially in ACP: it compresses the conversation and reports the result. If you pass trailing instructions (`/done <instructions>`), the agent compresses first, sends the compression status, then processes the instructions as a normal prompt.
+- The advertised `workflow` command is a **legacy no-op** — `/workflow` was removed; run multi-step workflows via the `octomind workflow <file.toml>` CLI.
+- `/effort` accepts `low`, `medium`, `high`, `xhigh`, or `max` (the advertised input hint only shows the first three).
+- Editors that support arbitrary slash input may still send other commands as prompts; only the 23 above are surfaced in the client command menu.
+
+### Programmatic command execution
+
+Beyond the slash-command menu, clients can invoke commands programmatically through the ACP extension method namespace `octomind/command`. The request carries `{ session_id, command, args }` and the response returns `{ success, output, error }` with structured JSON output. This lets editor integrations run session commands without routing them through the prompt stream.
+
+## Cost and Usage Reporting
+
+As a session runs, the agent emits a `SessionInfoUpdate` notification carrying a `_meta["octomind.usage"]` payload with `session_tokens`, `session_cost`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, and `reasoning_tokens`. Clients that pass `_meta` through can display live cost and token usage.
 
 ## Roles
 
-- **developer** -- full tool access (file editing, shell, code analysis)
-- **assistant** -- chat-only, limited tools
-- Custom roles work the same as in CLI sessions
+The role you pass to `octomind acp` determines which tools the session can use.
+
+- **`assistant`** (shipped default, full access) -- file editing, shell, and code analysis via the `core`, `runtime`, `filesystem`, and `agent` MCP servers (`allowed_tools = ["core:*", "runtime:*", "filesystem:*", "agent:*"]`).
+- **`task_refiner`** -- lightweight query refinement; no MCP servers.
+- **`task_researcher`** -- read-only reconnaissance; `filesystem` server with only the `view` tool allowed.
+- **`reduce`** -- session-history compression; special-purpose.
+- **Tap agents** like `developer:general` provide richer development presets and come from the built-in default tap `muvon/tap`.
+- Custom roles work the same as in CLI sessions.
 
 ## Troubleshooting
 
 **Agent not found:**
-Ensure `octomind` is on your PATH. Try running `octomind acp developer` in terminal first.
+Ensure `octomind` is on your PATH. Try running `octomind acp assistant` in a terminal first. If you use a tap agent like `developer:general`, confirm the tap is installed.
 
 **No response / hangs:**
 - Check that the API key is set in your shell environment
 - Editor may need to inherit shell environment variables
-- Check `~/.local/share/octomind/logs/acp-debug.log` for errors
+- Check `~/.local/share/octomind/logs/acp-debug.log` for runtime errors
 
 **Tools not available:**
 - Verify the role has correct `server_refs` and `allowed_tools`
-- Check `~/.local/share/octomind/logs/acp-errors.jsonl` for details
+- Check `~/.local/share/octomind/logs/acp-errors.jsonl` for structured error details
+
+**Agent fails to start at all:**
+- In ACP mode stdout/stderr are reserved for JSON-RPC, so startup failures are written to `~/.local/share/octomind/logs/acp-init-errors.log`
 
 **JetBrains issues:**
 - Ensure AI Assistant plugin is up to date
 - The plugin must support external ACP agents
+
+## See Also
+
+- [ACP Protocol](../integration/02-acp-protocol.md) -- full handshake, capabilities, and session lifecycle
+- [WebSocket Server](../integration/01-websocket-server.md) -- alternative integration transport
+- [CLI Reference](../reference/01-cli-reference.md) -- complete `octomind` command and flag reference
+- [Session Commands](../reference/02-session-commands.md) -- all interactive session commands

--- a/doc/usage/13-learning.md
+++ b/doc/usage/13-learning.md
@@ -5,10 +5,15 @@ Octomind can extract and reuse lessons across sessions — mistakes corrected, p
 ## Overview
 
 The learning system has two phases:
-1. **Extraction** — after `/done` (or during auto-compaction), an LLM analyzes the conversation and extracts generalizable lessons.
-2. **Injection** — at session start, stored lessons for the current project and role are injected into the system prompt.
+1. **Extraction** — after `/done` (or during auto-compaction), an LLM analyzes the conversation and extracts a small number of lessons from your corrections and stated rules.
+2. **Injection** — at the start of a session (and as the conversation continues) relevant stored lessons are injected as a user-role message the model reads before responding.
 
-Lessons are scoped by **project first, then role** — project knowledge stays within the project, role filters further.
+Each lesson has a **scope** that decides where it lands and how it is retrieved:
+
+- **`scoped`** (the default) — tied to a single project and role. Stored under `learning/{project}/{role_base}/` and retrieved by relevance to what you're working on right now.
+- **`global`** — a durable, user-wide preference that applies in every project and role. Stored under `learning/_/` and injected once per session by importance, with no relevance gating.
+
+So scoped lessons are organized **project first, then role** (project knowledge stays within the project, the role filters it further), while global lessons deliberately cross both boundaries. See [Lesson Scope](#lesson-scope) for details.
 
 ## Configuration
 
@@ -24,52 +29,108 @@ max_inject = 5
 | Field | Description | Default |
 |-------|-------------|---------|
 | `enabled` | Enable the learning system. | `true` |
-| `model` | Model for extraction and retrieval LLM calls. Use a cheap model. | `anthropic:claude-haiku-4-5` |
+| `model` | Model for extraction and retrieval-prep LLM calls. Use a cheap model. | `anthropic:claude-haiku-4-5` |
 | `backend` | `"file"` (default) or `"mcp"` for external memory tools. | `"file"` |
 | `min_messages_for_intermediate` | Minimum user messages before intermediate learning triggers during auto-compaction. | `3` |
-| `max_inject` | Maximum lessons injected into the system prompt per session. | `5` |
+| `max_inject` | Maximum lessons injected per tier per retrieval. | `5` |
+
+> **Defaults come from the shipped config, not the code.** The default `config.toml` template enables learning and sets the model shown above. If you *remove* the `[learning]` table (or omit a field), the underlying code default takes over: `enabled` falls back to `false` (learning OFF), and `model` falls back to the dated build `anthropic:claude-haiku-4-5-20251001`. In short: learning is on out of the box, but only because the default config turns it on explicitly.
 
 ## How It Works
 
+### Lesson Scope
+
+Every lesson is classified as either `scoped` or `global`, and the extraction LLM picks the scope for each one. It is instructed to be conservative: most lessons are `scoped`, and a lesson only becomes `global` when it is clearly about *how you work in general* rather than this task, project, or role.
+
+| Scope | Stored in | Retrieved how |
+|-------|-----------|---------------|
+| `scoped` (default) | `learning/{project}/{role_base}/` | By relevance to your current request (hybrid keyword + embedding search) |
+| `global` | `learning/_/` | Once per session, ranked by importance, with no relevance gating — they always apply |
+
+A worked example: you tell the agent *"always open a single PR"* while working in project `octofs` as `developer:general`. That is a general working preference, so it becomes a **global** lesson and lands in `learning/_/`. Later you tell it *"in this repo, all API endpoints require bearer auth"* — that is specific to this project, so it is **scoped** and lands in `learning/octofs/developer/` (note the role is truncated at `:` to its base, `developer`).
+
 ### Storage (File Backend)
 
-Lessons are stored as markdown files with YAML frontmatter:
+Scoped lessons are stored as markdown files with YAML frontmatter, one file per lesson, in a project/role directory; global lessons go in the shared `_` directory:
 
 ```
-~/.local/share/octomind/learning/{project}/{role}/
-  ├── 20260405143000-bearer-auth-required.md
-  └── 20260405143001-custom-error-types.md
+~/.local/share/octomind/learning/
+  ├── octofs/developer/              # scoped: {project}/{role_base}
+  │   ├── 20260405143000-bearer-auth-required.md
+  │   └── 20260405143001-custom-error-types.md
+  └── _/                             # global: cross-project, cross-role
+      └── 20260405150000-always-single-pr.md
 ```
 
-Each file:
+The role component is the **base part before `:`** — a lesson from role `developer:general` is stored under `developer/`, matching how role tags are sent to MCP servers.
+
+Each file carries the full frontmatter the backend writes, in this exact order:
+
 ```markdown
 ---
+title: "Bearer token auth required for all API endpoints"
 content: "Bearer token auth required for all API endpoints"
 memory_type: learning
-importance: 0.8
+importance: 0.9
 confidence: high
 tags: [auth, api]
 source: "260405-142040-octofs-25e37715"
 role: "developer"
 project: "octofs"
+scope: scoped
 created: "2026-04-05T14:30:00Z"
 ---
 ```
 
-Files are human-readable and editable. Delete a file to remove a lesson.
+- `title` is a short summary auto-derived from the first ~80 characters of the content (trimmed to a word boundary).
+- `scope` is `scoped` or `global` and determines which directory the file lives in.
+
+Files are human-readable and editable. Delete a file to remove a lesson — or use the [`/learning` command](#managing-lessons-learning).
 
 ### Extraction
 
-Triggered by:
-- **`/done`** — always extracts, regardless of compression result.
+Extraction is triggered by:
+- **`/done`** — extracts (if `learning.enabled`) regardless of the compression result, and marks the session so `/exit` and Ctrl+D don't extract a second time.
 - **Auto-compaction** — extracts during compression if the session has enough user messages (configurable via `min_messages_for_intermediate`).
-- **Session exit** — fire-and-forget extraction when the session ends naturally (not via `/done`). Runs asynchronously with no cost tracking. Skipped if `/done` already extracted during the session.
+- **Session exit** — fire-and-forget extraction when the session ends naturally via `/exit`, `/quit`, or Ctrl+D. Skipped if `/done` already extracted during the session.
 
-The extraction LLM receives the conversation transcript plus existing lessons (for deduplication) and outputs structured `<lesson>` tags with confidence and tags.
+Extraction always runs **detached** (a background task with no cost tracked against your session) and is deliberately strict about what counts as a lesson:
+
+1. **Decision gate.** The LLM first emits `<decision>LEARN</decision>` or `<decision>NONE</decision>`. On `NONE`, extraction stops immediately and nothing is parsed.
+2. **Mandatory evidence.** Every `<lesson>` must carry an `evidence` attribute quoting the user verbatim. A lesson with no (or empty) evidence is silently dropped.
+3. **At most 3 lessons** per extraction — one strong lesson beats three weak ones.
+4. **Only user corrections and user-stated rules qualify** — explicit corrections, declared project conventions/preferences/constraints, or a repeated correction of the same mistake. Things the AI figured out on its own, one-off debugging steps, generic developer knowledge, and anything derivable by reading the codebase do **not** qualify.
+
+Confidence drives importance: `confidence=high` (a direct correction) → `importance 0.9`; anything else (a stated preference, `confidence=medium`) → `importance 0.6`.
+
+**Dedup and supersede.** The extraction LLM receives the existing lessons (both scoped and global) so it can avoid duplicates. Before storing, within the same scope: an identical-content lesson is skipped, and a refinement — a new lesson with **more than 60% word overlap** against an existing one — *supersedes* it (the old file is deleted, the new one written). This is why a hand-edited near-duplicate can disappear after the next extraction.
 
 ### Injection
 
-At session start, all lessons for the current `{project}/{role}` are read and appended to the system prompt under `## Lessons from Past Sessions`. They are cached with the system message — zero per-turn overhead.
+Injected lessons are added as a **user-role message** (under a `##` heading) that the model reads before it responds — not appended to the system prompt. Injection happens in two moments:
+
+- **First message of the session** — the global tier (ranked by importance) plus a full hybrid scoped recall are retrieved and injected under `## Lessons from Past Sessions`.
+- **Each subsequent new user message** — an embedding-only scoped recall runs and any *newly* relevant lessons are injected under `## Additional Relevant Lessons`. Lessons already injected earlier in the session are deduped out, so nothing is repeated.
+
+There is therefore a small per-turn cost on new user messages (the scoped recall), not a one-time cached append. Tool follow-up rounds within a single turn do not trigger another recall.
+
+### Retrieval (File Backend)
+
+Scoped recall is a **hybrid search**: LLM-extracted keywords (sparse substring ranking) are fused with BGE-small embedding cosine similarity (dense) via Reciprocal Rank Fusion (RRF, `k=60`), then recency-reweighted (30-day half-life, up to a +50% boost so fresh lessons edge out stale ones among already-relevant matches). Embedding candidates below a `0.2` cosine floor are dropped as noise, and if the embedding model isn't ready yet the cosine signal is silently skipped — keyword ranking alone still returns results. The LLM keyword-prep call runs only on the **first** retrieval of a session; follow-up messages use embedding-only recall (no extra LLM call).
+
+### Managing Lessons (`/learning`)
+
+The interactive `/learning` command lets you browse and prune lessons for the current role and project:
+
+| Command | Effect |
+|---------|--------|
+| `/learning` | List lessons (page 1). |
+| `/learning list [page]` | List a specific page. 15 lessons per page. |
+| `/learning list *pattern*` | Filter by a glob pattern matched against content, title, and tags (e.g. `/learning list *auth*`). Combine with a page number. |
+| `/learning delete <index>` | Delete a lesson by its **1-based index** from the last list. Aliases: `rm`, `remove`. |
+| `/learning clear` | Delete **all** lessons for the current role + project scope. |
+
+The list (and therefore delete indexing) covers the current scoped lessons followed by the global lessons, in a stable order. `clear` only wipes the current role+project scope. See [Session Commands](../reference/02-session-commands.md) for the full command reference.
 
 ## MCP Backend
 
@@ -88,7 +149,7 @@ content = "content"        # required by memorize
 title = "title"            # required by memorize — short summary
 memory_type = "memory_type"
 importance = "importance"
-confidence = "source"      # maps confidence → octobrain's source trust tier
+confidence = "source"      # remapped to octobrain's source trust tier (see below)
 tags = "tags"
 role = "role"
 project = "project"
@@ -96,16 +157,26 @@ project = "project"
 [learning.retrieve]
 tool = "remember"
 [learning.retrieve.field_map]
-query = "query"            # string or array of search terms
-memory_type = "memory_types" # passed as ["learning"] array to match octobrain schema
+query = "query"            # the LLM-prepared search query (or raw intent)
+memory_type = "memory_types" # always sent as ["learning"] to match octobrain schema
 role = "role"
 project = "project"
 limit = "limit"            # octobrain max is 5
 ```
 
-Each entry in `field_map` maps a canonical learning field to the MCP tool's actual argument name. Set a value to `""` to omit that field. Missing entries are also omitted.
+Each entry in `field_map` maps a canonical learning field to the MCP tool's actual argument name. Set a value to `""` to omit that field. Missing entries are also omitted. Store and retrieve have separate field maps because MCP tools have different argument schemas.
 
-Store and retrieve have separate field maps because MCP tools have different argument schemas.
+**Mappable canonical keys differ by endpoint:**
+
+- **store** can map any lesson field: `content`, `title`, `memory_type`, `importance`, `confidence`, `tags`, `source`, `role`, `project`, `scope`, `created`.
+- **retrieve** can map only these five: `query`, `role`, `project`, `limit`, `memory_type`. `memory_type` is always sent as the array `["learning"]` regardless of the value.
+
+**Value remapping.** When `confidence` is mapped, the value sent is **not** the literal `"high"`/`"medium"` string — it is remapped to a trust tier: `high` → `"user_confirmed"`, anything else → `"agent_inferred"`. This is what makes `confidence = "source"` line up with octobrain's source field.
+
+**MCP backend limitations:**
+
+- **Deletion is not supported** — `delete` always errors. Manage lessons through the MCP tool directly. (This also means `/learning delete`/`clear` won't work against an MCP backend.)
+- The internal "all lessons" and "all global lessons" reads used for dedup/supersede during extraction issue a wildcard query (`["*"]`) with a hardcoded `limit = 100`, and rely on the tool returning the existing lessons. Global lessons are queried with empty `role`/`project` — the MCP server owns the scoping semantics.
 
 ### `McpEndpointConfig`
 
@@ -123,4 +194,4 @@ Learning is **separate from memory** (octobrain, CLAUDE.md, etc.):
 - **Memory** is broad context storage — code patterns, architecture, project state, references.
 - **Learning** is narrow and structured — actionable facts scored by confidence, extracted from outcomes, with deduplication.
 
-Both can coexist. Learning focuses on what the agent got wrong or right and forces those lessons into every future session via the system prompt.
+Both can coexist. Learning focuses on the corrections and rules you gave the agent, and surfaces the relevant ones into future sessions automatically.

--- a/doc/usage/15-skills.md
+++ b/doc/usage/15-skills.md
@@ -4,7 +4,19 @@ Skills are reusable instruction packs that inject domain knowledge into AI sessi
 
 ## How Skills Work
 
-Skills are stored in taps at `skills/<name>/SKILL.md`. When activated, the skill's full content is injected into the session context, giving the AI domain-specific knowledge.
+A skill is a directory containing a `SKILL.md` file (frontmatter metadata + instruction body). When activated, the skill's full content is injected into the session context, giving the AI domain-specific knowledge.
+
+> New to taps? Skills are most commonly distributed via taps. See [Tap System](../integration/04-tap-system.md) for how to add one (`octomind tap <org/repo>`) before any tap skill becomes available.
+
+### Skill Locations
+
+Octomind discovers skills from three locations, scanned in this order (**first-wins** deduplication by skill `name` — tap skills shadow universal ones with the same name):
+
+1. **Taps** (highest priority) — `<tap>/skills/<name>/SKILL.md`
+2. **Project universal dir** — `<workdir>/.agents/skills/<name>/SKILL.md`
+3. **Global universal dir** — `~/.config/agents/skills/<name>/SKILL.md`
+
+The two universal directories follow the open `npx skills` ecosystem layout, so a skill pack dropped into either path works without a tap.
 
 ### Three Activation Methods
 
@@ -13,24 +25,26 @@ Skills are stored in taps at `skills/<name>/SKILL.md`. When activated, the skill
 OCTOMIND_SKILLS=programming-rust,git-workflow octomind run developer:general
 ```
 
-**2. Auto-activation** — skills with declarative `rules:` in frontmatter activate based on project context (e.g., `Cargo.toml` detected, user mentions "rust"). Scoped by `domains` field to the current agent's role.
+**2. Auto-activation** — skills with declarative `rules:` in frontmatter activate based on project context (e.g., `Cargo.toml` detected, user mentions "rust"). Auto-activation requires **both** a non-empty `rules:` list **and** a `domains:` entry matching the current agent's role — `rules:` alone is not enough (skills without a matching domain are never placed in the activation pool). Auto-activation also only runs on fresh user messages and skips already-active skills.
 
-**3. Manual** — via `/skill` command or the `skill` MCP tool:
+**3. Manual** — via the `/skill` command or the `skill` MCP tool:
 ```
-/skill use programming-rust        # CLI command
-skill(action="use", name="...")     # MCP tool (AI-initiated)
+/skill programming-rust                  # interactive command (toggles on/off by name)
+skill(action="use", name="...")          # MCP tool (AI-initiated)
 ```
 
 ### Skill Directory Structure
 
 ```
-skills/<name>/
+<name>/
   SKILL.md      # Required: metadata (frontmatter) + instructions (body)
   validate      # Optional: validation script (exit 0 = valid, stderr = error)
   scripts/      # Optional: executable scripts the skill references
   references/   # Optional: supplementary documentation
   assets/       # Optional: templates, config files, resources
 ```
+
+When a skill is activated, any files in `scripts/`, `references/`, and `assets/` are listed (with their absolute paths) in a `## Skill Resources` section appended to the injected skill block, so the AI can open them on demand via `shell`/`view`.
 
 ## SKILL.md Format
 
@@ -39,7 +53,6 @@ skills/<name>/
 ```yaml
 ---
 name: programming-rust
-title: "Rust Development"
 description: "Rust conventions, idiomatic patterns, and cargo tooling. Auto-activates in Rust projects."
 license: Apache-2.0
 compatibility: "Requires cargo and rustc."
@@ -53,17 +66,20 @@ rules:                                # declarative activation rules
 ---
 ```
 
+Octomind's parser reads exactly these keys: `name`, `description`, `compatibility`, `license`, `allowed-tools`, `capabilities`, `domains`, and `rules`. Any other key (including the AgentSkills-spec `title`) is silently ignored — adding it does nothing. The skill is loaded only if **both `name` and `description` are present**; if either is missing, the skill is skipped entirely.
+
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | yes | Max 64 chars. Lowercase, hyphens. Must match directory name. |
-| `title` | yes | 5-60 chars. Human-readable label. |
-| `description` | yes | 20-1024 chars. What the skill does and when to use it. |
+| `name` | yes | Lowercase, hyphens. Used as the skill identifier. Must equal the directory name to be activatable by name (`use`/`forget`/auto-activation look up `skills/<name>/` and verify the frontmatter `name` matches). The `/skill` and `skill` list views use the frontmatter `name` regardless of directory. |
+| `description` | yes | What the skill does and when to use it. |
 | `capabilities` | no | Capabilities to auto-load when skill activates. Space-delimited or `["git", "memory"]`. |
 | `domains` | no | Agent categories for auto-activation scoping. Without this, skill is manual-only. |
-| `allowed-tools` | no | Space-delimited pre-approved tools. |
+| `allowed-tools` | no | Space-delimited pre-approved tools. Also drives a live compatibility check against the current session tool map: `/skill` list flags ` ⚠️ [missing tools: ...]` and `use` appends a warning if any declared tool is still unavailable after capability loading. |
 | `license` | no | License name (e.g., `Apache-2.0`). |
-| `compatibility` | no | Max 500 chars. Environment requirements. |
+| `compatibility` | no | Free-text environment requirements (shown in the skill list). |
 | `rules` | no | Declarative activation rules. Each `- ` line is an OR-group; space-separated checks within a line are AND. Empty = manual-only. |
+
+> Octomind performs **no length validation** on any frontmatter field. The 64/60/1024/500-character limits in the [AgentSkills specification](https://agentskills.io/specification) are author guidance, not enforced by Octomind — the only enforced rule is the presence of `name` and `description`.
 
 ### Body
 
@@ -71,7 +87,7 @@ The body after frontmatter is the skill's instructions. Structure: Conventions, 
 
 ## Declarative Activation Rules
 
-The `rules:` field in SKILL.md frontmatter defines when a skill should auto-activate. Rules are evaluated in-process (no script spawning) on every user message.
+The `rules:` field in SKILL.md frontmatter defines when a skill should auto-activate. Rules are evaluated in-process (no script spawning) on each fresh user message that carries enough intent (see [Activation Gating](#activation-gating) below).
 
 ### Logic
 
@@ -98,15 +114,24 @@ rules:
 | `bin` | `bin(name)` | Executable is findable on PATH (case-sensitive). Example: `bin(cargo)`, `bin(node)` |
 | `session` | `session(pattern)` | Case-insensitive substring match on current session name. Example: `session(octomind)` matches "260421-octomind-a1b2" |
 | `workdir` | `workdir(pattern)` | Case-insensitive substring match on working directory path. Example: `workdir(rust)` matches "/home/dev/rust-project" |
+| `semantic` | `semantic(phrase)` or `semantic(phrase, threshold)` | BGE-small embedding cosine match of `phrase` against the user message (via `muvon/octomind-embed`). Fires when cosine ≥ threshold (default `0.45`). Example: `semantic(deploying to production)` matches paraphrases like "ship to prod" that `content`/`match` would miss. |
 
 ### Evaluation Context
 
 - **`file`**, **`grep`**, **`workdir`** — evaluated against the project working directory.
-- **`content`**, **`match`** — evaluated against the user's message text.
+- **`content`**, **`match`**, **`semantic`** — evaluated against the user's message text.
 - **`env`** — evaluated against environment variables.
 - **`bin`** — evaluated against the system PATH.
 - **`session`** — evaluated against the current session name.
-- Rules are checked on every user message. Already-active skills are skipped.
+- Already-active skills are skipped.
+
+### Activation Gating
+
+Auto-activation does not run on every message — it is gated to avoid expensive false-positive MCP server loads:
+
+- **Intent gate** — the user message must have **at least 8 non-whitespace characters** (after XML stripping). Short acknowledgments like `try`, `ok`, `do it`, or `fix bug` never trigger any skill (or capability) auto-activation.
+- **XML-block stripping** — `<tag>...</tag>` blocks (injected `<skill>` content, `<validation>` feedback, log pastes, system tags) are removed from the message before any `content`/`match`/`semantic` evaluation, so injected context cannot trigger false positives.
+- **Semantic abstain-on-tie** — when a skill matches *only* via `semantic(...)` checks, it must win by a margin of **0.08** cosine over the next-best semantic candidate across the activation pool; if two skills are near-tied, **neither** activates. Skills that match via any deterministic check (`file`/`content`/`grep`/`match`/etc.) bypass this margin gate. `semantic` checks evaluate to `false` when the embedding model isn't ready.
 
 ### Domain Scoping
 
@@ -131,7 +156,7 @@ octomind run developer:general
 
 - Skills are activated immediately as permanent skills
 - Declarative rules are not evaluated for env-loaded skills
-- Each name is validated against available skills in taps
+- Each name is validated against available skills across all locations (taps and the universal `.agents/skills` / `~/.config/agents/skills` dirs)
 - Unknown skill names are skipped with a warning
 - Already-active skills are not re-injected
 
@@ -141,11 +166,12 @@ An executable script at `skills/<name>/validate` that checks LLM output quality 
 
 **Protocol:**
 - Runs only on the final assistant message (end of turn)
+- The script file must be executable (`chmod +x`); a non-executable script simply fails to spawn (it is run directly via `Command::new(<path>)`)
 - `argv[1]` = `"assistant"` (always — the script receives the assistant's response)
 - `stdin` = the assistant message content
 - Runs in the project working directory
-- **exit 0** = output is valid
-- **exit non-zero** = output is invalid. stderr (or stdout if stderr empty) is captured and fed back to the LLM as an error message for correction.
+- **exit 0** = output is valid (also resets the per-skill retry counter)
+- **failure (retry + LLM feedback)** requires **non-zero exit AND non-empty captured output**. The captured output is stderr, or stdout when stderr is empty. A non-zero exit that produces no stderr/stdout output yields **no feedback** and does **not** increment the retry counter — so don't write a silent `exit 1` and expect the model to be corrected.
 
 **Example:**
 ```bash
@@ -155,37 +181,81 @@ set -euo pipefail
 cargo clippy --quiet --all-targets -- -D warnings 2>&1
 ```
 
-If clippy fails, its output is sent back to the LLM: "Validation failed (programming-rust): <clippy output>". The LLM gets another turn to fix the issue. Retries are capped by `max_retries` in `[skills]` config.
+If clippy fails, its output is pushed back to the model wrapped in a `<validation>` block:
+
+```
+<validation skill="programming-rust">
+Validation failed: <clippy output>
+Please fix the issue.
+</validation>
+```
+
+The model gets another turn to fix the issue. Retries are capped by `max_retries` in `[skills]` config.
 
 ## Capabilities Auto-Loading
 
 When a skill declares `capabilities: git memory`, activating the skill automatically:
 
-1. Resolves each capability from taps (`capabilities/<name>/<provider>.toml`)
+1. Resolves each capability from taps. A capability is split across two files in `<tap>/capabilities/<name>/`:
+   - `config.toml` — capability-level metadata: a **required** `triggers = [...]` array and an optional `domains = [...]` binding.
+   - `<provider>.toml` — provider-specific MCP wiring (`deps`, `server_refs`, `allowed_tools`, `mcp.servers`).
 2. Loads the backing MCP servers via the dynamic server manager
 3. Updates the tool map so tools become available
 
-Users can override providers in config:
+When a skill is later forgotten, its capabilities' MCP servers are offloaded — but a shared server is only fully shut down when the **last** active capability referencing it is removed (refcounted; otherwise only that capability's tools are stripped from the tool map).
+
+Users can override the provider backing a capability in config:
 ```toml
 [capabilities]
 memory = "octobrain"
 codesearch = "octocode"
 ```
 
+### Semantic Capability Auto-Activation
+
+Independently of skills, capabilities can auto-activate from their own `triggers` when the master switch is on:
+
+```toml
+auto_capabilities = true   # root config field (enabled by default)
+```
+
+When enabled, the user message is matched against every capability's `triggers` using BGE-small embeddings:
+
+- **Cosine floor** `0.45` and **abstain-on-tie margin** `0.08` (same gating as semantic skill rules)
+- Score is the **mean of the top-3** matching trigger phrases per capability
+- At most **4 capabilities** stay active at once; a new activation that would exceed this evicts the least-recently-used capability first
+- The same intent gate (≥ 8 non-whitespace chars) and domain filtering apply
+
+### OCTOMIND_CAPABILITIES (boot-time activation)
+
+Force-activate capabilities at session start (comma-delimited), bypassing semantic matching but still subject to domain gating:
+
+```bash
+OCTOMIND_CAPABILITIES=cron,docker octomind run -r developer:general
+```
+
+This gives long-running or resumed sessions a deterministic tool surface. Capabilities that fail to load (or that aren't available in the current role's domain) are reported on stderr and skipped.
+
 ## /skill Command
 
-Toggle skills interactively during a session:
+List or toggle skills interactively during a session:
 
 ```
-/skill                     # list all skills with active status
+/skill                     # list all skills (active first, then alphabetical), page 1
+/skill <page>              # list a specific page (numeric arg, 15 skills per page)
+/skill *pattern*           # filter the list by glob pattern (matches name OR description)
 /skill <name>              # toggle: enable if inactive, disable if active
 ```
 
 Tab completion suggests available skill names after `/skill `.
 
+### `skill` MCP tool
+
+The AI-facing `skill` tool exposes three actions: `list`, `use`, and `forget`. The `list` action accepts optional `pattern` (substring filter on name/description), `offset`, and `limit` (default `20`) parameters for pagination.
+
 ## Configuration
 
-Required `[skills]` section in config:
+Required `[skills]` section in config (shipped in the default template — each field has a default value, but the section itself must be present, otherwise config loading fails):
 
 ```toml
 [skills]
@@ -196,12 +266,13 @@ validation_timeout = 60      # seconds per validate script, 0 = unlimited
 max_retries = 3              # max validation retries per skill before giving up
 ```
 
-All fields have defaults in `config-templates/default.toml`. The `[skills]` section can be omitted from user config if defaults are acceptable.
+All fields have defaults in `config-templates/default.toml`, where `auto_validation` ships as `false`. However, the hardcoded in-process fallback used when **no session config is loaded** defaults `auto_validation` to `true`. To get deterministic behavior across all code paths, set `auto_validation` explicitly rather than relying on the omitted-section default.
 
-## Lint Validation
+## Authoring Checklist
 
-`validate` scripts must be executable (`chmod +x`). The tap lint script checks this:
+There is no shipped lint tool. When authoring a skill, verify by hand:
 
-```bash
-bash scripts/lint-skills.sh
-```
+- `SKILL.md` has valid frontmatter with both `name` and `description` (missing either silently drops the skill).
+- The frontmatter `name` matches the skill's directory name (required for `use`/`forget`/auto-activation).
+- If you ship a `validate` script, make it executable (`chmod +x`) — a non-executable script fails to spawn at end-of-turn.
+- A `validate` script that should correct the model must exit non-zero **and** write to stderr/stdout; a silent `exit 1` produces no feedback.

--- a/doc/usage/16-token-efficiency.md
+++ b/doc/usage/16-token-efficiency.md
@@ -13,16 +13,25 @@ Static MCP config has two failure modes:
 1. **Over-provisioned**: every potentially-useful server is bound at boot. The system prompt balloons, costs rise, and the model wastes attention on irrelevant tools.
 2. **Under-provisioned**: only the bare minimum is bound. The model silently fails when a query needs a missing tool, or worse, fakes the result.
 
-Capabilities split the difference. They are TOML-defined bundles (`<tap>/capabilities/<name>/<provider>.toml`) that resolve to one or more MCP servers and optional tool filters. Nothing about a capability is loaded until it is actually needed. When loaded, only the relevant tools enter the prompt.
+Capabilities split the difference. A capability is a directory in a tap — `<tap>/capabilities/<name>/` — that resolves to one or more MCP servers and optional tool filters. Nothing about a capability is loaded until it is actually needed. When loaded, only the relevant tools enter the prompt.
+
+### Anatomy of a Capability
+
+Each capability is two kinds of file:
+
+- **`config.toml`** — capability-level metadata, shared across every provider. Holds the **required** `triggers = [...]` array (the phrases that drive auto-activation and `discover`) and an **optional** `domains = [...]` array (which roles may load it). If `config.toml` is missing or has no `triggers`, the capability fails to resolve.
+- **`<provider>.toml`** — provider-specific MCP wiring: `[[mcp.servers]]` / `server_refs`, `allowed_tools`, and `[deps]`. The provider name comes from the `[capabilities]` config map (`<name> = "<provider>"`), defaulting to `default` (so `codesearch.toml` unless you set `codesearch = "octocode"`).
+
+Triggers — central to everything below — live in `config.toml`, never in the `<provider>.toml`.
 
 ## The `capability` Tool
 
-A built-in `core` MCP tool. Available to every role in every session.
+A built-in `runtime` MCP tool — the `runtime` builtin server hosts `mcp`, `agent`, `skill`, `schedule`, and `capability`, while `core` hosts only `plan` and `tap`. Available to every role in every session.
 
 | Action | Description |
 |--------|-------------|
-| `list` | Show all installed capabilities. Active ones are marked. |
-| `discover` | Semantic search: `intent="..."` returns the top 5 capabilities matching the user's wording. |
+| `list` | Show all installed capabilities (in the current domain). Active ones are marked. |
+| `discover` | Semantic search: `intent="..."` scores caps by trigger similarity, drops anything at or below a 0.2 cosine noise floor, and returns up to the top 5. |
 | `enable` | Register and connect a capability's MCP servers. Tools become available next turn. |
 | `disable` | Disconnect a capability's servers and remove its tools. |
 
@@ -35,20 +44,23 @@ A built-in `core` MCP tool. Available to every role in every session.
 
 `enable` and `disable` are idempotent. Activation paths are also entered automatically by the auto-activator (see below) and by skills that declare `capabilities: ...` in their frontmatter.
 
+**Domains.** Every action is scoped to the current session's *domain* — the category part of the active role (`developer` for `developer:general`). A capability with a non-empty `domains` list is only visible to roles in those domains; an empty list means universal. `list` and `discover` silently omit out-of-domain caps, and `enable` **hard-fails** for one (returning an error that names the role you'd need to run). See [Domain Gating](#domain-gating) below.
+
 ### What "Activate" Actually Does
 
-For each `[[mcp.servers]]` block in the resolved capability TOML:
+For each `[[mcp.servers]]` block in the resolved capability's `<provider>.toml`:
 
-1. Register the server with the dynamic registry (idempotent).
-2. Compute a per-server tool filter from the capability's `allowed_tools` — namespace prefixes (`playwright:*`) are stripped to bare names (`*`); patterns scoped to other servers are dropped.
-3. `dynamic::enable_server` connects the server, fetches its tool list, applies the filter, and registers the resulting tools in the global tool map.
-4. The capability is recorded in the active set with its server names and a fresh `last_used` timestamp.
+1. Compute a per-server tool filter from the capability's `allowed_tools` — namespace prefixes (`playwright:*`) are stripped to bare names (`*`); patterns scoped to other servers are dropped.
+2. Branch on whether the server is already in the role's **static** config:
+   - **Already static** (the role's `capabilities = [...]` brought it in at boot): the server is already running, so we don't re-register it. Instead we extend the role's effective per-server filter via `runtime_overlay::set_capability_extras` and register this cap's named tools in the global tool map so dispatch can route them. Because the server belongs to the role, eviction never tears it down — only this cap's overlay-added tools are stripped.
+   - **Fully dynamic** (the cap brought the server in at runtime): register it with the dynamic registry and `dynamic::enable_server` connects it, fetches its tool list, applies the filter, and registers the resulting tools.
+3. The capability is recorded in the active set with its `(server, tools)` records and a fresh `last_used` timestamp.
 
 Capabilities with no `[[mcp.servers]]` block but a non-empty `[deps]` section are toolchain capabilities (e.g. `programming-nodejs`): activation runs the dep installers and that *is* the activation. They are tracked by the LRU registry with an empty server list.
 
 ## Deterministic Auto-Activation
 
-Asking the model "do you need a database tool?" before every turn would burn a routing turn for every message. Instead, Octomind embeds the user's message and matches it against hand-authored triggers in each capability TOML. No LLM in the routing loop.
+Asking the model "do you need a database tool?" before every turn would burn a routing turn for every message. Instead, Octomind embeds the user's message and matches it against the hand-authored triggers in each capability's `config.toml`. No LLM in the routing loop.
 
 ### When It Runs
 
@@ -59,16 +71,21 @@ user message arrives
   → run_activation hook (skill auto-activation)
   → prepare_for_api_call
        ├─ compression check
-       ├─ auto_activate_capabilities      ← here
+       ├─ if config.auto_capabilities:    ← master toggle (default true)
+       │     auto_activate_capabilities   ← here
        └─ system message caching
   → API call
 ```
 
+`auto_capabilities = true` in `default.toml` is the master switch for this whole path. Set it to `false` and capabilities only ever activate through an explicit `capability(action="enable")` call (manual, skill-declared, or `OCTOMIND_CAPABILITIES`).
+
 It is a silent no-op when:
 
+- `config.auto_capabilities` is `false` (the entire call is gated on the master toggle).
 - The last message in the session is not a fresh user message (e.g. mid tool loop).
+- The cleaned user message has fewer than `MIN_INTENT_NON_WS_CHARS` (8) non-whitespace characters — short acknowledgments like `ok` or `do it` are suppressed because they produce noisy embeddings that can clear the threshold against an unrelated trigger by coincidence.
 - The local embedding model (`muvon/octomind-embed`, a BGE-small-en-v1.5 fine-tune) is not yet ready (still downloading on first run).
-- No capability has triggers, or every cap is already active.
+- No capability is in the current domain, has triggers, or every cap is already active.
 - No score clears the gate.
 
 ### How It Decides
@@ -77,23 +94,28 @@ It is a silent no-op when:
 1. Strip XML blocks (skill injections, <log> pastes, <instructions>, etc.)
    from the user message so pasted content does not drive matches.
 
-2. Embed the (cleaned) intent once.
+2. Bail if the cleaned intent has < 8 non-whitespace chars.
 
-3. For each inactive capability:
+3. Drop out-of-domain capabilities (current role's domain), then keep
+   only the inactive ones. This happens before embedding, to save work.
+
+4. Embed the (cleaned) intent once.
+
+5. For each remaining capability:
      - Embed its triggers (cached by content hash; free after first turn).
      - Score = mean of top-3 cosines between intent and trigger vectors.
 
-4. Margin gate:
-     activate iff   top1 >= 0.55   AND   top1 - top2 >= 0.08.
+6. Margin gate:
+     activate iff   top1 >= 0.45   AND   top1 - top2 >= 0.08.
 
-5. On a hit, register + enable the capability's MCP servers directly.
+7. On a hit, register + enable the capability's MCP servers directly.
    The agent never sees the routing decision; it just gets a wider tool
    surface next turn.
 ```
 
 | Constant | Value | Purpose |
 |----------|-------|---------|
-| `AUTO_ACTIVATE_THRESHOLD` | `0.55` | Minimum mean-of-top-3 cosine. Tuned for the fine-tuned octomind-embed model over short hand-authored triggers. |
+| `AUTO_ACTIVATE_THRESHOLD` | `0.45` | Minimum mean-of-top-3 cosine. Calibrated for the fine-tuned octomind-embed model, which separates chitchat/out-of-domain inputs into a distinct cluster — so the floor can drop and the margin gate becomes the binding constraint. History: `0.42` (base BGE, recall-tuned) → `0.55` (base BGE, false-positive-tuned) → `0.45` (FT model). |
 | `AUTO_ACTIVATE_MARGIN` | `0.08` | Required gap between top-1 and top-2. Prevents flipping a near-tied competitor on. |
 | `AUTO_ACTIVATE_TOP_K` | `3` | Number of triggers averaged per capability. Mean-of-top-K smooths a single noisy trigger while still rewarding cap-author-aligned triggers. |
 
@@ -107,6 +129,22 @@ A simple threshold flips the wrong capability on whenever two are nearly tied (e
 
 Descriptions are written for humans and tend to use abstract domain language ("PostgreSQL adapter for relational queries"). User messages are concrete and verbal ("I want to look at the slow query in our Postgres prod"). Mean-of-top-K cosine over hand-authored example triggers ("query a postgres database", "EXPLAIN ANALYZE a slow postgres query", "look at the postgres schema") puts the cap centroid where users actually live.
 
+## Domain Gating
+
+A capability can declare optional `domains = [...]` in its `config.toml`. The **session domain** is the category part of the active role: `developer:general` runs in the `developer` domain. The gate rule is simple:
+
+- **Empty `domains`** → universal. Available in every role (typical for filesystem-style utilities).
+- **Non-empty `domains`** → the capability is available only when the session domain is in the list.
+
+This single gate is applied at *every* entry point, with no bypass:
+
+- `capability(action="list")` and `capability(action="discover")` silently omit out-of-domain caps.
+- Auto-activation filters out-of-domain caps *before* embedding their triggers — so a `developer:general` message can never accidentally flip on a `medical`-domain capability.
+- `capability(action="enable")` **hard-fails** for an out-of-domain cap with an error like `Capability 'X' is bound to domains ["medical"]; current domain is 'developer'. Run the matching role (e.g. octomind run medical:general) to access it.`
+- `OCTOMIND_CAPABILITIES` boot-loading (below) goes through the same `enable` path, so it is gated too.
+
+When no domain is set at all (early init, out-of-session tool calls), only universal caps survive — the strict reading of "a domain-restricted cap needs a known domain context."
+
 ## LRU Eviction
 
 The active set has a soft cap of `MAX_ACTIVE_CAPS` capabilities (currently 4). When activating one more would exceed it, the **least-recently-used** active capability is disabled first to make room. Eviction is the only auto-disable mechanism — Octomind deliberately does not time-decay or domain-shift evict, because production agent UX is hurt more by false-disable than by carrying an idle cap.
@@ -117,8 +155,10 @@ Multiple capabilities can legitimately back onto the **same** MCP server with di
 
 Each `CapState` records `server_tools: Vec<(String, Vec<String>)>` — the precise list of bare tool names *this* capability registered on each backing server. Eviction (and explicit `disable`) computes a refcount across the active set:
 
-- **kill_server = true** → no other active cap references this server. The server process is shut down, its function cache cleared, and all of its tools are removed from `TOOL_MAP`.
-- **kill_server = false** → another active cap still references this server. Only **this cap's** tools are stripped from `TOOL_MAP`; the server stays enabled and its process keeps running for the remaining cap(s).
+- **kill = true** → the server is *not* in the role's static config **and** no other active cap references it. The server process is shut down, its function cache cleared, and all of its tools are removed from `TOOL_MAP`.
+- **kill = false** → another active cap still references this server, **or** the server is declared in the role's static config. Only **this cap's** tools are stripped from `TOOL_MAP`; the server stays enabled and its process keeps running.
+
+So a server present in the role's static config is **never torn down** by eviction or `disable` — `kill = !static_owned && refcount == 0`. The capability only contributed an overlay filter and some tool-map entries to a server the role already owns; those overlay-added tools are stripped, the server keeps running.
 
 The decision is per-(capability, server) pair, computed atomically under a single registry write lock so refcounts never see a partial state. This means tap authors can split a chunky capability into focused sub-capabilities (`filesystem` + `filesystem-edit`, `memory` + `memory-knowledge`, `codesearch` + `codesearch-structural` + `codesearch-graph`) without worrying that activating one will tear down the others — even when they all point at the same MCP server binary.
 
@@ -152,14 +192,18 @@ fn evict_lru_if_full(config: &Config) {
 
     // 2. Compute the disable plan under one write lock so refcounts
     //    are consistent: pull the LRU's per-server tool record,
-    //    remove the cap from the registry, then compute kill_server
-    //    for each (server, tools) by counting remaining references.
+    //    remove the cap from the registry, then compute kill for each
+    //    (server, tools): never kill a static-owned server, otherwise
+    //    kill only when no other active cap references it.
     let plan: Option<(String, Vec<(String, Vec<String>, bool)>)> = {
         let mut reg = registry().write().unwrap();
         select_lru_in(&mut reg).map(|(lru_name, server_tools)| {
             let entries = server_tools.into_iter()
                 .map(|(srv, tools)| {
-                    let kill = server_refcount(&reg, &srv, &lru_name) == 0;
+                    // A server in the role's static config is never killed:
+                    // the role owns it regardless of dynamic-cap activity.
+                    let static_owned = config.mcp.servers.iter().any(|s| s.name() == srv);
+                    let kill = !static_owned && server_refcount(&reg, &srv, &lru_name) == 0;
                     (srv, tools, kill)
                 })
                 .collect();
@@ -167,14 +211,15 @@ fn evict_lru_if_full(config: &Config) {
         })
     };
 
-    // 3. Apply the plan outside the lock. `disable_server_tools` strips
-    //    the listed tool names from TOOL_MAP, and only kills the server
-    //    process when kill == true.
+    // 3. Apply the plan outside the lock. Drop the overlay contributions
+    //    first, then `disable_server_tools` strips the listed tool names
+    //    from TOOL_MAP, and only kills the server process when kill == true.
     if let Some((name, entries)) = plan {
+        clear_capability_extras(&name);
         for (srv, tools, kill) in &entries {
             dynamic::disable_server_tools(srv, tools, *kill, Some(config))?;
         }
-        log_info!("capability LRU evicted: '{}' ({} server-tool-group(s))", ...);
+        log_info!("capability LRU evicted: '{}' ({} server-tool-group(s) processed)", ...);
     }
 }
 ```
@@ -194,21 +239,24 @@ Called at every activation entry point:
 - **One eviction per activation.** Matches the call pattern (every new activation makes room for itself); no loop is needed.
 - **Demand-driven only.** No background timer, no idle cleanup. A capability sitting unused at 4/4 stays active forever — until a 5th activation pushes the LRU one out.
 - **Failure-tolerant.** A failure to disable one server is logged but does not block the new activation. Worst case: the cap is removed from the active set while one server stays enabled — preferable to refusing to activate.
+- **Static servers are protected.** A server declared in the role's static config is never killed by eviction or `disable`, even at refcount 0 — only the cap's overlay-added tools are stripped from `TOOL_MAP`.
 - **Pre-loaded boot capabilities are not tracked.** Anything resolved from the agent manifest at boot is merged into the role's effective config and behaves as a regular MCP server. The LRU registry only governs runtime-activated caps.
 
 ### Pseudocode of the Full Lifecycle
 
 ```text
-on user_message:
+on user_message (only if config.auto_capabilities):
     auto_activate_capabilities():
+        if intent < 8 non-ws chars: return
         if not embedding_model_ready: return
-        if no inactive caps: return
-        score each inactive cap (mean-of-top-3 trigger cosine)
-        if top1 >= 0.55 and top1 - top2 >= 0.08:
+        drop out-of-domain caps; keep inactive ones
+        if no candidates: return
+        score each candidate (mean-of-top-3 trigger cosine)
+        if top1 >= 0.45 and top1 - top2 >= 0.08:
             activate_capability_inline(top1.name):
                 evict_lru_if_full()         ← may disable LRU cap + its servers
                 register + enable each [[mcp.servers]]
-                mark_active(name, [servers], now)
+                mark_active(name, [(server, tools)], now)
 
 on tool_call:
     try_execute_tool_call() -> result
@@ -216,22 +264,28 @@ on tool_call:
         if tool came from a dynamic server:
             touch_capability_for_server(server)   ← bumps last_used to now
 
-on capability(action="disable"):
-    for each server in cap: dynamic::disable_server(server)
-    mark_inactive(cap)
+on capability(action="disable", name=X):
+    if X not active: return idempotent ok
+    remove X from registry under one write lock
+    for each (server, tools) in X:
+        kill = !static_owned && refcount(server) == 0
+        dynamic::disable_server_tools(server, tools, kill)
 
 on capability(action="enable", name=X):
     if X already active: return idempotent ok
+    if X out of domain: return error (run the matching role)
     evict_lru_if_full()
-    register + enable each server
-    mark_active(X, [servers], now)
+    register + enable each server (static-overlay or fully-dynamic)
+    mark_active(X, [(server, tools)], now)
 ```
 
 ## Operational Notes
 
-- **Logs.** Auto-activation logs at `info` (`capability auto-activated: 'X' (score 0.NN) — servers: [...]`). Eviction logs at `info` (`capability LRU evicted: 'X' (N server(s) disabled to make room)`). Embedding model warmup and silent skips log at `debug`.
-- **Discovering what's installed.** `capability(action="list")` shows everything available across taps with active markers. `capability(action="discover", intent="...")` ranks them by trigger similarity.
+- **Logs.** Auto-activation logs at `info` (`· capability auto-activated: 'X' (score 0.NN) — servers: [...]`). Eviction logs at `info` (`capability LRU evicted: 'X' (N server-tool-group(s) processed)`). Embedding model warmup and silent skips (including the intent-too-short and domain skips) log at `debug`.
+- **Discovering what's installed.** `capability(action="list")` shows everything available in the current domain with active markers. `capability(action="discover", intent="...")` ranks in-domain caps by trigger similarity, drops scores at or below the 0.2 noise floor, and returns up to 5. `discover` is embedding-only — there is no keyword fallback, so it errors if the embedding model is still downloading. (The capability tool's own JSON schema description still says discover "falls back to keyword match"; that fallback no longer exists in the code.)
 - **Skills can pull capabilities.** A skill with `capabilities: programming-rust git` resolves and activates those capabilities on `skill use`. They go through the same registry and LRU bookkeeping.
+- **Force-loading at boot.** `OCTOMIND_CAPABILITIES=cap1,cap2 octomind run -r developer` force-activates the listed capabilities at session start — *before* the agent's first turn — bypassing both the embedding auto-activator and the `capability` tool. Activation still passes through the domain gate and the LRU; already-active caps are no-ops, and any failures are logged and skipped (never aborting the session). Useful for CI / non-interactive runs that need a deterministic tool surface.
+- **Master toggle.** `auto_capabilities = true` (the default in `default.toml`) controls the whole auto-activation path; set it `false` to require explicit `enable` calls only.
 - **`MAX_ACTIVE_CAPS = 4`** is a compile-time constant in `src/mcp/core/capability.rs`. The value balances two pressures: (1) tool-overload research (Microsoft, AWS, Boundary, Chroma) shows sharp accuracy degradation past ~20-25 total tools exposed to the model — with ~15-20 baseline tools plus ~4-5 tools per cap, four active caps keeps total surface in the safe zone; (2) real task concurrency rarely needs more than 2-3 capabilities at once, so 4 leaves headroom for cross-domain work without churning.
 - **Re-activation on next match.** Evicted capabilities can be re-activated immediately if the next user message or `enable` call demands them. Eviction only releases servers; trigger embeddings stay cached.
 
@@ -249,8 +303,11 @@ Octomind's design point: the model gets exactly the tools it needs, when it need
 | Touch hook in tool dispatch | `src/mcp/mod.rs` (around the `try_execute_tool_call` site) |
 | Auto-activation call site | `src/session/chat/session/api_prep.rs` → `prepare_for_api_call` |
 | Server enable / disable / unregister | `src/mcp/core/dynamic.rs` |
+| Static-server filter extension | `src/config/runtime_overlay.rs` → `set_capability_extras` |
+| Domain gate | `src/agent/registry.rs` → `cap_available_in_domain`; `src/mcp/core/capability.rs` → `filter_caps_by_domain` |
 | Embedding model | `src/embeddings/` (`muvon/octomind-embed`, fine-tuned BGE-small via candle) |
-| Capability TOML parsing | `src/agent/registry.rs` → `parse_capability_toml`, `list_all_capabilities` |
+| Capability TOML parsing (`config.toml` + `<provider>.toml`) | `src/agent/registry.rs` → `read_capability_config`, `parse_capability_toml`, `list_all_capabilities` |
+| Master toggle / intent gate | `src/session/chat/session/api_prep.rs`; `src/mcp/core/skill_auto.rs` → `MIN_INTENT_NON_WS_CHARS` |
 | Tap layout (capabilities directory) | `doc/integration/04-tap-system.md` |
 
 ## See Also

--- a/doc/usage/17-local-tools.md
+++ b/doc/usage/17-local-tools.md
@@ -25,15 +25,15 @@ chmod +x .agents/tools/echo
 octomind run developer:general
 ```
 
-In the session, the model now sees `echo` under server `local`.
+In the session, the model now sees `echo` under server `local`. Run `/mcp list` (or `/mcp full` for the parameter schemas) to confirm it was discovered.
 
 ## File Contract
 
 | Aspect | Rule |
 |---|---|
 | **Path** | `<workdir>/.agents/tools/<tool-name>` (no extension) |
-| **Tool name** | The filename. Must match `[A-Za-z0-9_-]+`. Hidden files and bad names skipped. |
-| **Executable** | Must be `chmod +x`. Non-executable files are skipped (logged at debug). |
+| **Tool name** | The filename. Must match `[A-Za-z0-9_-]+`. Names beginning with `-` or `.` are also skipped, along with any other invalid characters (e.g. a `.` extension). |
+| **Executable** | On Unix, must be `chmod +x`; non-executable files are skipped (logged at debug). On non-Unix platforms (e.g. Windows) the executable bit check is bypassed — any existing file is treated as runnable and the OS decides whether it can run. |
 | **Shebang** | Line 1 may be a `#!...` shebang. Skipped during header parsing. Required for the OS to actually run the file. |
 | **Header** | Leading comment block. Comment prefixes `#`, `//`, `--` are recognized. Parsing stops at the first non-comment, non-blank line, or after 80 lines. |
 
@@ -66,10 +66,12 @@ Unknown tags are ignored with a debug log so the format can grow without breakin
 @param [*]NAME TYPE DESCRIPTION...
 ```
 
-- **Required** — prefix the name with `*` (e.g. `*target`). Mirrors how octomind renders required params in `/tools` output.
+- **Required** — prefix the name with `*` (e.g. `*target`). Mirrors how octomind renders required params in `/mcp full` output. The `*` must be attached directly to the name: `*target`, not `* target`.
 - **Optional** — no prefix. This is the default.
-- **TYPE** — one of `string`, `number`, `integer`, `boolean`, `array`, `object`. Common aliases (`str`, `int`, `bool`, `list`, `obj`) are normalized. Unknown types fall back to `string`.
+- **TYPE** — one of `string`, `number`, `integer`, `boolean`, `array`, `object`. Common aliases (`str`→string, `int`→integer, `num`/`float`→number, `bool`→boolean, `list`→array, `obj`/`map`→object) are normalized. Unknown types fall back to `string`.
 - **DESCRIPTION** — everything after the type, joined with single spaces. Shown in the tool's parameter docs.
+
+A bare `*` with no name (e.g. `@param * string ...`), or any otherwise-malformed `@param` line, is silently skipped (logged at debug). If a parameter seems to vanish, check that the name is well-formed.
 
 Example with all flavors:
 
@@ -112,8 +114,8 @@ When the model invokes the tool, octomind spawns the script with:
 | **env `OCTOMIND_TOOL_NAME`** | The tool name, in case one binary handles multiple. |
 | **env `OCTOMIND_WORKDIR`** | The session's working directory (also `cwd`). |
 | **stdout** | Result content shown to the model. |
-| **stderr** | Appended to the result with an `[stderr]` marker. |
-| **exit code** | Non-zero → reported as a tool error (stderr + stdout included in the message). |
+| **stderr** | Non-empty stderr is appended to the result under an `[stderr]` marker — even on a successful (exit 0) run. Use stderr only for content you want the model to see; don't leak progress chatter there. |
+| **exit code** | Non-zero → tool error. The message is `local tool '<name>' exited with status <code>`, followed (when non-empty) by an `[stderr]` block and then a separate `[stdout]` block. |
 
 Pick whichever input style fits the language. Bash scripts usually read env vars; Python scripts often parse stdin JSON. Both arrive every call.
 
@@ -167,14 +169,14 @@ process.stdin.on('end', () => {
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Tool doesn't appear in `/tools` | Not executable | `chmod +x .agents/tools/<name>` |
-| Tool doesn't appear in `/tools` | Header missing `@description` | Add the line; debug log shows `parse … failed: missing @description` |
-| Tool doesn't appear in `/tools` | Filename has `.` (e.g. `mytool.sh`) | Drop the extension — `mytool` |
+| Tool doesn't appear under server `local` in `/mcp` | Not executable (Unix) | `chmod +x .agents/tools/<name>` |
+| Tool doesn't appear under server `local` in `/mcp` | Header missing `@description` | Add the line; debug log shows `parse … failed: missing @description` |
+| Tool doesn't appear under server `local` in `/mcp` | Filename has `.` (e.g. `mytool.sh`) or starts with `-`/`.` | Drop the extension and leading punctuation — `mytool` |
 | Tool returns non-JSON garbage | Script writes binary on stdout | Stick to text; or base64-encode |
-| Tool times out | Default 5-minute cap | Make the script faster or split into multiple calls |
+| Tool times out | Hard 5-minute (300s) cap — not configurable for local tools | Make the script faster or split into multiple calls |
 | Param values look wrong | Forgot `*` and the script assumed required | Add `*` to the name in the header |
 
-Enable `OCTOMIND_LOG=debug` to see why specific files were skipped during discovery.
+To see why specific files were skipped during discovery, raise the log level to debug — set config `log_level = "debug"`, use the `/loglevel debug` session command, pass `--log-level debug` on the CLI, or set `RUST_LOG`. The debug logs show non-executable files, header parse failures, and malformed or unknown tags.
 
 ## Security Notes
 

--- a/doc/usage/18-guardrails.md
+++ b/doc/usage/18-guardrails.md
@@ -6,14 +6,18 @@ Per-project policy for tool use and input preprocessing, defined in `.agents/gua
 |---|---|---|---|
 | `[[pipe]]` | Pre-model | Transform or validate user input before the model sees it | Non-zero exit → hard stop; stdout replaces user message |
 | `[[guard]]` | Pre-call | Block a tool from running | Synthetic error result returned to the model |
-| `[[hook]]` | Post-result | Run a script against the tool result | Non-zero exit → script stdout injected as user message |
-| `[[validator]]` | End-of-turn | Run a script after the assistant's final message | Non-zero exit → `<validation>`-wrapped stdout injected |
+| `[[hook]]` | Post-result | Run a script against the tool result | Non-zero exit → script stdout pushed to the session inbox (delivered as a user turn on the next request) |
+| `[[validator]]` | End-of-turn | Run a script after the assistant's final message | Non-zero exit → `<validation>`-wrapped stdout pushed to the session inbox |
 
 All four live in the same file. Nothing is mandatory; missing file = no policy.
+
+**Who can stop vs who can only nudge:** only `[[pipe]]` and `[[guard]]` can *block* — a pipe stops the message before the model sees it, a guard stops a tool call before it runs. `[[hook]]` and `[[validator]]` can only *nudge*: they cannot undo anything, they just push a message to the inbox that the model reads on the next turn.
 
 ## File location
 
 `<workdir>/.agents/guardrails.toml` — loaded fresh at session start. Parse errors are printed to stderr and treated as "no policy"; a broken file never crashes the session.
+
+The file is read once per session (`init_for_session`) and the resulting rules — together with the per-session state they drive (call log, per-validator cursors, per-pipe run counts, message counter) — are scoped to that session. Editing `guardrails.toml` mid-session has no effect; start a new session for changes to take effect.
 
 ## Matching DSL
 
@@ -25,9 +29,23 @@ capability(regex)                # regex matched against full args JSON
 capability(arg_name=regex)       # regex matched against a specific arg
 ```
 
-- **capability** = the MCP capability name as declared in tap manifests (e.g. `shell`, `filesystem-read`, `filesystem-write`). Resolved from the call's MCP server + tool name. Tools that aren't part of any capability never match.
+- **capability** = the MCP capability name as declared in tap manifests (e.g. `shell`, `filesystem-read`, `filesystem-write`). See [How a tool call resolves to a capability](#how-a-tool-call-resolves-to-a-capability) below. Tools that aren't part of any capability never match.
 - **regex on full args JSON** = the call's params object serialized to JSON, then matched. Use for any-arg patterns.
 - **arg-targeted** = regex matched against just that arg's value. String args matched directly (no quotes); arrays/objects/numbers matched against their JSON form. Example: `paths=secret` matches `paths=["a","b/secret.env"]` because the haystack becomes `["a","b/secret.env"]`.
+
+> **Two namespaces, one word.** The word "capability" appears in three places with **two distinct meanings**, so be careful:
+> - In `match` / `when` targets and in the hook payload (`capability` field / `OCTOMIND_CAPABILITY` env) it means a **capability name** — the resolved tap-capability that owns the tool (e.g. `shell`, `filesystem-read`).
+> - In `[[guard]] has` it means an **MCP server name** — the name of a configured `[[mcp.servers]]` entry active for the role (e.g. `core`, `runtime`, `agent`, `filesystem`). These are *not* capability names, so `has = "filesystem-read"` would never match.
+
+### How a tool call resolves to a capability
+
+`match` / `when` targets and the hook `capability`/`OCTOMIND_CAPABILITY` value all use a **capability name**. Octomind resolves a call's `(server, tool)` pair to that name as follows:
+
+1. **Static tap manifests first** — a `(server, tool) → capability` map is built from every installed capability's `allowed_tools`. A capability "owns" a tool when its `allowed_tools` lists `server:tool` (exact) or `server:*` (wildcard). The capability name is matched exact first, then by wildcard.
+2. **Runtime overlay fallback** — capabilities activated mid-session (via `skill use` or enabling a capability) are checked next.
+3. **No owner → no match.** Tools registered directly by a role (not through any capability) resolve to *no* capability and can never be matched by a guard/hook/validator DSL target.
+
+So the capability name for, say, the `view` tool is whatever tap capability lists `filesystem:view` (or `filesystem:*`) in its `allowed_tools` — not the server name `filesystem`. To discover the capability names available in a session, use the `/mcp` command (see the Skills and Token Efficiency docs for how capabilities are declared).
 
 ## `when` conditions (signed list)
 
@@ -99,7 +117,7 @@ roles   = ["developer"]                    # optional: role filter
 | `OCTOMIND_WORKDIR` | session working directory path |
 | `PIPE_NAME` | the `name` field from the `[[pipe]]` entry |
 | `PIPE_RUN_COUNT` | number of times this pipe has been invoked in this session (starts at `1`) |
-| `SESSION_MESSAGE_COUNT` | total number of user messages in the session so far (including the current one) |
+| `SESSION_MESSAGE_COUNT` | total number of user messages in the session so far (including the current one); incremented for every user message even when no pipe matches |
 
 ### Example: validate input format
 
@@ -136,7 +154,7 @@ roles   = ["developer"]
 ```toml
 [[guard]]
 match   = "shell(command=^rm\\s+-rf?)"   # required: DSL target on the call
-has     = "filesystem-read"              # optional: capability must be loaded
+has     = "filesystem"                   # optional: MCP server must be loaded
 when    = ["-filesystem-read"]           # optional: history filter
 message = "rm -rf blocked."              # required: shown to the model
 ```
@@ -146,8 +164,9 @@ message = "rm -rf blocked."              # required: shown to the model
 - Evaluated in declaration order; **first match wins**.
 - All conditions AND'd. Rule fires only when:
   - `match` target matches the current call, AND
-  - every `has` capability is loaded in the session, AND
+  - every `has` entry is the name of an MCP **server** active for the role, AND
   - every `when` item is satisfied against the session call log.
+- **`has` uses MCP server names, not capability names.** It is checked against the set of configured `[[mcp.servers]]` entries active for the current role (e.g. `core`, `runtime`, `agent`, `filesystem`) — *not* the capability vocabulary used by `match`/`when`. A value like `filesystem-read` (a capability name) will never match and the rule will never fire.
 - When the rule fires, the call is **blocked** before the executor runs. The model receives a synthetic tool error: `[guardrail] <message>`.
 
 ### Fields
@@ -155,7 +174,7 @@ message = "rm -rf blocked."              # required: shown to the model
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `match` | DSL target | yes | the call to match |
-| `has` | string or list | no | loaded-capability filter; empty = no filter |
+| `has` | string or list | no | loaded-MCP-**server**-name filter (e.g. `core`, `filesystem`); empty = no filter. Not a capability name. |
 | `when` | list of `+/-target` | no | history filter; empty = no filter |
 | `message` | string | yes | the text the model sees |
 
@@ -172,10 +191,12 @@ message = "Force push blocked. Use --force-with-lease and ask first."
 
 [[guard]]
 match   = "shell(command=^ls\\b)"
-has     = "filesystem-read"
+has     = "filesystem"
 when    = ["-filesystem-read"]
 message = "Use the view tool instead of ls."
 ```
+
+`has = "filesystem"` checks that the `filesystem` MCP server is loaded for the role; `when = ["-filesystem-read"]` checks that the `filesystem-read` *capability* has not been used yet in this session — two different namespaces working together.
 
 ### Performance
 
@@ -198,14 +219,14 @@ script = ".agents/hooks/cargo-lint.sh"   # required: path relative to workdir
 - Fires after each tool result lands, before results are returned to the model.
 - All matching hooks fire (no first-match-wins). Multiple hooks compose.
 - Skipped for guardrail-blocked tools — their synthetic result is not a real result.
-- Script runs with the tool context on stdin and environment. Exit 0 = no-op; exit ≠ 0 = stdout injected as one user message.
+- Script runs with the tool context on stdin and environment. Exit 0 = no-op; exit ≠ 0 = stdout pushed to the session inbox (delivered as a user turn on the next request). Stdout is trimmed first; if it is empty after trimming, nothing is pushed even on a non-zero exit.
 
 ### Fields
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `match` | DSL target | no | call filter; empty = any tool |
-| `result` | regex | no | regex on the result text; empty = any result (incl. empty) |
+| `match` | DSL target | no | call filter; empty/whitespace = any tool (skipped, treated as no filter) |
+| `result` | regex | no | regex on the result text; `result = ""` compiles to a match-everything regex (unlike `match`, which skips empty), so it matches any result incl. empty |
 | `on` | enum | no | `success`, `error`, or `any` (default) |
 | `script` | path | yes | relative to workdir |
 
@@ -214,12 +235,12 @@ script = ".agents/hooks/cargo-lint.sh"   # required: path relative to workdir
 | Channel | Use |
 |---|---|
 | **cwd** | session workdir |
-| **stdin** | JSON `{capability, tool, tool_id, params, result, success}` |
+| **stdin** | JSON `{capability, tool, tool_id, params, result, success}` (`capability` = resolved capability name, or `null` if the tool isn't owned by any capability) |
 | **env** | `OCTOMIND_CAPABILITY`, `OCTOMIND_TOOL`, `OCTOMIND_SUCCESS=1\|0`, `OCTOMIND_WORKDIR` |
-| **stdout** | injected as user message if exit ≠ 0 |
+| **stdout** | pushed to the session inbox if exit ≠ 0; trimmed first |
 | **stderr** | logged at debug level, never injected |
 | **exit 0** | no-op |
-| **exit ≠ 0** | stdout → inbox |
+| **exit ≠ 0** | trimmed stdout → inbox; if empty after trimming, nothing is pushed |
 | **timeout** | 300 s; killed → no inject |
 
 ### Example: parse cargo errors after every build
@@ -262,7 +283,8 @@ script = ".agents/validators/remind-tests.sh"
 - Fires once at the end of the assistant turn (after the model produces its final message with no further tool calls).
 - Per-validator cursor into the session call log. `when` is evaluated against `call_log[cursor..]` — i.e. **calls since this validator last ran**. On run, cursor advances to `call_log.len()`.
 - All filters AND'd. None set → fires every turn (skill-like).
-- On exit ≠ 0, stdout is wrapped as `<validation validator="<name>">…</validation>` and injected.
+- Guardrail validators run at the end of **every** assistant turn (subject only to the `roles`/`when`/`match` filters). They are a separate system from skill `SKILL.md` validate scripts and are **not** gated by the `[skills].auto_validation` config flag — that flag only controls skill validators.
+- On exit ≠ 0, stdout is trimmed, then wrapped as `<validation validator="<name>">…</validation>` and pushed to the session inbox. If stdout is empty after trimming, nothing is pushed even on a non-zero exit.
 
 ### Fields
 
@@ -289,11 +311,13 @@ Only validators that pass all three filters spawn their script. The cursor advan
 | **cwd** | session workdir |
 | **stdin** | JSON `{validator, role, assistant_text, triggered_by:[{capability,params}, …]}` |
 | **env** | `OCTOMIND_VALIDATOR`, `OCTOMIND_ROLE`, `OCTOMIND_WORKDIR` |
-| **stdout** | wrapped + injected if exit ≠ 0 |
+| **stdout** | trimmed, then wrapped + pushed to inbox if exit ≠ 0 |
 | **stderr** | logged at debug level |
 | **exit 0** | no-op |
-| **exit ≠ 0** | `<validation validator="<name>">stdout</validation>` → inbox |
+| **exit ≠ 0** | `<validation validator="<name>">stdout</validation>` → inbox; if stdout is empty after trimming, nothing is pushed |
 | **timeout** | 300 s |
+
+`triggered_by` lists the calls in the since-last-run slice that matched a `+used` target. When the validator has no `+used` targets configured, it instead contains **every** call in that slice — i.e. everything that happened since this validator last ran — so an always-on validator still sees the full window of activity.
 
 ### Example: nudge to test after edits
 
@@ -359,17 +383,17 @@ LLM emits tool calls [t0, t1, …]
   │     for each (call, real result):
   │       evaluate [[hook]] rules
   │       spawn matching scripts in parallel
-  │       non-zero exits → inbox push
+  │       non-zero exits with non-empty (trimmed) stdout → inbox push
   ├── truncate large outputs
   ├── return results to the LLM
 LLM produces final assistant message (no more tool calls)
   ├── run_turn_validators:
   │     for each [[validator]] in declaration order:
   │       role filter → when filter → match filter
-  │       survivors spawn scripts in parallel
-  │       advance per-validator cursors
-  │       non-zero exits → wrap + inbox push
-Inbox messages flow into the next API call as user messages
+  │       survivors spawn scripts; advance their cursors immediately
+  │         (cursor moves regardless of exit code — "the validator ran")
+  │       collect outputs; non-zero exits → wrap + inbox push
+Inbox messages flow into the next API call as user turns
 ```
 
 ---
@@ -391,7 +415,7 @@ message = "rm -rf blocked."
 
 [[guard]]
 match   = "shell(command=^ls\\b)"
-has     = "filesystem-read"
+has     = "filesystem"
 when    = ["-filesystem-read"]
 message = "Use the view tool instead of ls."
 
@@ -428,12 +452,14 @@ script = ".agents/validators/remind-tests.sh"
 
 Hook and validator injections land in the **session inbox** — the same queue used by skill validators, scheduled messages, webhooks, etc. The session loop drains the inbox before the next API request. Each non-zero-exit script produces one inbox entry; entries are flushed in the order they were enqueued.
 
-Inbox source kinds (visible in JSONL/WebSocket output):
+Inbox source kinds (the `source_kind` field in JSONL/WebSocket output) emitted by guardrails:
 
 | Source | When |
 |---|---|
-| `guardrail_hook` | a `[[hook]]` script exited non-zero |
-| `guardrail_validator` | a `[[validator]]` script exited non-zero |
+| `guardrail_hook` | a `[[hook]]` script exited non-zero (with non-empty trimmed stdout) |
+| `guardrail_validator` | a `[[validator]]` script exited non-zero (with non-empty trimmed stdout) |
+
+These two values let you distinguish guardrail injections from the other inbox sources sharing the same queue — `skill_validator`, `schedule`, `webhook`, `background_agent`, `tap_run`, `skill`, and `inject`. Grep the JSONL/WebSocket stream by `source_kind` to filter for just guardrail output. See [WebSocket Server](../integration/01-websocket-server.md) for the full structured-output schema.
 
 ---
 
@@ -443,7 +469,7 @@ Inbox source kinds (visible in JSONL/WebSocket output):
 - **Use `+used / -unused` for conditional rules, not separate `[[guard]]`s.** Composing two rules with `when` is clearer than three rules with no history.
 - **Keep scripts fast.** Hook and validator scripts run synchronously in the turn boundary; a 30-second script is a 30-second pause. The 300 s timeout exists as a backstop, not a target.
 - **stdout = the message, stderr = debugging.** If you're injecting noise, the model treats it as a literal user message. Be precise.
-- **Test before shipping.** `echo 'call shell …' | octomind run --format jsonl` lets you grep the JSONL for `"type":"injected"` and verify the guardrail fires exactly when intended.
+- **Test before shipping.** `echo 'call shell …' | octomind run --format jsonl` lets you grep the JSONL for `"type":"injected"` events and verify the guardrail fires exactly when intended. Filter by the `source_kind` field (`guardrail_hook` / `guardrail_validator`) to isolate guardrail output from other inbox injections.
 
 ---
 
@@ -455,6 +481,7 @@ Inbox source kinds (visible in JSONL/WebSocket output):
 | Trigger | declared in skill config | declared in guardrails file |
 | State | skill auto-activation | per-validator cursor into call log |
 | Filter | always when skill active | `roles` + `when` + `match` |
+| Gated by `[skills].auto_validation` | yes — the flag enables/disables skill validate scripts | no — guardrail validators always run at turn end |
 | Wrapping | `<validation skill="…">` | `<validation validator="…">` |
 
 They share the inbox path and the activation-by-failure pattern, but live at different layers — skills are reusable across projects, guardrails are project-local policy.

--- a/doc/use-cases/01-ci-cd-code-review.md
+++ b/doc/use-cases/01-ci-cd-code-review.md
@@ -8,40 +8,82 @@ Manual code review is slow. You want AI to catch common issues -- security vulne
 
 ## Solution
 
-Use non-interactive mode with structured output to get machine-readable results.
+Use non-interactive mode and read the result back as JSON.
+
+Two facts shape everything below, so get them straight up front:
+
+1. **`--format plain` is decorated terminal text, not data.** In a pipeline the
+   assistant reply is wrapped in `─────` horizontal rules, colored, and
+   markdown-rendered by default. It is meant for humans (e.g. a job summary), not
+   for `jq`. Use it only for human-readable output.
+2. **`--format jsonl` is the machine-readable surface.** It emits a *stream* of
+   type-tagged JSON objects, one per line -- `assistant`, `cost`, and (when they
+   occur) `thinking`, `tool_use`, `tool_result`, `status`. It is NOT a single
+   JSON object. To get the model's answer you filter the `assistant` line(s) out
+   of the stream.
+
+> **Note on "structured output":** the CLI does not enforce a JSON Schema on the
+> model's reply. There is no `--schema` flag. What you get is *prompt-coaxed*
+> JSON -- you ask the model to reply as JSON and parse it best-effort. Provider-
+> enforced schema output is only available through the WebSocket and ACP server
+> interfaces. See [Structured Output](../usage/11-structured-output.md).
+
+> **Note on roles:** the commands below use the built-in `assistant` role. The
+> built-in roles are `assistant`, `task_refiner`, `task_researcher`, and `reduce`
+> (the default tag is `assistant:concierge`). A dedicated `developer:general`
+> agent also exists; it ships via the built-in default tap `muvon/tap`, which
+> auto-clones on first use (a one-time network fetch). See [Tap System](../integration/04-tap-system.md).
 
 ### Basic: Review from Stdin
 
+In non-interactive mode Octomind reads the **entire** message from stdin -- a
+single stream. Do not combine a pipe with a heredoc (`<<<`); only one of them
+reaches stdin and the other is silently dropped. Build the whole prompt, diff
+included, and pipe it once:
+
 ```bash
-# Feed a diff to Octomind and get a review
-git diff main..HEAD | octomind run developer \
-  --format plain <<< "Review this diff for security issues, performance problems, and bugs. Be specific about file and line numbers."
+# Feed the prompt + diff to Octomind and print a human-readable review
+diff=$(git diff main..HEAD)
+printf 'Review this diff for security issues, performance problems, and bugs. Be specific about file and line numbers.\n\n%s' "$diff" \
+  | octomind run assistant --format plain
 ```
+
+The `--format plain` output is colorized and framed for a terminal, which is fine
+for a human reading the log. If you need to scrape it as text, prefer the `jsonl`
+approach below, or disable rendering with `enable_markdown_rendering = false` in
+config (and strip ANSI / the `─────` rules) -- but JSON is the cleaner path.
 
 ### Structured: JSON Output for Pipeline Decisions
 
-Prompt the AI to return JSON directly:
+Ask the model to reply as JSON, run with `--format jsonl`, then pull the
+`assistant` payload out of the stream and parse the JSON the model put inside it:
 
 ```bash
 #!/bin/bash
 # ci-review.sh
+set -euo pipefail
 
 diff=$(git diff main..HEAD)
-result=$(echo "Review this diff for issues. Respond in JSON with: {summary, issues: [{file, line, severity, description}], approval}.\n\n$diff" | \
-  octomind run developer \
-  --model openai:gpt-4o \
-  --format plain)
 
-approval=$(echo "$result" | jq -r '.approval')
-errors=$(echo "$result" | jq '[.issues[] | select(.severity == "error")] | length')
+# Run non-interactively. jsonl is a stream of type-tagged objects, one per line.
+stream=$(printf 'Review this diff for issues. Respond ONLY with JSON of the form: {"summary": "...", "issues": [{"file": "...", "line": 0, "severity": "...", "description": "..."}], "approval": "approve|request_changes"}.\n\n%s' "$diff" \
+  | octomind run assistant --model openai:gpt-4o --format jsonl)
+
+# Slurp the stream, keep the last assistant line, take its .content (the model's text).
+review=$(echo "$stream" | jq -rsc 'map(select(.type == "assistant")) | last | .content')
+
+# $review is the model's JSON string — parse it as JSON now.
+approval=$(echo "$review" | jq -r '.approval')
+errors=$(echo "$review" | jq '[.issues[] | select(.severity == "error")] | length')
 
 echo "Review: $approval ($errors errors)"
 
 if [ "$approval" = "request_changes" ] || [ "$errors" -gt 0 ]; then
-  echo "$result" | jq '.issues[]'
+  echo "$review" | jq '.issues[]'
   exit 1
 fi
 ```
+
 ```yaml
 # .github/workflows/ai-review.yml
 name: AI Code Review
@@ -63,30 +105,82 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           diff=$(git diff origin/main..HEAD)
-          result=$(echo "$diff" | octomind run developer \
-            --format plain <<< "Review for security, performance, bugs")
-          echo "$result" >> $GITHUB_STEP_SUMMARY
+          # --format plain is fine here: we want a human-readable summary in the job log.
+          summary=$(printf 'Review for security, performance, bugs.\n\n%s' "$diff" \
+            | octomind run assistant --format plain)
+          echo "$summary" >> "$GITHUB_STEP_SUMMARY"
 ```
+
+### Multi-step pipelines
+
+For anything beyond a single review call -- chaining steps and passing one step's
+output into the next -- use the [`octomind workflow`](../usage/09-workflows.md)
+subcommand instead of hand-rolling shell. It reads the initial input from stdin
+and runs each step as an independent `octomind run` subprocess:
+
+```bash
+git diff main..HEAD | octomind workflow review.toml 2> progress.log
+```
+
+Note an important quirk: a real workflow run writes **everything** -- per-step
+responses, progress, cost, and totals -- to **stderr**. stdout is empty (it is
+used only by `--dry-run`, which prints the execution plan). So you cannot capture
+a workflow's final answer from stdout; if a downstream step needs a result, have
+that step write it to a file itself. See [Workflows](../usage/09-workflows.md)
+for the full model.
 
 ## Cost Control
 
-Set spending limits to prevent runaway costs:
+Octomind has two spending thresholds, in USD, and they behave **differently** --
+this matters in CI:
 
 ```toml
-max_request_spending_threshold = 0.50  # Max $0.50 per review
+# Hard-stops a single request once it exceeds the limit. Safe for CI.
+max_request_spending_threshold = 0.50  # max $0.50 per review
+
+# PROMPTS the user before continuing once the cumulative session cost exceeds
+# the limit. The prompt is interactive — in a non-interactive CI run there is
+# nobody to answer it, so the run can block. Leave at 0.0 in CI, or rely on the
+# request threshold instead.
+max_session_spending_threshold = 0.0   # 0.0 = no limit
 ```
 
-Or use a cheaper model for initial triage:
+`>0` enables a threshold; `0.0` disables it. For CI, prefer
+`max_request_spending_threshold` (it stops execution) and keep
+`max_session_spending_threshold` at `0.0` to avoid a blocking prompt.
+
+Or use a cheaper model for initial triage. `run` takes its message from stdin --
+there is no free-text message argument (the only positional is the role/tag):
 
 ```bash
-octomind run -m openrouter:openai/gpt-4o-mini "Quick check for obvious bugs"
+echo 'Quick check for obvious bugs' \
+  | octomind run assistant -m openrouter:openai/gpt-4o-mini --format plain
 ```
 
-## Key Points
-- `--format plain` or `--format jsonl` for non-interactive output
-- Pipe input via stdin for non-interactive mode
-- `--model` to balance cost vs quality per pipeline step
-- Octomind has full tool access -- it can read files, not just the diff you pipe in
+## Clean CI logs
 
-> **Note:** Structured output with JSON schemas is available via the WebSocket and ACP
-> interfaces. See [Structured Output](../usage/11-structured-output.md) for details.
+To keep CI output tidy:
+
+- Non-interactive mode (`--format plain`/`jsonl` with piped stdin) shows no
+  spinner or animations -- those only appear in an interactive terminal.
+- Set `log_level = "none"` in config (or `octomind config --log-level none`) to
+  suppress informational logging.
+- Restrict filesystem writes with the `--sandbox` flag (or `sandbox = true` in
+  config) so a review run can read your tree but cannot write outside the current
+  working directory. Octomind has full tool access by default -- it can read and
+  write files, not just the diff you pipe in -- so sandboxing is worth enabling in
+  CI.
+
+## Key Points
+- `--format plain` = human-readable, decorated terminal text (rules + color +
+  markdown). `--format jsonl` = machine-readable stream of type-tagged JSON
+  objects, one per line.
+- Both run non-interactively and read the whole message from stdin. Use one
+  stdin source -- never a pipe AND a heredoc together.
+- Extract the answer from jsonl with `jq -rsc 'map(select(.type=="assistant")) | last | .content'`.
+- `--model` to balance cost vs quality per pipeline step.
+- The CLI gives prompt-coaxed JSON, not schema-enforced output. For enforced
+  schemas use the WebSocket/ACP servers -- see
+  [Structured Output](../usage/11-structured-output.md).
+- Octomind has full tool access -- it can read and write files, not just the
+  diff you pipe in. Use `--sandbox` to confine writes in CI.

--- a/doc/use-cases/02-event-driven-agent.md
+++ b/doc/use-cases/02-event-driven-agent.md
@@ -23,7 +23,7 @@ Webhook Hook (HTTP listener on port 9876)
     v
 Hook Script (process-event.sh)
     |
-    | stdout: message for AI
+    | stdout: message for AI (only on exit 0)
     v
 Daemon Session Inbox
     |
@@ -31,7 +31,21 @@ Daemon Session Inbox
 AI processes event, takes action
 ```
 
+The **inbox** is the daemon's queue of pending events. When a hook script exits 0 with
+non-empty output, that stdout is added to the session as the **next user message** -- the
+AI responds to it on its next turn, just as if you had typed it interactively. The daemon
+drains this inbox continuously, so events are processed one turn at a time.
+
 ### Step 1: Write a Hook Script
+
+The contract is simple and decided by the script's **exit code**:
+
+- **Exit 0 with non-empty stdout** -- the trimmed stdout is injected as the next user message (listener responds `200 ok`).
+- **Exit 0 with empty stdout** -- nothing is injected; the listener responds `204 No Content`.
+- **Non-zero exit** -- nothing is injected; the listener responds `500` and logs the script's stderr at error level.
+
+So `exit 1` is how you tell Octomind "this event isn't interesting, drop it" -- the
+webhook sender will see an HTTP 500, which may trigger its retry or alerting.
 
 ```bash
 #!/bin/bash
@@ -46,7 +60,7 @@ commits=$(echo "$payload" | jq -r '.commits | length')
 
 # Only react to main branch
 if [ "$branch" != "main" ]; then
-  exit 1  # Non-zero = ignore
+  exit 1  # Non-zero = nothing injected (sender gets HTTP 500)
 fi
 
 # Files changed
@@ -80,11 +94,22 @@ script = "/opt/hooks/github-push.sh"
 timeout = 30
 ```
 
+Each hook needs a **unique `name`** and a **unique `bind` address**. `bind` must be a
+valid `host:port` socket address, `script` must be non-empty, and `timeout` must be
+between 1 and 3600 seconds (default 30). Octomind validates these at startup and refuses
+to launch if any rule is violated.
+
 ### Step 3: Start the Daemon
 
 ```bash
 octomind run --name code-monitor --daemon --format jsonl --hook github-push
 ```
+
+`--daemon` keeps the process running indefinitely, draining its inbox and waiting for the
+next event. It must run **non-interactively** -- a session decides interactivity from
+`stdin` being a terminal and `--format` being unset, so use `--format jsonl` (recommended:
+output is machine-parseable) or pipe stdin. `--name` is required so external tools can
+reach the session via `octomind send`.
 
 ### Step 4: Point GitHub Webhook
 
@@ -134,6 +159,22 @@ Besides webhooks, you can inject messages directly:
 echo "Summarize what happened in the last hour" | octomind send --name ops-agent
 ```
 
+`octomind send` connects to the running session over a per-session Unix socket
+(`<data>/run/<name>.sock`) or, on Windows, a named pipe (`\\.\pipe\octomind-<name>`). It
+only works **while a daemon/session with that name is live** -- if no such session is
+running, it fails with `no running session named '<name>'`. The message must be non-empty,
+and `send` reads back `ok` on success or an error string. (You can pass the message as an
+argument instead of piping it via stdin.)
+
+### Reacting to Background Work
+
+There is a third event source besides webhooks and manual `send`: **completed background
+agents**. When a delegated async agent (an `agent_<name>` job spawned with `async = true`,
+or a background tap run) finishes, its result is pushed into the same inbox the daemon
+drains, prefixed with `[Async agent 'NAME' completed]` or `[Async agent 'NAME' failed]`.
+The daemon processes these identically to webhook and `send` messages, so a long-running
+agent can fire off work and react to its own results asynchronously.
+
 ## Hook Script Environment
 
 Your script receives rich context via environment variables:
@@ -142,35 +183,64 @@ Your script receives rich context via environment variables:
 |----------|---------|
 | `HOOK_NAME` | `github-push` |
 | `HOOK_METHOD` | `POST` |
-| `HOOK_PATH` | `/webhook` |
+| `HOOK_PATH` | `/` (whatever path the sender POSTed to) |
+| `HOOK_QUERY` | `repo=foo&action=push` (raw URL query string, empty if none) |
 | `HOOK_CONTENT_TYPE` | `application/json` |
 | `HOOK_SESSION` | `code-monitor` |
 | `HOOK_HEADER_X_GITHUB_EVENT` | `push` |
+
+The listener serves all paths -- it only requires the method to be `POST` -- so `HOOK_PATH`
+reflects whatever URL the sender used. Every request header is also exposed as
+`HOOK_HEADER_<NAME>` (uppercased, dashes replaced with underscores).
 
 Use these to route different event types in a single script:
 
 ```bash
 #!/bin/bash
 event="$HOOK_HEADER_X_GITHUB_EVENT"
+payload=$(cat)   # read the HTTP body once — stdin can only be consumed a single time
 
 case "$event" in
   push)
-    echo "Code pushed: $(cat | jq -r '.commits | length') commits"
+    echo "Code pushed: $(echo "$payload" | jq -r '.commits | length') commits"
     ;;
   pull_request)
-    echo "PR $(cat | jq -r '.action'): $(cat | jq -r '.pull_request.title')"
+    echo "PR $(echo "$payload" | jq -r '.action'): $(echo "$payload" | jq -r '.pull_request.title')"
     ;;
   *)
-    exit 1  # Ignore unknown events
+    exit 1  # Unknown event: nothing injected (sender gets HTTP 500)
     ;;
 esac
 ```
 
+## HTTP Responses
+
+The listener returns a status code the webhook sender can use for retry and health logic:
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Script exited 0 with output; message injected (body `ok`) |
+| `204` | Script exited 0 with empty output; nothing injected |
+| `400` | Request body could not be read |
+| `405` | Request was not `POST` |
+| `500` | Script exited non-zero, or failed to spawn / had an IO error |
+| `504` | Script exceeded its `timeout` |
+
+A non-zero script exit returns `500` to the sender (body `Script error (exit N)`) and logs
+the script's stderr at error level -- so a 500 you see in your webhook provider usually
+means the hook script failed or deliberately bailed, not that Octomind is down.
+
 ## Key Points
 
-- `--daemon` keeps the session alive between events
-- `--hook` activates webhook listeners (multiple allowed)
-- Scripts exit 0 = inject stdout as user message; non-zero = ignore
-- `octomind send --name X` for manual message injection
-- JSONL output is parseable by downstream tools
-- The AI has full tool access -- it can read the actual files, not just the webhook payload
+- `--daemon` keeps the session alive between events, draining its inbox; it must run
+  non-interactively (use `--format jsonl` or pipe stdin).
+- The daemon is resilient: if a turn hits an API error, it logs it and keeps listening
+  rather than exiting (unlike a one-shot non-interactive run, which exits non-zero).
+- `--hook` activates webhook listeners (multiple allowed); each needs a unique name and bind.
+- Hook script contract: exit 0 + non-empty stdout = inject (HTTP 200); exit 0 + empty
+  stdout = nothing injected (HTTP 204); non-zero exit = nothing injected (HTTP 500).
+- Injected text becomes a literal user message; the AI answers it on its next turn.
+- `octomind send --name X` injects a message manually -- but only while a session named `X`
+  is actually running.
+- JSONL output is parseable by downstream tools.
+- The AI has full tool access -- it can read the actual files, not just the webhook payload.

--- a/doc/use-cases/03-custom-development-workflow.md
+++ b/doc/use-cases/03-custom-development-workflow.md
@@ -12,27 +12,29 @@ Use the external `octomind workflow <file.toml>` CLI to chain multiple independe
 
 > The session-internal `[[workflows]]` system and `/workflow` command have been removed. Workflows now sit **above** sessions, not inside them. See [Workflows](../usage/09-workflows.md) for the full reference.
 
+> This use-case covers **sequential** steps and the **loop** step. Workflows also support **parallel** and **conditional** steps — see [Workflows](../usage/09-workflows.md) for those, plus the full reference for `retries`, `timeout`, `model`, and variable substitution.
+
 ### Architecture
 
 ```
 echo "fix the login bug" | octomind workflow dev.toml
     |
     v
-[refine]        Clarify the request, guess relevant files (gpt-4.1-mini)
+[refine]        Clarify the request, guess relevant files (cheap fast model)
     |
     v
-[research]      Read code, search patterns, gather context (gemini-flash)
+[research]      Read code, search patterns, gather context (large-context model)
     |
     v
-[execute]       Produce the fix with full understanding (claude-sonnet)
+[execute]       Produce the fix with full understanding (powerful model)
     |
     v
-stdout
+stderr (each step's response + per-step stats + totals)
 ```
 
 ### Workflow File
 
-Drop this at `dev.toml`:
+Drop this at `dev.toml`. The `role` values here (`developer:general`, `developer:brief`) are **tap agents** from the built-in default tap `muvon/tap` (auto-cloned on first use), not local `[[roles]]` shipped in `default.toml` — they resolve out of the box, or swap in any role/tag you already have. The optional per-step `model = "provider:model"` field overrides that role's model for this step and is forwarded to the subprocess as `--model`.
 
 ```toml
 name   = "dev"
@@ -41,6 +43,7 @@ name   = "dev"
 name    = "refine"
 role    = "developer:general"
 session = "fresh"
+model   = "openai:gpt-5-mini"   # cheap fast model for simple refinement
 prompt  = """
 Refine this request into a clear, actionable task. Guess which files might
 be relevant. If already clear, return unchanged. Respond ONLY with the
@@ -54,6 +57,8 @@ Request:
 name    = "research"
 role    = "developer:general"
 session = "fresh"
+model   = "openrouter:google/gemini-2.5-flash-preview"   # large-context model for code reading
+timeout = 300                          # seconds; 0 = no timeout (default)
 prompt  = """
 Gather the key context for this task. Search relevant files, read
 signatures (not full bodies), note conventions. Output:
@@ -69,6 +74,8 @@ Task:
 name    = "execute"
 role    = "developer:general"
 session = "fresh"
+model   = "anthropic:claude-sonnet-4-6"   # powerful model for the actual fix
+retries = 1                                # one extra attempt on failure
 prompt  = """
 Implement the task using the gathered context.
 
@@ -80,17 +87,46 @@ Context:
 """
 ```
 
+Each sequential step (including sub-steps inside a loop) accepts these optional fields:
+
+| Field | Default | What it does |
+|-------|---------|--------------|
+| `session` | `"fresh"` | `"fresh"` = brand-new session; `"continue"` = resume the same session across loop iterations |
+| `model` | _(role default)_ | `provider:model` override forwarded as `--model`; must not be empty when set |
+| `timeout` | `0` | Seconds before the subprocess is killed; `0` = no timeout. A timeout counts as a failure |
+| `retries` | `0` | Extra attempts when the step fails (total attempts = `retries + 1`) |
+
+A step **fails** when its `octomind run` subprocess exits non-zero, produces no assistant output, or hits its `timeout`. When all attempts are exhausted the whole workflow stops and exits non-zero with `step '<name>' failed after <N> attempts: <reason>`.
+
 ### Run It
 
 ```bash
 echo "fix the login bug" | octomind workflow dev.toml
 ```
 
-Each step's assistant message is rendered to stderr as it completes (with markdown rendering when enabled), alongside per-step timing, cost, and tokens.
+Each step's assistant message is rendered to **stderr** as it completes (with markdown rendering when enabled), alongside per-step timing, cost, and tokens. The run produces **no stdout** — see [Key Points](#key-points). A run looks like this (color stripped):
+
+```
+workflow · dev
+
+╭ refine
+╰ ✓ refine  1.4s  · $0.0009  · 420 tok  · ⚒0
+
+╭ research
+│ ▸ ast_grep · octofs
+╰ ✓ research  6.2s  · $0.0071  · 2980 tok  · ⚒5
+
+╭ execute
+╰ ✓ execute  9.1s  · $0.0188  · 4120 tok  · ⚒8
+
+total · 16.7s  · $0.0268  · 7520 tok  · ⚒13
+```
+
+> **In workflow step prompts, only `{{input}}` and `{{step_name}}` resolve.** Pre-flight validation (`src/workflow/validate.rs`, run even under `--dry-run`) rejects **any** `{{var}}` that is not `{{input}}` or a declared step name — so built-in placeholders like `{{DATE}}`/`{{CWD}}`/`{{GIT_STATUS}}` **cannot** be used in a step prompt (the workflow aborts before running). Put date/context text directly in the prompt, or inline a file with a `<context>path</context>` / `<context>path:start:end</context>` block. (Built-in placeholders work in role/layer system prompts, not workflow steps.) See [Workflows → Variable substitution](../usage/09-workflows.md#variable-substitution).
 
 ## Advanced: Validation Loop
 
-Add an iterative validate-fix cycle. Researcher and tester each get their own continuing session via `session = "continue"`:
+Add an iterative researcher↔tester refine cycle. Both sub-steps keep a continuing session via `session = "continue"`, so each loop iteration builds on the last instead of starting cold:
 
 ```toml
 name   = "validated_dev"
@@ -133,23 +169,42 @@ session = "fresh"
 prompt  = "Implement: {{refine}}\n\nContext:\n{{research}}"
 ```
 
+**How the loop actually runs.** This is the GAN-style refine pattern, and continue-sessions behave in a specific way you should understand before reading the prompts above literally:
+
+- **Iteration 1** runs `research` with the templated prompt (`Gather context for: <refined task>`), then `tester` with its templated prompt.
+- **Iteration 2+**: for each continue-session step, `octomind` first sends `/done` to compress the prior context, then **replaces the templated prompt with the most recent prior step's raw output**. So in round 2 `research` does not re-receive `Gather context for: …`; it receives `tester`'s last verdict and reacts to it. Likewise `tester` reacts to the fresh `research` output. The session already holds the full task, so each round only feeds it the latest signal.
+- After every iteration, `exit_when` is tested. The loop stops as soon as `tester`'s output contains `READY`.
+
+Continue-sessions are **ephemeral to a single `octomind workflow` invocation** — their generated session names (`wf-<workflow>-<step>-<uuid>`) are never reused across runs. For the full reference on this behavior, see [Workflows → Session modes](../usage/09-workflows.md#session-modes).
+
 ## Cost Optimization
 
-Each step is a separate `octomind run` invocation, so you can give each one its own role with its own model:
+Each step is a separate `octomind run` invocation, so you can match the model to the job — cheap models for simple steps, a powerful model only where it matters:
 
-| Step | Role | Why |
-|------|------|-----|
-| refine | cheap fast model | Simple text refinement |
-| research | fast model with large context | Code reading |
-| tester | small judge model | Yes/no decision |
-| execute | powerful model | Complex reasoning + code generation |
+| Step | Job | Suggested model |
+|------|-----|-----------------|
+| refine | Simple text refinement | `openai:gpt-5-mini` |
+| research | Code reading, large context | `openrouter:google/gemini-2.5-flash-preview` |
+| tester | Yes/no judge decision | small judge model, e.g. `openai:gpt-5-mini` |
+| execute | Complex reasoning + code generation | `anthropic:claude-sonnet-4-6` |
 
-Configure the per-role model in your normal `[[roles]]` config (or use `[taps]` overrides per agent tag). The workflow file just names the role; cost lives in role config.
+**How to actually set a step's model**, in priority order (highest wins):
+
+1. **Per-step `model = "provider:model"` in the workflow file** — the simplest and most direct lever, shown in the [Workflow File](#workflow-file) example above. It is forwarded to the subprocess as `--model` and overrides everything else for that step.
+2. The model declared by the step's role/tap-agent definition (a plain `[[roles]]` entry, or a tap agent's manifest role).
+3. A `[taps]` override keyed by the agent tag — applies to tap agents (`category:variant`) and acts at the `config.model` tier. (See [Configuration](../usage/03-configuration.md) and [Roles](../usage/06-roles.md).)
+4. The global default `model` from config.
+
+> For workflow steps, prefer the per-step `model` field — it is forwarded as `--model` and always wins, for any role or tap agent.
 
 ## Key Points
 
 - Workflow steps are **separate sessions** — they don't share context unless `session = "continue"` is set
-- Loop step exits as soon as `exit_when.contains` matches the named output
+- A loop exits as soon as its `exit_when` matches the named output via `contains` (substring) **or** `matches` (Rust regex); `exit_when` must set at least one of the two
+- If a loop reaches `max_iterations` without `exit_when` matching, it prints a `⚠ … reached max_iterations` warning to stderr and continues with the last iteration's outputs — the workflow does **not** fail
+- A step **fails** on non-zero exit, empty assistant output, or `timeout`. `retries = N` gives `N+1` total attempts; when all are exhausted the workflow exits non-zero with `step '<name>' failed after <N> attempts: <reason>`
 - Stdin → `{{input}}`; each step's last assistant message prints to **stderr** as it completes (with markdown rendering when enabled)
-- All progress, timing, cost, tokens also print to **stderr**; the workflow produces no stdout
-- Use `--dry-run` to validate the file and print the execution plan without spawning any sessions
+- All progress, timing, cost, tokens also print to **stderr**; a real run produces **no stdout**
+- `--dry-run` validates the file and prints the execution plan to **stdout** (the only stdout the command ever produces), then exits — it never reads stdin and spawns no sessions
+- Pre-flight validation (before any step runs) rejects: empty workflows, duplicate step names, a step named `input` (reserved), forward references to a not-yet-completed step, parallel blocks with fewer than 2 sub-steps, loops missing `exit_when`, an invalid `matches` regex, and an empty `model` string
+- This page covers sequential and loop steps; for **parallel** and **conditional** steps see [Workflows](../usage/09-workflows.md#step-types)

--- a/doc/use-cases/04-web-dashboard-integration.md
+++ b/doc/use-cases/04-web-dashboard-integration.md
@@ -13,14 +13,22 @@ Run the WebSocket server and connect from your web frontend.
 ### Step 1: Start the Server
 
 ```bash
-octomind server developer --host 127.0.0.1 --port 8080
+octomind server --host 127.0.0.1 --port 8080
+```
+
+`--host` defaults to `127.0.0.1` and `--port` (short `-p`) defaults to `8080`, so a bare `octomind server` already binds to `ws://127.0.0.1:8080`. The optional `TAG` argument before the flags selects an agent (`role:tag`, e.g. `developer:general`) or a role name; omit it to use the default role from your config. The shipped config defines the roles `assistant`, `task_refiner`, `task_researcher`, and `reduce` -- if you pass a name that does not exist as a role and is not provided by a tap, the server falls back to the first configured role silently, so use a real role:
+
+```bash
+octomind server assistant -p 8080
 ```
 
 For production, bind to `0.0.0.0` behind a reverse proxy with TLS:
 
 ```bash
-octomind server developer --host 0.0.0.0 --port 8080
+octomind server assistant --host 0.0.0.0 --port 8080
 ```
+
+> The server performs no authentication, authorization, TLS, or origin checking itself. Any client that can reach the socket can drive a session. Always put it behind a reverse proxy that handles TLS and auth (see Step 3), and never bind `0.0.0.0` on an untrusted network.
 
 ### Step 2: Connect from JavaScript
 
@@ -51,17 +59,26 @@ class OctomindClient {
     this.ws.onmessage = (event) => {
       const msg = JSON.parse(event.data);
       switch (msg.type) {
+        case 'status':
+          // The server replies to `session` with a status carrying the
+          // ACTUAL session_id ("Session created: <id>" / "Session resumed: <id>").
+          // When you omit session_id the server auto-names the session, so
+          // always capture the returned id and use it for subsequent messages.
+          if (msg.session_id) this.sessionId = msg.session_id;
+          break;
         case 'assistant':
           this.handlers.onMessage(msg.content);
           break;
         case 'tool_use':
-          this.handlers.onToolUse(msg.tool_name, msg.parameters);
+          this.handlers.onToolUse(msg.tool, msg.params);
           break;
         case 'cost':
+          // `cost` is emitted once after each completed AI turn — the
+          // canonical end-of-turn signal.
           this.handlers.onCost(msg.session_cost);
           break;
         case 'error':
-          this.handlers.onError(msg.content);
+          this.handlers.onError(msg.message);
           break;
       }
     };
@@ -76,6 +93,9 @@ class OctomindClient {
   }
 
   command(cmd: string) {
+    // `command` is the bare command name WITHOUT the leading slash —
+    // the server prepends '/'. Sending '/info' would become '//info'.
+    // Unknown commands come back as an `error` payload.
     this.ws.send(JSON.stringify({
       type: 'command',
       session_id: this.sessionId,
@@ -93,7 +113,7 @@ const ai = new OctomindClient('ws://localhost:8080', 'dev-session', {
 });
 
 ai.send('Explain how authentication works in this project');
-ai.command('/info');  // Get session stats
+ai.command('info');  // Get session stats (note: bare name, no leading slash)
 ```
 
 ### Step 3: Production Setup with nginx
@@ -151,7 +171,10 @@ async def ask_octomind(question: str) -> str:
             msg = json.loads(message)
             if msg['type'] == 'assistant':
                 response_parts.append(msg['content'])
-            elif msg['type'] == 'status' and 'complete' in msg.get('content', ''):
+            elif msg['type'] == 'cost':
+                # `cost` is emitted once after each completed AI turn — the
+                # canonical end-of-turn marker. `status` text is free-form and
+                # never reliably signals completion, so don't parse it for that.
                 break
 
         return ''.join(response_parts)
@@ -164,16 +187,21 @@ answer = asyncio.run(ask_octomind("What does the login function do?"))
 
 | Direction | Type | Purpose |
 |-----------|------|---------|
-| Client -> Server | `session` | Create/resume session |
-| Client -> Server | `message` | Send user input |
-| Client -> Server | `command` | Execute session command |
-| Server -> Client | `assistant` | AI response text |
-| Server -> Client | `thinking` | Extended thinking (if model supports) |
-| Server -> Client | `tool_use` | Tool being called |
-| Server -> Client | `tool_result` | Tool execution result |
-| Server -> Client | `cost` | Token usage and cost |
-| Server -> Client | `status` | Progress updates |
-| Server -> Client | `error` | Error messages |
+| Client -> Server | `session` | Create or resume a session (no AI call). With no `session_id` the server creates an auto-named session; with a `session_id` it resumes that session if it exists on disk, otherwise creates one with that name. |
+| Client -> Server | `message` | Send user input (field `content`, max 10 MB) |
+| Client -> Server | `command` | Execute a session command (field `command`, bare name without the leading `/`; optional `args` array) |
+| Server -> Client | `assistant` | AI response text (`content`) |
+| Server -> Client | `thinking` | Extended thinking (`content`, if the model supports it) |
+| Server -> Client | `tool_use` | Tool being called (`tool`, `tool_id`, `server`, `params`) |
+| Server -> Client | `tool_result` | Tool execution result (`tool`, `tool_id`, `server`, `content`, `success`) |
+| Server -> Client | `cost` | Token usage and cost; emitted once after each completed AI turn (use it as the end-of-turn signal) |
+| Server -> Client | `status` | Free-form status text in `message` (e.g. the connection welcome, `Session created: <id>` / `Session resumed: <id>`, command-executed notices, `Session ended`, `Conversation compressed`). Not a machine-readable completion marker -- use `cost` for that. May carry an optional `session_id` and structured `data`. |
+| Server -> Client | `error` | Error text in `message` |
+| Server -> Client | `mcp_notification` | Notification forwarded from an MCP server (`server`, `method`, `params`) |
+| Server -> Client | `skill` | Skill lifecycle event (`action` = activate/use/forget, `name`, optional `trigger`) |
+| Server -> Client | `injected` | Non-user input being added to the conversation (`source_kind` = schedule/background_agent/tap_run/skill/skill_validator/inject/webhook/guardrail_hook/guardrail_validator, `source_label`, `content`); emitted just before the AI responds so the UI can show what triggered it |
+
+> For the authoritative, exhaustive wire-format spec (every field and JSON example) see [doc/integration/01-websocket-server.md](../integration/01-websocket-server.md). When the two docs differ, that reference and the source win.
 
 ## Multi-Session Support
 
@@ -188,11 +216,14 @@ bob.send('Help me write tests for the API');
 // Both sessions run independently
 ```
 
+Concurrency is across **different** `session_id`s. Requests to the **same** `session_id` are serialized by a per-session lock: if you send a second `message` or `command` while that session is still processing, the server replies immediately with an `error` payload (`Session '<id>' is busy processing another request. Please wait.`) -- it does not queue the request. A dashboard sending overlapping input to one session must wait for the turn's `cost` message (or handle the busy error) before sending again.
+
 ## Key Points
 
 - The WebSocket server provides the same capabilities as the CLI
 - Sessions are stateful -- context persists across messages
 - Tool execution (file reading, shell commands) is streamed in real-time
-- Use a reverse proxy with TLS for production
-- Never expose the server directly to the internet without authentication
+- A `cost` message is emitted once after each completed AI turn -- use it as the end-of-turn signal, not the free-form `status` text
+- User `message` `content` is capped at 10 MB, and the WebSocket frame/message size limit is also 10 MB; larger input returns a validation error
+- The server has no built-in authentication, authorization, or TLS -- use a reverse proxy with TLS for production and never expose the server directly to the internet
 - Cost tracking is per-session via `cost` messages

--- a/doc/use-cases/05-multi-agent-delegation.md
+++ b/doc/use-cases/05-multi-agent-delegation.md
@@ -10,7 +10,15 @@ A single AI call struggles with large tasks: "Refactor the authentication system
 
 Configure multiple agents, each with its own role and tools. The main session delegates to them and synthesizes results.
 
+Octomind offers three ways to delegate, in increasing flexibility:
+
+1. **Static `[[agents]]`** — pre-defined local sub-agents exposed as `agent_<name>` tools. Best when you have stable, project-specific specialists. (Steps 1–3 below.)
+2. **The `tap` tool** — run a community-maintained specialist role from a tap registry with no config edits. Best when someone already built the role you need. (See [Tap Roles](#tap-roles-no-config-needed).)
+3. **The dynamic `agent` tool** — let the orchestrator create sub-agents on the fly during a session. Best for ad-hoc, one-off tasks. (See [Dynamic Agents](#dynamic-agents).)
+
 ### Step 1: Define Agent Roles
+
+A role's `system`, `welcome`, `temperature`, `top_p`, and `top_k` are all **required** — there are no implicit defaults, so omitting any of them makes the config fail to load. Set `welcome = ""` for sub-agent roles you never start interactively.
 
 ```toml
 # Roles for each agent (in config.toml)
@@ -18,6 +26,9 @@ Configure multiple agents, each with its own role and tools. The main session de
 [[roles]]
 name = "context_gatherer"
 temperature = 0.2
+top_p = 0.7
+top_k = 20
+welcome = ""
 system = """
 You are a codebase researcher. Your job is to:
 1. Find all relevant files for the given task
@@ -36,6 +47,9 @@ allowed_tools = ["filesystem:view", "filesystem:ast_grep"]
 [[roles]]
 name = "code_reviewer"
 temperature = 0.1
+top_p = 0.7
+top_k = 20
+welcome = ""
 system = """
 You are a senior code reviewer. Analyze code for:
 - Security vulnerabilities
@@ -51,6 +65,8 @@ Be specific: file, line, issue, suggestion.
 server_refs = ["filesystem"]
 allowed_tools = ["filesystem:view"]
 ```
+
+> **Note:** `filesystem` is **not** a built-in server. The default config declares only `core`, `runtime`, and `agent` as MCP servers — the `filesystem` tools (`view`, `text_editor`, `ast_grep`, `shell`, …) are supplied by the default tap (`muvon/tap`). With MCP disabled or that tap not installed, `server_refs = ["filesystem"]` resolves to nothing. See [Tap System](../integration/04-tap-system.md) and [MCP Tools](../usage/07-mcp-tools.md) for how filesystem tools become available.
 
 ### Step 2: Configure Agents
 
@@ -68,15 +84,23 @@ command = "octomind acp code_reviewer"
 workdir = "."
 ```
 
+Each `[[agents]]` entry is exposed to the main session as a tool named `agent_<name>`. The positional argument in `command` (`octomind acp context_gatherer`) **is the role name** — the agent inherits its model, system prompt, temperature, and tools from the matching `[[roles]]` entry. Keep the agent name and the role name identical so the wiring is obvious.
+
+Config agents run as ACP subprocesses with their stderr suppressed, so a child-side crash or misconfiguration surfaces only as an error or empty result returned from the `agent_<name>` call — not as console output.
+
 ### Step 3: Use in Session
 
-Start a session and delegate:
+Start the orchestrating session with your default role and delegate:
 
 ```bash
-octomind run developer
+octomind run            # uses the configured default tag (assistant:concierge)
+# or name an orchestrator role explicitly:
+octomind run assistant
 ```
 
-The main AI can now use these agents as tools:
+> `developer` is not a built-in role — it only resolves through the default tap's `developer` category. Use `assistant` (the shipped default) or any orchestrator role you defined, as long as it has access to the `agent` tools.
+
+The main AI can now use these agents as tools (illustrative transcript):
 
 ```
 > Refactor the authentication module to support OAuth2
@@ -99,7 +123,7 @@ AI thinking: "This is complex. Let me gather context first."
 
 ### Parallel Execution with Async Agents
 
-For large tasks, run agents in parallel:
+For large tasks, run agents in parallel (illustrative transcript):
 
 ```
 > Analyze the entire codebase for the quarterly security audit
@@ -125,13 +149,21 @@ If a tap registry already provides a specialist role for the sub-task, use the `
 {"action": "run", "role": "security:owasp", "prompt": "Audit src/auth/ for OWASP issues", "background": true}
 ```
 
-Tap roles share their own system prompt + model + tool kit. `background: true` returns the run id immediately and the reply lands as a user message in the next turn. Resume with `{"action": "run", "session": "<id>", "prompt": "follow-up question"}`. See [Tap System](../integration/04-tap-system.md) and [MCP Tools — `tap`](../usage/07-mcp-tools.md#tap----run-specialist-roles-from-taps).
+Tap roles share their own system prompt + model + tool kit. `background: true` returns the run id immediately and, when the run finishes, the reply lands as a user message in the next turn labeled `[Tap-run '<id>' (<role>) completed]` (or `… failed]` on error) — distinct from the `[Async agent '...' completed]` label used by `agent_*` jobs. Resume with `{"action": "run", "session": "<id>", "prompt": "follow-up question"}`.
+
+A few runtime constraints worth knowing:
+
+- `discover` (and `capability`) require the local embedding model to be initialized — if it failed to load or is not ready yet, the action returns an error instead of results.
+- `discover` returns at most the **top 5** matching roles, and only those with a cosine score above `0.2`. A vague intent may return nothing.
+- Resuming a tap-run that is still executing returns a **busy** error. Wait for it to finish, or stop it first with `{"action": "stop", "session": "<id>"}`.
+
+See [Tap System](../integration/04-tap-system.md) and [MCP Tools — `tap`](../usage/07-mcp-tools.md#tap----run-specialist-roles-from-taps).
 
 Use `[[agents]]` (this page) when the role doesn't exist in any tap or you need a custom local-only agent. Use `tap` when a community-maintained role already covers the task.
 
 ### Dynamic Agents
 
-Create agents on the fly during a session using the `agent` runtime tool (formerly under `core`):
+Create agents on the fly during a session using the `agent` tool from the `runtime` server (the `core` server hosts only `plan` and `tap`):
 
 ```json
 // AI creates a specialized agent at runtime
@@ -146,7 +178,11 @@ Create agents on the fly during a session using the `agent` runtime tool (former
 // Now agent_test_writer is available as a tool
 ```
 
+If you omit `server_refs` but list `allowed_tools`, the servers are inferred automatically from the tool prefixes (e.g. `filesystem:view` implies `server_refs = ["filesystem"]`).
+
 ## Example: Full Development Pipeline
+
+The following is an illustrative walkthrough of how the orchestrator chains the agents — not literal commands to type:
 
 ```
 User: "Add rate limiting to the API endpoints"
@@ -172,11 +208,14 @@ Main AI:
 
 ## Agent Configuration Tips
 
+The snippets below show only the field being changed — a real `[[roles]]` entry must still include the required `system`, `welcome`, `temperature`, `top_p`, and `top_k` fields shown in [Step 1](#step-1-define-agent-roles).
+
 **Cheap models for simple agents:**
 ```toml
 [[roles]]
 name = "context_gatherer"
 model = "openrouter:google/gemini-2.5-flash-preview"  # Fast, cheap, large context
+# ... plus the required system / welcome / temperature / top_p / top_k fields
 ```
 
 **Powerful models for complex analysis:**
@@ -184,6 +223,7 @@ model = "openrouter:google/gemini-2.5-flash-preview"  # Fast, cheap, large conte
 [[roles]]
 name = "code_reviewer"
 model = "anthropic:claude-sonnet-4"  # Best reasoning
+# ... plus the required system / welcome / temperature / top_p / top_k fields
 ```
 
 **Tool restrictions for safety:**
@@ -205,6 +245,6 @@ allowed_tools = ["core:*", "filesystem:*"]
 - Agents have their own role, tools, and model -- fully independent
 - `async: true` runs agents in parallel (results arrive via inbox)
 - Dynamic agents can be created at runtime for ad-hoc tasks
-- Max concurrent async jobs = CPU cores (minimum 4)
+- Max concurrent async jobs = number of CPU cores (defaults to 4 only if the core count cannot be detected)
 - The main session orchestrates; agents do focused work
 - Use cheap models for simple agents, powerful models where reasoning matters

--- a/doc/use-cases/06-dynamic-mcp-servers.md
+++ b/doc/use-cases/06-dynamic-mcp-servers.md
@@ -8,7 +8,9 @@ You don't always know upfront which tools a session will need. A developer asks 
 
 ## Solution
 
-The built-in `mcp` tool lets the AI add, enable, and remove MCP servers during a live session.
+The built-in `mcp` tool lets the AI add, enable, disable, remove, and persist MCP servers during a live session. This tool lives in the `runtime` builtin MCP server, so it is only available when the AI's role grants access to `runtime` (the default `assistant` role does — `server_refs` includes `runtime` with `runtime:*` allowed). A custom role that drops `runtime` cannot self-configure.
+
+> The conversational snippets below are simplified illustrations of an agent's reasoning and the resulting tool calls. Real tool result strings differ in wording (for example, `enable` returns `Server '<name>' enabled with N tools: ...`).
 
 ### How It Works
 
@@ -20,7 +22,7 @@ User: "Check the open GitHub issues for this repo"
 AI (thinking): "I don't have GitHub tools. Let me add the GitHub MCP server."
 
 AI calls: mcp(action="add", name="github", server_type="http",
-          url="https://api.github.com/mcp", timeout_seconds=30)
+          url="https://api.github.com/mcp")
 
 AI calls: mcp(action="enable", name="github")
 
@@ -29,6 +31,8 @@ AI: "Connected to GitHub MCP server. Found 12 open issues..."
 
 No config changes. No restart. The AI recognized a gap and filled it.
 
+> The `url` above is an illustrative endpoint, not a real GitHub API. Substitute the actual MCP server URL you want to connect to.
+
 ### Example: Full Dynamic Tool Discovery
 
 ```
@@ -36,27 +40,37 @@ User: "I need to analyze our database schema and cross-reference with GitHub iss
 
 AI:
   1. mcp(action="list")
-     -> Shows: core (builtin), filesystem (stdio) -- no GitHub, no DB tools
+     -> Configured servers:
+
+          core [builtin] ✓ active → (all tools)
+          runtime [builtin] ✓ active → (all tools)
+          agent [builtin] ✓ active → (all tools)
+
+        (no GitHub, no DB tools yet)
 
   2. mcp(action="add", name="github", server_type="http",
-         url="https://api.github.com/mcp", timeout_seconds=30)
+         url="https://api.github.com/mcp")
      -> "Server 'github' registered"
 
   3. mcp(action="enable", name="github")
-     -> "Server 'github' enabled. Available tools: github_list_issues, github_search_code, ..."
+     -> "Server 'github' enabled with 12 tools:
+         github_list_issues, github_search_code, ..."
 
   4. mcp(action="add", name="db", server_type="stdio",
          command="mcp-postgres", args=["--connection", "postgresql://..."])
      -> "Server 'db' registered"
 
   5. mcp(action="enable", name="db")
-     -> "Server 'db' enabled. Available tools: query, list_tables, describe_table, ..."
+     -> "Server 'db' enabled with 3 tools:
+         query, list_tables, describe_table"
 
   6. Now uses both servers to cross-reference issues with schema
 
   7. When done:
      mcp(action="disable", name="db")  # Clean up sensitive connection
 ```
+
+The `list` action groups servers under a `Configured servers:` header (those declared in config — by default `core`, `runtime`, and `agent`) and a separate `Dynamic servers:` header for anything added at runtime. Each line shows `name [type] status → tools`, a 💾 marker if the server is persisted, and `(all tools)` when no tool filter is set. The default configuration declares only the three builtin servers; a `filesystem` server appears only if a tap or your own config adds one.
 
 ### Persisting Dynamic Servers
 
@@ -65,8 +79,12 @@ If a dynamically added server proves useful, persist it to config:
 ```
 AI calls: mcp(action="persist", name="github")
 -> Saved to ~/.local/share/octomind/config/mcp-github.toml
--> Auto-binds to current role for future sessions
 ```
+
+Whether the persisted server auto-loads next session depends on its state at persist time:
+
+- **Enabled when persisted** -> `auto_bind` is set to the current role, so it loads automatically in future sessions for that role.
+- **Disabled when persisted** -> the config is still written, but `auto_bind` is cleared (the tool reports "Auto-bind cleared (server disabled)"), so it won't auto-load until you enable and persist it again.
 
 Remove persisted config:
 ```
@@ -83,8 +101,11 @@ AI calls: mcp(action="add", name="octocode", server_type="stdio",
           command="octocode", args=["mcp", "--path=."], timeout_seconds=240)
 
 AI calls: mcp(action="enable", name="octocode")
--> "Server 'octocode' enabled. Available tools: semantic_search, view_signatures, graphrag"
+-> "Server 'octocode' enabled with 3 tools:
+    semantic_search, view_signatures, graphrag"
 ```
+
+`timeout_seconds` is optional and defaults to **60**. Raise it (as above) only for servers that take a long time to respond.
 
 ### Tool Filtering
 
@@ -99,6 +120,12 @@ AI calls: mcp(action="add", name="github", server_type="http",
 Or use wildcards:
 ```
 tools=["github_*"]
+```
+
+The `enable` action also accepts a `tools` filter, applied when the server actually connects. It overrides whatever filter was registered at `add` time, so you can register a server broadly and narrow its exposed tools later:
+
+```
+AI calls: mcp(action="enable", name="github", tools=["github_list_issues"])
 ```
 
 ### Dynamic Agents Too
@@ -116,6 +143,11 @@ AI calls: agent(action="enable", name="db_expert")
 
 AI calls: agent_db_expert(task="Analyze the schema for N+1 query risks")
 ```
+
+Once enabled, the agent becomes callable as a tool named `agent_<name>` (here `agent_db_expert`). A few details worth knowing:
+
+- **`server_refs` is validated at add time.** Any name you list explicitly must already exist as a configured server or a dynamic server you have added; an unknown reference fails the call with `Server '<name>' not found. Available servers: ...`. (In the example, `filesystem` must be available — for instance provided by a tap — and `db` must have been added first.)
+- **`server_refs` can be inferred.** If you omit `server_refs` but provide `allowed_tools`, Octomind auto-populates `server_refs` from the server prefixes in the tool names (so `allowed_tools=["db:*"]` implies `server_refs=["db"]`).
 
 ## Practical Scenario: Self-Assembling Toolkit
 
@@ -140,21 +172,30 @@ AI:
 | Action | Description |
 |--------|-------------|
 | `list` | Show all servers with status |
-| `add` | Register new server (doesn't connect) |
-| `enable` | Connect and activate tools |
+| `add` | Register new server (doesn't connect; `timeout_seconds` defaults to 60) |
+| `enable` | Connect and activate tools (optional `tools` filter applied at connect time) |
 | `disable` | Deactivate (keep config) |
-| `remove` | Unregister entirely |
-| `persist` | Save to config for future sessions |
+| `remove` | Unregister a dynamically added server (does not remove config-defined servers) |
+| `persist` | Save to config dir; auto-binds to the current role only if enabled |
 | `unpersist` | Remove from saved config |
 
-Session command equivalent: `/mcp list`, `/mcp add ...`, etc.
+### AI tool vs human command — two separate surfaces
+
+It is important not to confuse two things that look similar:
+
+- **The `mcp` tool (AI-driven).** This is what the AI calls to *mutate* its tool ecosystem: `add`, `enable`, `disable`, `remove`, `persist`, `unpersist`, and `list`. Everything in this document is about this tool.
+- **The `/mcp` interactive command (human-driven, read-only).** When *you* type `/mcp` in a session, it only inspects state. Its subcommands are `info` (default), `list`, `full`, `health`, `dump`, and `validate`. There is no `/mcp add`, `/mcp enable`, `/mcp remove`, or `/mcp persist` — typing those returns an unknown-subcommand error. Runtime server mutation is exclusively the AI's job via the `mcp` tool.
 
 ## Key Points
 
+- The `mcp` tool lives in the `runtime` builtin server; the AI's role must grant `runtime` access (the default `assistant` role does) for self-configuration to be possible
 - The AI can add/remove MCP servers without human intervention
 - Supports both HTTP (remote) and stdio (local process) servers
-- `persist` saves a dynamic server to config for future sessions
-- Tool filtering prevents exposing unnecessary capabilities
-- Dynamic agents follow the same add/enable/disable/remove pattern
+- `timeout_seconds` is optional and defaults to 60
+- `persist` saves a dynamic server to the config dir; it auto-binds to the current role only when the server is enabled at persist time (disabled servers persist with `auto_bind` cleared)
+- `remove` only unregisters dynamic (runtime-added) servers — it cannot delete servers defined in config
+- Tool filtering prevents exposing unnecessary capabilities, and a filter can be applied at `add` time or refined at `enable` time
+- Dynamic agents follow the same add/enable/disable/remove pattern, are callable as `agent_<name>`, and validate their `server_refs` at add time
+- The `mcp` tool (AI-driven, mutating) and the `/mcp` command (human-driven, read-only) are distinct surfaces with non-overlapping actions
 - This is unique to Octomind -- most AI tools require static tool configuration
 - The AI can assess a project and self-configure its toolkit

--- a/doc/use-cases/07-scheduled-tasks.md
+++ b/doc/use-cases/07-scheduled-tasks.md
@@ -8,7 +8,24 @@ During long development sessions, you need the AI to do things at specific times
 
 ## Solution
 
-The `schedule` MCP tool lets the AI (or you) schedule messages that fire at specific times and get processed automatically.
+The `schedule` MCP tool lets the AI (or you) schedule messages that fire at specific times -- or the next time the session is idle -- and get processed automatically.
+
+Only `message` is required when adding an entry. Both `when` and `every` are optional: if you omit both, the entry defaults to `when="idle"` (a one-shot that fires the next time the session is idle).
+
+### Basic: Fire on Next Idle (default)
+
+The simplest schedule has no time at all -- it fires as soon as the session goes idle (no running taps, no background jobs):
+
+```
+> When you're done with the current work, summarize everything we did today
+
+AI calls: schedule(command="add",
+          message="Summarize all changes made in this session today",
+          description="Daily summary")
+
+# 'when'/'every' omitted -> defaults to when="idle"
+# Fires once the session becomes idle, then is removed
+```
 
 ### Basic: Timed Reminders
 
@@ -44,6 +61,29 @@ AI calls: schedule(command="add", when="2026-03-30 10:00",
           message="Time to deploy the release. Run the deployment checklist.",
           description="Release deployment")
 ```
+
+### Idle Scheduling
+
+Instead of a clock time, you can fire a message the next time the session becomes **idle** -- meaning there are no running tap-runs and no running background agent jobs. This is useful for "do this once the current work settles" tasks.
+
+```
+> Once you're idle, run the linter and report any issues
+
+AI calls: schedule(command="add", when="idle",
+          message="Run the linter and report any issues found",
+          description="Lint on idle")
+```
+
+Use `every="idle"` to fire on **every** idle, not just the first one:
+
+```
+AI calls: schedule(command="add", every="idle",
+          message="Remind me to commit my changes",
+          description="Commit nudge")
+# Re-fires each time the session returns to idle, until removed
+```
+
+Idle scheduling cannot be combined with a clock time: passing a time-based `when` (e.g. `"in 5m"`) together with `every="idle"`, or a time-based `every` together with `when="idle"`, is rejected with an error. Use the idle keyword on both fields, or omit the one you do not need.
 
 ### Build-Check-Fix Loop
 
@@ -93,6 +133,11 @@ AI calls: schedule(command="remove", id="abc12345")
 > Push the build check back to 20 minutes
 
 AI calls: schedule(command="edit", id="def67890", when="in 20m")
+
+> Stop the daily standup reminder from repeating, but keep it for tomorrow
+
+AI calls: schedule(command="edit", id="ghi13579", every="none")
+# every="none" (or every="off") clears the interval, turning a recurring entry into a one-shot
 ```
 
 ### Direct Control: `/schedule` Slash Command
@@ -101,9 +146,12 @@ The same operations are available as a session command, so you can list, add, ed
 
 ```
 /schedule                                                 # list pending
+/schedule add message="summarize what we just did"        # default: when="idle"
 /schedule add when="in 5m" message="check the build"
-/schedule add when="9am" message="standup" every="1d" description="daily"
+/schedule add when="9am" message="standup" every="24h" description="daily"
+/schedule add every="idle" message="remind me to commit"  # fires every idle
 /schedule edit abc12345 when="in 1h"
+/schedule edit abc12345 every="none"                      # clear a repeat interval
 /schedule remove abc12345
 ```
 
@@ -118,37 +166,46 @@ Combine with daemon mode for long-running automated workflows:
 octomind run --name project-monitor --daemon --format jsonl
 ```
 
-Then inject a setup message:
+Then send it a setup message over the session socket with `octomind send`:
 ```bash
 echo "Set up monitoring: check git status every 30 minutes, summarize changes, and alert if there are uncommitted changes older than 2 hours" | octomind send --name project-monitor
 ```
 
-The AI schedules recurring checks within the session, each check can schedule the next.
+The AI schedules recurring checks within the session, each check can schedule the next. A `--daemon` session stays alive regardless of the schedule queue, so it keeps firing entries indefinitely. See [Daemon and Hooks](../integration/03-daemon-and-hooks.md) for how `octomind send` reaches a running session.
 
 ## Supported Time Formats
 
 | Format | Example | Description |
 |--------|---------|-------------|
+| Idle | `idle` | Fires the next time the session is idle (no running taps/jobs) |
 | Immediate | `now` | Fires on the next scheduler tick |
 | Relative | `in 5m` | Minutes from now |
 | Relative | `in 2h` | Hours from now |
 | Relative | `in 1h30m` | Combined hours and minutes |
 | Relative | `in 90s` | Seconds from now |
 | Relative | `in 2h 30m 10s` | Full combination (spaces optional) |
+| Time today | `9am` | Bare hour, 12-hour form (minutes/seconds default to 0) |
 | Time today | `15:30` | 24-hour format (tomorrow if past) |
 | Time today | `3:30pm` | 12-hour format (tomorrow if past) |
 | Absolute | `2026-03-30 15:30` | Exact date and time |
 
+Relative durations accept only **h** (hours), **m** (minutes), and **s** (seconds), in any combination (`90s`, `10m`, `1h30m`, `2h 30m 10s`). There is no day or week unit -- `1d` is invalid.
+
+The `every` field for repeating entries uses the same `h`/`m`/`s` duration grammar (e.g. `every="10m"`, `every="1h30m"`); it fires first at `when`, then repeats at that interval. `every="idle"` repeats on each idle instead.
+
 ## Limitations
 
-- **Session-scoped**: Schedules belong to the session that created them. When resuming a session, scheduled entries are restored from the session event log.
+- **Session-scoped**: Schedules belong to the session that created them. Each change is written as a `SCHEDULE_SNAPSHOT` entry in the session's compressed `.jsonl.zst` log, and the snapshot is re-seeded automatically when the session is resumed.
+- **Process lifetime**: In a non-daemon, non-interactive run (`--format` without `--daemon`), the process exits once every scheduled entry has fired and no background jobs remain. Interactive sessions and `--daemon` runs stay alive independently of the schedule queue, so they keep waiting for future and idle entries.
+- **Idle firing covers more than `run`**: idle entries also fire under the WebSocket server (`octomind server`) and the ACP agent loop, not just interactive and daemon `run` sessions.
 
 ## Key Points
 
 - `schedule` is a built-in MCP tool -- the AI uses it naturally in conversation
 - The same operations are exposed as the `/schedule` slash command for direct control
+- Only `message` is required for `add`; omit both `when` and `every` to default to `when="idle"`
 - Messages fire automatically and the AI processes them like any user message
-- One-shot entries fire once; entries with `every` re-schedule themselves automatically until removed
+- One-shot entries fire once; entries with `every` re-schedule themselves automatically until removed (clear the interval with `edit ... every="none"`)
 - Combine with daemon mode for persistent monitoring
 - Use `schedule(command="list")` or `/schedule` to see all pending entries
-- The session stays alive until all scheduled messages have fired
+- A non-daemon non-interactive run exits once all entries have fired and no jobs remain; interactive and `--daemon` sessions stay alive regardless

--- a/doc/use-cases/08-long-running-development.md
+++ b/doc/use-cases/08-long-running-development.md
@@ -60,7 +60,10 @@ Don't remember the exact session name? Use `--resume-recent`:
 octomind run --resume-recent
 ```
 
-Finds the most recent session for the current project directory automatically.
+This matches saved sessions whose name contains the current working directory's
+basename and resumes the most recently modified one. Run it from the same project
+directory you started in -- a session begun in a different directory (different
+basename) will not be matched, even if it is newer.
 
 Or list all sessions:
 
@@ -69,7 +72,8 @@ octomind run
 ```
 ```
 /list
-# Shows all saved sessions with dates and names
+# Lists saved sessions with their metadata (date, name, message/token counts).
+# Paginated 15 per page -- use "/list 2" for the next page.
 ```
 
 ### Managing Context Over Long Sessions
@@ -89,10 +93,34 @@ As sessions grow, context management becomes important:
 
 # View what's in context
 /context
-/context large    # Show only large messages
+/context large    # Show only messages larger than 1000 characters
 ```
 
-The automatic compression system also helps -- it kicks in at configured token thresholds and preserves critical knowledge (decisions, constraints, preferences) across compressions.
+`/done` and automatic compression are the **same engine** with different triggers --
+`/done` forces it now, automatic compression waits for a threshold. `/run reduce` is a
+separate, configurable ACP layer command and is independent of that engine.
+
+**How automatic compression decides to fire.** Each `[[compression.pressure_levels]]`
+entry has an *absolute* `threshold` (a token count) and a `target_ratio`. When the
+full-context token count exceeds any configured threshold, compression triggers using
+the highest matched ratio. Critical knowledge (decisions, constraints, preferences) is
+extracted and re-injected so it survives every compression.
+
+Above all sits the root-level `max_session_tokens_threshold` (default `200000`). This
+is a hard ceiling: once the context reaches it, compression is forced unconditionally --
+bypassing the cooldown and cost guards that govern ordinary pressure-level compressions.
+It is the single most important knob to tune for genuinely long sessions; set it `0` to
+disable the session-token limit entirely. See
+[Context Compression](../usage/08-compression.md) for the full mechanics.
+
+**Why a second `/done` may report nothing to compress.** `/done` *forces* compression,
+which bypasses the automatic cooldown and resets its counters — so the cooldown is not
+the cause. The forced path still needs something to compress: it always keeps at least
+the 3 most recent conversation messages (vs 5 for automatic compaction), so once the
+first `/done` has folded everything down to the session anchor, a near-unchanged context
+has no compressible range left and reports "nothing to compress." This is expected, not
+a bug. (The `10% × 2^n` exponential cooldown governs only *automatic* compaction — it
+raises the bar for the next automatic pass and resets on each new user message.)
 
 ### Multi-Branch Development
 
@@ -134,7 +162,22 @@ AI calls: agent_context_gatherer(task="Analyze test coverage for src/auth/. List
 > and today's coverage analysis.
 ```
 
+### Carrying Knowledge Across Separate Sessions
+
+Compression keeps a *single* session compact. The **learning system** is what carries
+knowledge between *separate* named sessions. When learning is enabled (`[learning]
+enabled = true`, on by default), `/done` and session exit fire a background lesson
+extraction: generalizable, project- and role-scoped lessons are saved and later injected
+into future sessions for the same project. So `auth-refactor` on Day 5 can benefit from a
+lesson learned during `auth-bugfix-csrf` on Day 2, even though they are different
+sessions. This is distinct from per-session compression, which only summarizes the
+current conversation. See [Adaptive Learning](../usage/13-learning.md) for details.
+
 ### Session Persistence Details
+
+Sessions are stored as append-only `.jsonl.zst` files (zstd-compressed JSON lines) in
+`~/.local/share/octomind/sessions/`. Resuming replays the log -- including `SUMMARY`,
+`KNOWLEDGE_ENTRY`, and `COMMAND` entries -- to rebuild the exact context.
 
 What's saved and restored:
 
@@ -146,6 +189,10 @@ What's saved and restored:
 | Compression knowledge | Critical decisions and constraints survive compression |
 | Model info | Which model was used |
 | Media attachments | Images and videos attached during session |
+
+Critical knowledge survives **both** compression and resume: it is replayed from the
+`KNOWLEDGE_ENTRY` log entries when the session is reloaded, so decisions and constraints
+are intact across sittings.
 
 What's NOT persisted:
 - Active schedules (in-memory only)
@@ -165,8 +212,15 @@ octomind run --name "investigate-memory-leak"
 **Use `/done` at natural checkpoints:**
 ```
 /done
+
+# Or steer the summary toward what matters next
+/done focus on the API layer and the migration plan
 ```
-This triggers task completion, summary, and cleanup -- creating a clean checkpoint before the next phase.
+`/done` force-compresses the current context (bypassing automatic thresholds and the
+cooldown) and, when learning is enabled, extracts lessons in the background -- producing
+a compact checkpoint before the next phase. A bare `/done` compresses with default
+behavior; `/done <instructions>` passes guidance for the compression summary so you can
+emphasize what the next phase will need.
 
 **Set spending limits for safety:**
 ```toml
@@ -188,6 +242,19 @@ target_ratio = 2.0
 
 This keeps context manageable while preserving critical decisions.
 
+**Keep the prompt cache warm across idle gaps (Anthropic only):**
+```toml
+cache_keepalive_enabled = true          # default: false
+cache_keepalive_max_idle_seconds = 1800 # stop pinging after 30 min idle (cap: 86400)
+```
+When you step away mid-session, the prompt cache normally expires before you return, so
+the next turn pays full price. With keepalive enabled, Octomind sends minimal idle pings
+to keep the cache warm, then stops after `cache_keepalive_max_idle_seconds` so an
+abandoned session does not bill forever. The ping interval is provider-driven and this
+applies only to providers whose API supports refresh-on-read -- today that is Anthropic.
+Ping costs are folded into the session cost. See
+[Providers & Caching](../usage/04-providers.md) for the provider-facing details.
+
 ## Key Points
 
 - `--name` creates or resumes a named session
@@ -195,6 +262,13 @@ This keeps context manageable while preserving critical decisions.
 - `--resume-recent` finds the most recent session for the current project
 - Full conversation history is persisted in `~/.local/share/octomind/sessions/`
 - The AI picks up exactly where you left off -- all context, decisions, and findings intact
-- Use `/done` or automatic compression to manage growing context
+- Use `/done` or automatic compression to manage growing context (same engine, different triggers)
 - Combine with agents for parallel subtask delegation
-- Session persistence works across CLI, daemon, and WebSocket modes
+- Session persistence works across CLI, daemon, and WebSocket/ACP modes -- a session started in one mode is resumable by the same name in another
+
+## See Also
+
+- [Sessions](../usage/05-sessions.md) -- full session lifecycle, naming, and resume
+- [Context Compression](../usage/08-compression.md) -- pressure levels, ratios, and the decision model
+- [Adaptive Learning](../usage/13-learning.md) -- how knowledge is carried across separate sessions
+- [Providers & Caching](../usage/04-providers.md) -- prompt caching and cache keepalive

--- a/doc/use-cases/09-custom-hooks.md
+++ b/doc/use-cases/09-custom-hooks.md
@@ -2,6 +2,8 @@
 
 Hooks are HTTP listeners backed by scripts you write in any language. You have full control: parse any payload, filter events, transform data, and inject precisely crafted messages into a running AI agent session.
 
+> **`[[hooks]]` vs `[[hook]]` -- two different systems.** This doc covers **HTTP webhook hooks** (`[[hooks]]`, plural, in the main config): an external POST request runs your script, and on **exit 0 with non-empty stdout** the output is injected into the session. That is unrelated to the guardrail `[[hook]]` (singular, in `.agents/guardrails.toml`), which runs after a tool result and has the **inverted** rule -- a **non-zero exit** injects its stdout. If you want post-tool-result policy hooks, see [Guardrails](../usage/18-guardrails.md). This page is only about the webhook listeners.
+
 ## The Problem
 
 Every team has unique infrastructure -- internal APIs, custom CI systems, proprietary monitoring, Slack bots, Jira workflows. Pre-built integrations never fit. You need to wire arbitrary external events into an AI agent that understands your specific context.
@@ -13,7 +15,7 @@ A hook is: HTTP endpoint + your script + AI session. That's it. The script is th
 ### How Hooks Work
 
 ```
-External System (any HTTP POST)
+External System (HTTP POST only)
     |
     v
 Hook HTTP Listener (bind address:port)
@@ -24,13 +26,27 @@ Hook HTTP Listener (bind address:port)
     v
 Your Script (any language, any logic)
     |
-    | exit 0 + stdout → inject message into AI session
-    | exit non-zero → ignore (stderr logged)
+    | exit 0 + non-empty stdout → inject message into AI session  (HTTP 200 "ok")
+    | exit 0 + empty stdout      → skipped                        (HTTP 204)
+    | exit non-zero              → not injected; stderr logged at error level (HTTP 500)
     v
 AI Agent Session (processes message with full tool access)
 ```
 
 You control everything between the HTTP request and what the AI sees.
+
+**The listener accepts POST only.** A GET, PUT, or any other method returns `405 Method Not Allowed` and your script is never run. There is no response body you can shape -- the hook is one-way (POST in, status code out), so it cannot answer challenge/verification requests (e.g. Slack's `url_verification`). Handle those at a proxy in front of Octomind.
+
+**HTTP status codes returned to the caller:**
+
+| Situation | Status | Injected? |
+|---|---|---|
+| Non-POST method | `405 Method Not Allowed` | no -- script not run |
+| Body could not be read | `400 Bad Request` | no |
+| Script exit 0, non-empty stdout | `200 OK` (body `ok`) | yes |
+| Script exit 0, empty/whitespace-only stdout | `204 No Content` | no -- skipped |
+| Script non-zero exit / failed to spawn / IO error | `500 Internal Server Error` | no -- stderr logged at error level |
+| Script ran longer than `timeout` | `504 Gateway Timeout` | no |
 
 ### Configuration
 
@@ -42,10 +58,36 @@ script = "/opt/hooks/my-hook.py"
 timeout = 30  # seconds (1-3600)
 ```
 
-Activate when starting the agent:
+Two things are validated at session start, before any listener binds:
+
+- **`bind` must be unique** across all `[[hooks]]`. Reusing the same address in two hooks fails with a `duplicate bind address` error.
+- **`script` must be an existing, regular, executable file.** On Unix the execute bit is required -- run `chmod +x /opt/hooks/my-hook.py`. A missing, non-file, or non-executable script aborts startup.
+
+Activate the hook when starting the agent. `--hook` is repeatable and is accepted by both `octomind run` and `octomind acp`:
 ```bash
 octomind run --name my-agent --daemon --format jsonl --hook my-hook
 ```
+
+### Daemon mode is required for hook-driven agents
+
+Hook listeners start for **any** session (interactive or daemon) and stop when the session ends. The catch: a normal non-interactive run drains its inbox and then exits as soon as there is nothing left to wait for. The only way to keep the session alive between webhook requests is `--daemon`, which holds the session open so injected messages keep arriving and being processed. Without `--daemon` the run handles its first turn and exits, dropping the listeners -- any webhook that arrives afterward is silently lost. **Treat `--daemon` as mandatory for an always-on, hook-driven agent.**
+
+One subtlety when running detached (systemd, `nohup`, Docker without a TTY): with a controlling terminal, a daemon may start with empty input and idle waiting for hooks. With **no** TTY and no piped stdin, the run instead fails immediately with `No input provided via stdin`. So pipe an initial message in:
+
+```bash
+echo 'Standby for webhook events' | \
+  octomind run --name my-agent --daemon --format jsonl --hook my-hook
+```
+
+### Recognizing hook turns in the JSONL stream
+
+In `--format jsonl` mode, every hook injection emits one line **before** the AI turn it triggers:
+
+```json
+{"type":"injected","source_kind":"webhook","source_label":"webhook my-hook","content":"...","session_id":"my-agent"}
+```
+
+Downstream consumers can match `"type":"injected"` with `"source_kind":"webhook"` to tell hook-driven turns apart from user turns.
 
 ## Examples in Different Languages
 
@@ -96,9 +138,10 @@ else:
 #!/usr/bin/env node
 const payload = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
 
-// Slack sends URL verification challenges
+// Slack sends URL verification challenges expecting a challenge echo in the
+// response body. The hook is one-way (POST in, status code out) and POST-only,
+// so it can't answer these — terminate Slack's verification at a proxy instead.
 if (payload.type === 'url_verification') {
-  // Can't respond directly (hook is one-way), handle elsewhere
   process.exit(1);
 }
 
@@ -173,6 +216,8 @@ MSG
 ```
 
 ### Go: High-Performance Webhook Processor
+
+The script just needs an executable interpreter line and the execute bit (`chmod +x`); any language with a shebang works. The `go run` form below relies on `env -S` (GNU coreutils / recent BSD); on systems without `-S` support, compile the program and point `script` at the binary instead.
 
 ```go
 #!/usr/bin/env -S go run
@@ -279,7 +324,17 @@ octomind run --name ops-agent --daemon --format jsonl \
   --hook slack
 ```
 
-One AI agent, four event sources, each with its own script in its own language. The AI maintains context across all events -- it knows about the GitHub push when the monitoring alert fires 5 minutes later.
+One AI agent, four event sources, each with its own script in its own language. Each hook binds a distinct port (the `bind` addresses must be unique). The AI maintains context across all events -- it knows about the GitHub push when the monitoring alert fires 5 minutes later.
+
+### Testing your hook
+
+Send a POST to the bind address and watch the session's JSONL stream for the injected turn:
+
+```bash
+curl -X POST http://localhost:9001/ -d '{"ref":"refs/heads/main"}'
+```
+
+A `200` with body `ok` means the script injected a message; a `204` means it exited 0 with empty stdout (filtered out); a `500` means the script exited non-zero (check the logs for its stderr). In the agent's `--format jsonl` output you should see a matching `{"type":"injected","source_kind":"webhook",...}` line.
 
 ## Script Design Patterns
 
@@ -330,10 +385,12 @@ Max timeout is 3600 seconds (1 hour).
 
 ## Key Points
 
-- Scripts can be written in **any language** -- Bash, Python, Node, Ruby, Go, Rust, anything executable
+- Scripts can be written in **any language** -- Bash, Python, Node, Ruby, Go, Rust, anything executable (`chmod +x` required)
 - You have **full control**: parse payloads, filter events, validate signatures, transform data
-- **stdout** becomes the AI's input; **exit code** controls whether to inject or ignore
+- **POST only**: other methods get `405` and the script never runs; the hook is one-way (status code out, no shapeable response body)
+- **stdout + exit code decide injection**: exit 0 with non-empty stdout injects (`200`); exit 0 with empty stdout is skipped (`204`); non-zero exit is not injected and its stderr is logged at error level (`500`)
 - **Rich environment**: HTTP method, path, headers, session name all available as env vars
-- **Multiple hooks** on different ports feed into one agent session
+- **Multiple hooks** on distinct (unique) bind addresses feed into one agent session
 - The AI maintains **cross-event context** -- it connects the dots between GitHub pushes, Jira tickets, and monitoring alerts
-- Combine with **daemon mode** for persistent, always-on agents
+- **`--daemon` is required** for persistent, always-on agents -- without it the session exits after its first turn and stops listening
+- Not the same as the guardrail `[[hook]]` (singular) in [Guardrails](../usage/18-guardrails.md), which has the inverted exit rule (non-zero exit injects)


### PR DESCRIPTION
- Update README with usage, features, and filesystem tools
- Expand developer guides for builds, cross-compilation, and style
- Refine architecture docs for tool routing and session context
- Rewrite MCP server development guide and API signatures
- Detail WebSocket server protocol, session lifecycles, and frames
- Formalize ACP protocol specs, meta channels, and prompt mapping
- Document daemon mode, webhooks, and IPC endpoints
- Clarify Tap system architecture, resolution pipelines, and manifests
- Expand CLI reference for subcommands, flags, and configurations
- Update session command reference for roles, effort, and skills