### PR TITLE
feat(workflow): add working directory support for steps

### DIFF
--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -102,6 +102,9 @@ fn print_step(idx: usize, step: &Step, depth: usize) {
 			if let Some(m) = &s.model {
 				meta = format!("model: {m}  {meta}");
 			}
+			if let Some(w) = &s.workdir {
+				meta = format!("{meta}  workdir: {w}");
+			}
 			println!("{indent}   {meta}");
 			println!("{indent}   prompt: {}", truncate(&s.prompt, 120));
 		}
@@ -166,6 +169,9 @@ fn print_sub(idx: usize, s: &octomind::workflow::schema::Sequential, depth: usiz
 	);
 	if let Some(m) = &s.model {
 		meta = format!("model={m}  {meta}");
+	}
+	if let Some(w) = &s.workdir {
+		meta = format!("{meta}  workdir={w}");
 	}
 	println!(
 		"{indent}{idx}. {name}  {meta}",

--- a/src/workflow/proc.rs
+++ b/src/workflow/proc.rs
@@ -18,6 +18,7 @@
 use anyhow::{anyhow, Context, Result};
 use colored::Colorize;
 use indicatif::ProgressBar;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -59,6 +60,8 @@ pub struct RunStepArgs {
 	pub session_name: Option<String>,
 	/// Optional model override forwarded as `--model` to the subprocess.
 	pub model: Option<String>,
+	/// Absolute working directory for the subprocess. None = inherit cwd.
+	pub workdir: Option<PathBuf>,
 	pub timeout_secs: u64,
 	pub event_prefix: Option<String>,
 	pub spinner: Option<ProgressBar>,
@@ -77,6 +80,7 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 		prompt,
 		session_name,
 		model,
+		workdir,
 		timeout_secs,
 		event_prefix,
 		spinner,
@@ -104,6 +108,9 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 	}
 	if let Some(m) = &model {
 		cmd.arg("--model").arg(m);
+	}
+	if let Some(dir) = &workdir {
+		cmd.current_dir(dir);
 	}
 	cmd.kill_on_drop(true);
 
@@ -420,21 +427,25 @@ fn truncate(s: &str, n: usize) -> String {
 }
 
 /// Send `/done` to a named session so its context is compressed before
-/// the next run. Best-effort: errors are logged-and-swallowed by the
-/// caller (executor) — a failed `/done` should not abort the workflow.
-pub async fn send_done(session_name: &str) -> Result<()> {
+/// the next run. Runs in the step's `workdir` so the resumed session
+/// sees the same project context as the step itself. Best-effort:
+/// errors are logged-and-swallowed by the caller (executor) — a failed
+/// `/done` should not abort the workflow.
+pub async fn send_done(session_name: &str, workdir: Option<&Path>) -> Result<()> {
 	let exe = std::env::current_exe().context("current_exe")?;
-	let mut child = Command::new(exe)
-		.arg("run")
+	let mut cmd = Command::new(exe);
+	cmd.arg("run")
 		.arg("--name")
 		.arg(session_name)
 		.arg("--format")
 		.arg("jsonl")
 		.stdin(Stdio::piped())
 		.stdout(Stdio::null())
-		.stderr(Stdio::null())
-		.spawn()
-		.context("spawn /done failed")?;
+		.stderr(Stdio::null());
+	if let Some(dir) = workdir {
+		cmd.current_dir(dir);
+	}
+	let mut child = cmd.spawn().context("spawn /done failed")?;
 
 	if let Some(mut stdin) = child.stdin.take() {
 		stdin.write_all(b"/done\n").await.ok();

--- a/src/workflow/run.rs
+++ b/src/workflow/run.rs
@@ -21,6 +21,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use regex::Regex;
 use std::collections::HashMap;
 use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
@@ -142,6 +143,7 @@ impl Executor {
 		header_suffix: &str,
 	) -> Result<StepStats> {
 		let templated_prompt = self.substitute(&s.prompt, input).await;
+		let workdir = resolve_workdir(&s.name, s.workdir.as_deref())?;
 		let max_attempts = s.retries + 1;
 		let mut last_err: Option<String> = None;
 
@@ -174,7 +176,7 @@ impl Executor {
 						.clone();
 					// If this session has been used before, compress it with /done first.
 					if *self.used_continue.get(&s.name).unwrap_or(&false) {
-						let _ = send_done(&id).await;
+						let _ = send_done(&id, workdir.as_deref()).await;
 					}
 					Some(id)
 				}
@@ -222,6 +224,7 @@ impl Executor {
 				prompt: prompt_for_run,
 				session_name,
 				model: s.model.clone(),
+				workdir: workdir.clone(),
 				timeout_secs: s.timeout,
 				event_prefix: if has_spinner {
 					None
@@ -288,10 +291,14 @@ impl Executor {
 		// outer scope — sub-steps cannot reference each other. Each
 		// substitution may touch disk (project context placeholders), so
 		// we collect sequentially before kicking off the parallel tasks.
-		let mut prepared: Vec<(Sequential, String)> = Vec::with_capacity(p.run.len());
+		// Workdirs resolve here too — a bad one fails the whole parallel
+		// step before any subprocess spawns.
+		let mut prepared: Vec<(Sequential, String, Option<PathBuf>)> =
+			Vec::with_capacity(p.run.len());
 		for s in &p.run {
 			let resolved = self.substitute(&s.prompt, input).await;
-			prepared.push((s.clone(), resolved));
+			let workdir = resolve_workdir(&s.name, s.workdir.as_deref())?;
+			prepared.push((s.clone(), resolved, workdir));
 		}
 
 		// We can't borrow &mut self across the join, so run each sub-step
@@ -299,7 +306,7 @@ impl Executor {
 		// Implementation: launch all in parallel using join_all, but each
 		// task owns its own Sequential copy and we DON'T touch self.
 		let mut handles = Vec::new();
-		for (s, prompt) in prepared {
+		for (s, prompt, workdir) in prepared {
 			let sname = s.name.clone();
 			let role = s.role.clone();
 			let timeout = s.timeout;
@@ -317,6 +324,7 @@ impl Executor {
 						prompt: prompt.clone(),
 						session_name: None,
 						model: model.clone(),
+						workdir: workdir.clone(),
 						timeout_secs: timeout,
 						event_prefix: None,
 						spinner: None,
@@ -488,6 +496,31 @@ impl Executor {
 		}
 		Ok(())
 	}
+}
+
+/// Resolve a step's optional `workdir` to an absolute path. Relative
+/// paths resolve against the orchestrator's cwd. Checked at execution
+/// time rather than pre-flight so a directory created by an earlier
+/// step is legal. A missing directory is a hard error — the subprocess
+/// would otherwise die with an opaque spawn failure.
+fn resolve_workdir(step_name: &str, workdir: Option<&str>) -> Result<Option<PathBuf>> {
+	let Some(w) = workdir else {
+		return Ok(None);
+	};
+	let p = Path::new(w);
+	let abs = if p.is_absolute() {
+		p.to_path_buf()
+	} else {
+		std::env::current_dir()?.join(p)
+	};
+	if !abs.is_dir() {
+		bail!(
+			"step '{}': workdir '{}' is not a directory",
+			step_name,
+			abs.display()
+		);
+	}
+	Ok(Some(abs))
 }
 
 fn condition_matches(cond: &Condition, value: &str) -> bool {

--- a/src/workflow/schema.rs
+++ b/src/workflow/schema.rs
@@ -51,6 +51,11 @@ pub struct Sequential {
 	/// Optional model override forwarded as `--model` to the subprocess.
 	#[serde(default)]
 	pub model: Option<String>,
+	/// Optional working directory for the subprocess. Relative paths
+	/// resolve against the orchestrator's cwd at execution time.
+	/// None = inherit the orchestrator's cwd.
+	#[serde(default)]
+	pub workdir: Option<String>,
 }
 
 /// Pattern test against a step's output.

--- a/src/workflow/validate.rs
+++ b/src/workflow/validate.rs
@@ -77,7 +77,7 @@ fn insert_unique(name: &str, names: &mut HashSet<String>) -> Result<()> {
 fn structural_check(step: &Step) -> Result<()> {
 	match step {
 		Step::Sequential(s) => {
-			validate_model(&s.name, &s.model)?;
+			validate_fields(s)?;
 			Ok(())
 		}
 		Step::Parallel(ParallelStep { name, run }) => {
@@ -85,7 +85,7 @@ fn structural_check(step: &Step) -> Result<()> {
 				bail!("parallel step '{}' must have at least 2 sub-steps", name);
 			}
 			for s in run {
-				validate_model(&s.name, &s.model)?;
+				validate_fields(s)?;
 			}
 			Ok(())
 		}
@@ -99,7 +99,7 @@ fn structural_check(step: &Step) -> Result<()> {
 				bail!("loop step '{}' must have at least 1 sub-step", name);
 			}
 			for s in run {
-				validate_model(&s.name, &s.model)?;
+				validate_fields(s)?;
 			}
 			let exit_when = match exit_when {
 				Some(c) => c,
@@ -161,19 +161,24 @@ fn structural_check(step: &Step) -> Result<()> {
 				}
 			}
 			for s in run {
-				validate_model(&s.name, &s.model)?;
+				validate_fields(s)?;
 			}
 			Ok(())
 		}
 	}
 }
 
-fn validate_model(step_name: &str, model: &Option<String>) -> Result<()> {
-	if let Some(m) = model {
+fn validate_fields(s: &Sequential) -> Result<()> {
+	if let Some(m) = &s.model {
 		if m.trim().is_empty() {
+			bail!("step '{}': model must not be empty when specified", s.name);
+		}
+	}
+	if let Some(w) = &s.workdir {
+		if w.trim().is_empty() {
 			bail!(
-				"step '{}': model must not be empty when specified",
-				step_name
+				"step '{}': workdir must not be empty when specified",
+				s.name
 			);
 		}
 	}


### PR DESCRIPTION
- Add workdir field to Sequential step schema and definition
- Implement absolute path resolution for step working directories
- Pass resolved workdir to subprocesses during step execution
- Ensure session compression runs within the step's workdir
- Display workdir in workflow step printing
- Implement validation for workdir and model fields
- Refactor structural check to use unified field validation