### PR TITLE
ci(github): migrate rust and release jobs to shared workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,77 +17,17 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.95.0
-      with:
-        components: rustfmt, clippy
-
-    - name: Setup protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Install ripgrep and ast-grep
-      uses: taiki-e/install-action@v2
-      with:
-        tool: ripgrep,ast-grep
-
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
-
-    - name: Run cargo check
-      run: cargo check --all-targets --all-features
-
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.95.0
-      with:
-        components: rustfmt
-
-    - name: Run cargo fmt
-      run: cargo fmt --all -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.95.0
-      with:
-        components: clippy
-
-    - name: Setup protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Install ripgrep and ast-grep
-      uses: taiki-e/install-action@v2
-      with:
-        tool: ripgrep,ast-grep
-
-
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
-
-    - name: Run cargo clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
+  rust:
+    name: Rust CI
+    uses: muvon/ci-workflow/.github/workflows/rust-ci.yml@master
+    with:
+      feature-flags: '--all-features'
+      setup-protoc: true
+      tools: 'ripgrep,ast-grep'
+      # Test job stays local below: needs ONNX static libs and HF model cache
+      test: false
+      doc: false
+      tarpaulin-args: '--engine llvm --verbose --workspace --timeout 120 --out xml'
 
   test:
     name: Test Suite
@@ -317,69 +257,6 @@ jobs:
             export RUSTFLAGS="-C link-arg=-lgcc"
             cargo build --target ${{ matrix.target }}
           '
-
-  security:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.95.0
-
-    - name: Setup protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Install ripgrep and ast-grep
-      uses: taiki-e/install-action@v2
-      with:
-        tool: ripgrep,ast-grep
-
-    - name: Install cargo-audit
-      run: cargo install cargo-audit --locked
-
-    - name: Run security audit
-      run: cargo audit
-
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.95.0
-
-    - name: Setup protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Install ripgrep and ast-grep
-      uses: taiki-e/install-action@v2
-      with:
-        tool: ripgrep,ast-grep
-
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
-
-    # After cache restore: rust-cache includes ~/.cargo/bin, so this is a
-    # no-op when the same tarpaulin version is already cached.
-    - name: Install cargo-tarpaulin
-      run: cargo install cargo-tarpaulin --locked
-
-    - name: Generate code coverage
-      run: cargo tarpaulin --engine llvm --verbose --workspace --timeout 120 --out xml
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./cobertura.xml
-        fail_ci_if_error: false
 
   brief:
     uses: muvon/ci-workflow/.github/workflows/brief.yml@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,119 +16,8 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  create-release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      release_id: ${{ steps.create_release.outputs.id }}
-      version: ${{ steps.get_version.outputs.VERSION }}
-      changelog: ${{ steps.changelog.outputs.CHANGELOG }}
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Fetch full history for changelog generation
-
-    - name: Get version from tag
-      id: get_version
-      run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          VERSION="${{ github.event.inputs.tag }}"
-        else
-          VERSION="${GITHUB_REF#refs/tags/}"
-        fi
-        echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-        echo "VERSION_NO_V=${VERSION#v}" >> $GITHUB_OUTPUT
-
-    - name: Validate semver format
-      run: |
-        VERSION="${{ steps.get_version.outputs.VERSION }}"
-        # POSIX-compatible regex check for semver
-        case "$VERSION" in
-          [0-9]*.[0-9]*.[0-9]*)
-            # Basic semver format matched
-            ;;
-          *)
-            echo "Error: Tag '$VERSION' is not a valid semver format"
-            echo "Expected format: X.Y.Z, X.Y.Z-prerelease, or X.Y.Z+build"
-            exit 1
-            ;;
-        esac
-
-    - name: Generate changelog
-      id: changelog
-      run: |
-        # Get the previous tag
-        PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-
-        if [ -z "$PREV_TAG" ]; then
-          CHANGELOG="Initial release"
-        else
-          # Generate changelog from commits since last tag
-          CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --no-merges | head -20)
-          if [ -z "$CHANGELOG" ]; then
-            CHANGELOG="- No changes since last release"
-          fi
-        fi
-
-        # Escape for GitHub output (POSIX compatible)
-        CHANGELOG=$(printf '%s\n' "$CHANGELOG" | sed 's/%/%25/g; s/\r/%0D/g' | awk '{printf "%s%0A", $0}' | sed 's/%0A$//')
-        echo "CHANGELOG=$CHANGELOG" >> $GITHUB_OUTPUT
-
-    - name: Check if release exists
-      id: check_release
-      run: |
-        VERSION="${{ steps.get_version.outputs.VERSION }}"
-        if gh release view "$VERSION" >/dev/null 2>&1; then
-          echo "exists=true" >> $GITHUB_OUTPUT
-        else
-          echo "exists=false" >> $GITHUB_OUTPUT
-        fi
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Create Release
-      id: create_release
-      if: steps.check_release.outputs.exists == 'false'
-      run: |
-        VERSION="${{ steps.get_version.outputs.version }}"
-        IS_PRERELEASE="false"
-
-        # Check if this is a prerelease (contains - or is 0.x.x)
-        case "$VERSION" in
-          *-*|0.*)
-            IS_PRERELEASE="true"
-            ;;
-        esac
-
-        # Create the release as draft
-        if [ "$IS_PRERELEASE" = "true" ]; then
-          gh release create "$VERSION" \
-            --title "Release $VERSION" \
-            --notes "${{ steps.changelog.outputs.CHANGELOG }}" \
-            --draft \
-            --prerelease
-        else
-          gh release create "$VERSION" \
-            --title "Release $VERSION" \
-            --notes "${{ steps.changelog.outputs.CHANGELOG }}" \
-            --draft
-        fi
-
-        # Get release info
-        RELEASE_INFO=$(gh release view "$VERSION" --json id,uploadUrl)
-        RELEASE_ID=$(echo "$RELEASE_INFO" | jq -r '.id')
-        UPLOAD_URL=$(echo "$RELEASE_INFO" | jq -r '.uploadUrl')
-
-        echo "id=${RELEASE_ID}" >> $GITHUB_OUTPUT
-        echo "upload_url=${UPLOAD_URL}" >> $GITHUB_OUTPUT
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build:
     name: Build ${{ matrix.target }}
-    needs: create-release
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -363,10 +252,10 @@ jobs:
         cd target/${{ matrix.target }}/release
         case "${{ matrix.target }}" in
           *windows*)
-            tar czf ../../../dist/octomind-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.tar.gz octomind.exe
+            tar czf ../../../dist/octomind-${{ inputs.tag || github.ref_name }}-${{ matrix.target }}.tar.gz octomind.exe
             ;;
           *)
-            tar czf ../../../dist/octomind-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.tar.gz octomind
+            tar czf ../../../dist/octomind-${{ inputs.tag || github.ref_name }}-${{ matrix.target }}.tar.gz octomind
             ;;
         esac
 
@@ -375,157 +264,37 @@ jobs:
       shell: sh
       run: |
         cd target/${{ matrix.target }}/release
-        7z a ../../../dist/octomind-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.zip octomind.exe
+        7z a ../../../dist/octomind-${{ inputs.tag || github.ref_name }}-${{ matrix.target }}.zip octomind.exe
 
-    - name: Upload release asset
-      shell: sh
-      run: |
-        gh release upload "${{ needs.create-release.outputs.version }}" \
-          "./dist/octomind-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}" \
-          --clobber
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-${{ matrix.target }}
+        path: dist/*
+        if-no-files-found: error
 
   publish-crate:
     name: Publish to Crates.io
-    needs: [create-release, build]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+    needs: build
+    uses: muvon/ci-workflow/.github/workflows/rust-publish.yml@master
+    secrets: inherit
+    with:
+      tag: ${{ inputs.tag }}
+      publish-flags: '--no-default-features'
+      setup-protoc: true
 
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.95.0
-
-    - name: Setup protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Cache dependencies
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-publish-
-          ${{ runner.os }}-cargo-
-
-    - name: Validate version matches tag
-      run: |
-        VERSION="${{ needs.create-release.outputs.version }}"
-        CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-
-        if [ "$VERSION" != "$CARGO_VERSION" ]; then
-          echo "❌ Version mismatch!"
-          echo "Git tag: $VERSION"
-          echo "Cargo.toml: $CARGO_VERSION"
-          echo "Please update Cargo.toml version to match the git tag"
-          exit 1
-        fi
-
-        echo "✅ Version validation passed: $VERSION"
-
-    - name: Check if version already published
-      id: check_published
-      run: |
-        VERSION="${{ needs.create-release.outputs.version }}"
-
-        # Check if this version already exists on crates.io
-        if cargo search octomind --limit 1 | grep -q "octomind = \"$VERSION\""; then
-          echo "already_published=true" >> $GITHUB_OUTPUT
-          echo "⚠️  Version $VERSION already published to crates.io"
-        else
-          echo "already_published=false" >> $GITHUB_OUTPUT
-          echo "✅ Version $VERSION not yet published"
-        fi
-
-    - name: Dry run publish
-      if: steps.check_published.outputs.already_published == 'false'
-      run: |
-        echo "🔍 Running dry-run publish to validate package..."
-        cargo publish --dry-run --no-default-features
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-    - name: Publish to crates.io
-      if: steps.check_published.outputs.already_published == 'false'
-      run: |
-        echo "🚀 Publishing to crates.io..."
-        cargo publish --no-default-features
-        echo "✅ Successfully published to crates.io!"
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-    - name: Skip publishing
-      if: steps.check_published.outputs.already_published == 'true'
-      run: |
-        echo "⏭️  Skipping crates.io publish - version already exists"
-
-  finalize-release:
-    name: Finalize Release
-    needs: [create-release, build, publish-crate]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Publish release
-      run: |
-        VERSION="${{ needs.create-release.outputs.version }}"
-
-        # Update release notes with download links
-        cat > release_notes.md << EOF
-        ## 🚀 What's Changed
-
-        ${{ needs.create-release.outputs.changelog }}
-
-        ## 📦 Installation
-
-        ### Quick Install Script (Universal)
-        \`\`\`bash
-        curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | sh
-        \`\`\`
-
-        **Works on:** Linux, macOS, Windows (Git Bash/WSL/MSYS2), and any Unix-like system
-
-        ### Manual Download
-
-        | Platform | Architecture | Download |
-        |----------|--------------|----------|
-         | Linux | x86_64 (static) | [octomind-${VERSION}-x86_64-unknown-linux-musl.tar.gz](https://github.com/${{ github.repository }}/releases/download/${VERSION}/octomind-${VERSION}-x86_64-unknown-linux-musl.tar.gz) |
-         | Linux | ARM64 (static) | [octomind-${VERSION}-aarch64-unknown-linux-musl.tar.gz](https://github.com/${{ github.repository }}/releases/download/${VERSION}/octomind-${VERSION}-aarch64-unknown-linux-musl.tar.gz) |
-         | Windows | x86_64 | [octomind-${VERSION}-x86_64-pc-windows-msvc.zip](https://github.com/${{ github.repository }}/releases/download/${VERSION}/octomind-${VERSION}-x86_64-pc-windows-msvc.zip) |
-         | Windows | ARM64 | [octomind-${VERSION}-aarch64-pc-windows-msvc.zip](https://github.com/${{ github.repository }}/releases/download/${VERSION}/octomind-${VERSION}-aarch64-pc-windows-msvc.zip) |
-         | macOS | x86_64 | [octomind-${VERSION}-x86_64-apple-darwin.tar.gz](https://github.com/${{ github.repository }}/releases/download/${VERSION}/octomind-${VERSION}-x86_64-apple-darwin.tar.gz) |
-         | macOS | ARM64 | [octomind-${VERSION}-aarch64-apple-darwin.tar.gz](https://github.com/${{ github.repository }}/releases/download/${VERSION}/octomind-${VERSION}-aarch64-apple-darwin.tar.gz) |
-
-         ### Using Cargo (from crates.io)
-         \`\`\`bash
-         cargo install octomind
-         \`\`\`
-
-         ### Using Cargo (from Git)
-         \`\`\`bash
-         cargo install --git https://github.com/${{ github.repository }}
-         \`\`\`
-         ### Verify Installation
-        \`\`\`bash
-        octomind --version
-        \`\`\`
-        EOF
-
-        # Publish the release (remove draft status)
-        gh release edit "$VERSION" --draft=false --notes-file release_notes.md
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    name: Create Release
+    needs: [build, publish-crate]
+    uses: muvon/ci-workflow/.github/workflows/release.yml@master
+    with:
+      tag: ${{ inputs.tag }}
+      artifacts: 'release-*'
+      draft: false
 
   notify-homebrew:
     name: Notify Homebrew Tap
-    needs: [create-release, finalize-release]
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch update to homebrew-tap
@@ -534,11 +303,11 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.TAP_GITHUB_TOKEN }}" \
             https://api.github.com/repos/muvon/homebrew-tap/dispatches \
-            -d "{\"event_type\":\"octomind-release\",\"client_payload\":{\"version\":\"${{ needs.create-release.outputs.version }}\"}}"
+            -d "{\"event_type\":\"octomind-release\",\"client_payload\":{\"version\":\"${{ needs.release.outputs.version }}\"}}"
 
   docker:
     name: Build and Push Docker Images
-    needs: [create-release, build, finalize-release]
+    needs: release
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -574,7 +343,7 @@ jobs:
         platforms: ${{ matrix.platform }}
         push: true
         build-args: |
-          OCTOMIND_VERSION=${{ needs.create-release.outputs.version }}
+          OCTOMIND_VERSION=${{ needs.release.outputs.version }}
         outputs: type=image,name=ghcr.io/${{ steps.repo.outputs.repository }},push-by-digest=true,name-canonical=true,push=true
         cache-from: type=gha,scope=${{ matrix.platform }}
         cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
@@ -595,7 +364,7 @@ jobs:
 
   docker-merge:
     name: Merge Docker Manifests
-    needs: [create-release, docker]
+    needs: [release, docker]
     runs-on: ubuntu-latest
     steps:
     - name: Download digests
@@ -624,7 +393,7 @@ jobs:
       run: |
         docker buildx imagetools create \
           -t ghcr.io/${{ steps.repo.outputs.repository }}:latest \
-          -t ghcr.io/${{ steps.repo.outputs.repository }}:${{ needs.create-release.outputs.version }} \
+          -t ghcr.io/${{ steps.repo.outputs.repository }}:${{ needs.release.outputs.version }} \
           $(printf 'ghcr.io/${{ steps.repo.outputs.repository }}@sha256:%s ' *)
 
     - name: Inspect image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,15 +507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitpacking"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,31 +547,6 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
-]
-
-[[package]]
-name = "bon"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
-dependencies = [
- "bon-macros",
- "rustversion",
-]
-
-[[package]]
-name = "bon-macros"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
-dependencies = [
- "darling 0.23.0",
- "ident_case",
- "prettyplease",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
 ]
 
 [[package]]
@@ -756,12 +722,6 @@ dependencies = [
  "libc",
  "shlex 2.0.1",
 ]
-
-[[package]]
-name = "census"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cexpr"
@@ -1318,16 +1278,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "datasketches"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
-
-[[package]]
 name = "db-keystore"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc758963ac0d7ead30f47ff2a02a2fd3456cf4d7fc695cf9bae72e951a3df2b"
+checksum = "f9a1b2f1087c32a26a8c6c7d89eb80b50c33d8466e2431ea2a8345c969cded18"
 dependencies = [
  "anyhow",
  "clap",
@@ -1485,12 +1439,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "downcast-rs"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,17 +1545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,12 +1641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastdivide"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,16 +1731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs4"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2312,12 +2233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "htmlescape"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
-
-[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,15 +2617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inventory"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,12 +2850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "levenshtein_automata"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3068,25 +2968,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lz4_flex"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -3111,15 +2996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
-]
-
-[[package]]
-name = "measure_time"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -3252,12 +3128,6 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
-
-[[package]]
-name = "murmurhash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nom"
@@ -3434,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "octolib"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14991580fe55f15ab1a5224d1409508ec49db90234972fbb891148b1e6beb3ae"
+checksum = "9e6b7304db26f786898b5237838f97f4e2d4ca4dd27ad5ba85063e1307737d23"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3543,12 +3413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "oneshot"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
-
-[[package]]
 name = "onig"
 version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,24 +3462,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ownedbytes"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "owo-colors"
@@ -4356,16 +4202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-stemmers"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4951,15 +4787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
-name = "sketches-ddsketch"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5193,154 +5020,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tantivy"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
-dependencies = [
- "aho-corasick",
- "arc-swap",
- "base64 0.22.1",
- "bitpacking",
- "bon",
- "byteorder",
- "census",
- "crc32fast",
- "crossbeam-channel",
- "datasketches",
- "downcast-rs",
- "fastdivide",
- "fnv",
- "fs4",
- "htmlescape",
- "itertools 0.14.0",
- "levenshtein_automata",
- "log",
- "lru",
- "lz4_flex",
- "measure_time",
- "memmap2",
- "once_cell",
- "oneshot",
- "rayon",
- "regex",
- "rust-stemmers",
- "rustc-hash 2.1.2",
- "serde",
- "serde_json",
- "sketches-ddsketch",
- "smallvec",
- "tantivy-bitpacker",
- "tantivy-columnar",
- "tantivy-common",
- "tantivy-fst",
- "tantivy-query-grammar",
- "tantivy-stacker",
- "tantivy-tokenizer-api",
- "tempfile",
- "thiserror 2.0.18",
- "time",
- "typetag",
- "uuid",
- "winapi",
-]
-
-[[package]]
-name = "tantivy-bitpacker"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
-dependencies = [
- "bitpacking",
-]
-
-[[package]]
-name = "tantivy-columnar"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
-dependencies = [
- "downcast-rs",
- "fastdivide",
- "itertools 0.14.0",
- "serde",
- "tantivy-bitpacker",
- "tantivy-common",
- "tantivy-sstable",
- "tantivy-stacker",
-]
-
-[[package]]
-name = "tantivy-common"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
-dependencies = [
- "async-trait",
- "byteorder",
- "ownedbytes",
- "serde",
- "time",
-]
-
-[[package]]
-name = "tantivy-fst"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
-dependencies = [
- "byteorder",
- "regex-syntax",
- "utf8-ranges",
-]
-
-[[package]]
-name = "tantivy-query-grammar"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
-dependencies = [
- "fnv",
- "nom",
- "ordered-float",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "tantivy-sstable"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
-dependencies = [
- "futures-util",
- "itertools 0.14.0",
- "tantivy-bitpacker",
- "tantivy-common",
- "tantivy-fst",
- "zstd",
-]
-
-[[package]]
-name = "tantivy-stacker"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
-dependencies = [
- "murmurhash32",
- "tantivy-common",
-]
-
-[[package]]
-name = "tantivy-tokenizer-api"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5886,7 +5565,6 @@ dependencies = [
  "smallvec",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "tantivy",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -6021,40 +5699,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "typetag"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
-dependencies = [
- "erased-serde",
- "inventory",
- "once_cell",
- "serde",
- "typetag-impl",
-]
-
-[[package]]
-name = "typetag-impl"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "uncased"
@@ -6158,12 +5806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6183,7 +5825,6 @@ checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "serde_core",
  "sha1_smol",
  "wasm-bindgen",
 ]
@@ -6866,18 +6507,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
- Migrate Rust jobs to shared workflows
- Move release and publish logic to muvon/ci-workflow
- Replace manual asset uploads with upload-artifact
- Simplify job dependencies and version referencing