### PR TITLE
feat(workflow): add jsonl output format

### DIFF
--- a/doc/reference/01-cli-reference.md
+++ b/doc/reference/01-cli-reference.md
@@ -275,14 +275,18 @@ Run a multi-step workflow defined in a TOML file.
 |------|-------|-------------|
 | `FILE` | | Path to workflow TOML file (required) |
 | `--dry-run` | | Validate and print the execution plan without running any steps |
+| `--format <FORMAT>` | | `jsonl` emits structured `assistant` (final result) + `cost` (aggregated totals) events to stdout |
 
-Reads input from stdin. **All** output — per-step assistant responses, progress, cost, and token stats — is
-written to **stderr**. **stdout** receives output only for `--dry-run` (the execution plan); the workflow itself
-produces no stdout result stream. To capture a step's text, consume stderr (e.g. `2>flow.log`). See
+Reads input from stdin. Per-step assistant responses, progress, cost, and token stats are written to **stderr**.
+By default **stdout** receives output only for `--dry-run` (the execution plan). With `--format jsonl`, stdout
+also receives one `{"type":"assistant",...}` line carrying the workflow's final result and one
+`{"type":"cost",...}` line with aggregated tokens/cost — the same event shapes `octomind run --format jsonl`
+emits (workflows have no single resumable session, so `session_id` is empty). See
 [Workflows](../usage/09-workflows.md).
 
 ```bash
 echo "build a JSON-to-CSV CLI in Rust" | octomind workflow myflow.toml
+echo "build a JSON-to-CSV CLI in Rust" | octomind workflow myflow.toml --format jsonl
 octomind workflow myflow.toml --dry-run
 ```
 

--- a/doc/reference/01-cli-reference.md
+++ b/doc/reference/01-cli-reference.md
@@ -275,14 +275,15 @@ Run a multi-step workflow defined in a TOML file.
 |------|-------|-------------|
 | `FILE` | | Path to workflow TOML file (required) |
 | `--dry-run` | | Validate and print the execution plan without running any steps |
-| `--format <FORMAT>` | | `jsonl` emits structured `assistant` (final result) + `cost` (aggregated totals) events to stdout |
+| `--format <FORMAT>` | | `jsonl` streams one `assistant` event per step + a final aggregated `cost` event to stdout |
 
 Reads input from stdin. Per-step assistant responses, progress, cost, and token stats are written to **stderr**.
 By default **stdout** receives output only for `--dry-run` (the execution plan). With `--format jsonl`, stdout
-also receives one `{"type":"assistant",...}` line carrying the workflow's final result and one
-`{"type":"cost",...}` line with aggregated tokens/cost — the same event shapes `octomind run --format jsonl`
-emits (workflows have no single resumable session, so `session_id` is empty). See
-[Workflows](../usage/09-workflows.md).
+streams one `{"type":"assistant","content":...,"step":"<name>","session_id":""}` line **as each step completes**
+(the final result is simply the last one) followed by one `{"type":"cost",...}` line with aggregated
+tokens/cost. These are the same event shapes `octomind run --format jsonl` emits, with an extra `step` field
+identifying the originating step (omitted in `run` output). Workflows have no single resumable session, so
+`session_id` is empty. See [Workflows](../usage/09-workflows.md).
 
 ```bash
 echo "build a JSON-to-CSV CLI in Rust" | octomind workflow myflow.toml

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -36,6 +36,12 @@ pub struct WorkflowArgs {
 	/// Validate and print the execution plan to stdout without running any steps.
 	#[arg(long)]
 	pub dry_run: bool,
+
+	/// Output format for the final result on stdout. With `jsonl`, emit
+	/// structured `assistant` (final result) and `cost` (aggregated totals)
+	/// events for machine parsing. Per-step progress always goes to stderr.
+	#[arg(long = "format")]
+	pub format: Option<String>,
 }
 
 pub async fn execute(args: &WorkflowArgs, config: &Config) -> Result<()> {
@@ -68,7 +74,7 @@ pub async fn execute(args: &WorkflowArgs, config: &Config) -> Result<()> {
 		bail!("workflow requires input via stdin");
 	}
 
-	execute_workflow(&wf, &input, config).await?;
+	execute_workflow(&wf, &input, config, args.format.as_deref()).await?;
 	Ok(())
 }
 

--- a/src/mcp/agent/functions.rs
+++ b/src/mcp/agent/functions.rs
@@ -886,6 +886,7 @@ fn forward_session_update_to_parent(update: &Value) {
 			crate::websocket::ServerMessage::Assistant(crate::websocket::AssistantPayload {
 				content: text.to_string(),
 				session_id,
+				step: None,
 			})
 		}
 		"agent_thought_chunk" => {

--- a/src/session/chat/response.rs
+++ b/src/session/chat/response.rs
@@ -727,6 +727,7 @@ pub async fn process_response<S: OutputSink>(
 	params.emit(ServerMessage::Assistant(AssistantPayload {
 		content: current_content.clone(),
 		session_id: session_id.clone(),
+		step: None,
 	}));
 
 	handle_final_response(

--- a/src/session/output.rs
+++ b/src/session/output.rs
@@ -244,6 +244,7 @@ mod tests {
 		let msg = ServerMessage::Assistant(AssistantPayload {
 			content: "test".to_string(),
 			session_id: "session_123".to_string(),
+			step: None,
 		});
 
 		// Should not panic, should not output anything
@@ -256,6 +257,7 @@ mod tests {
 		let msg = ServerMessage::Assistant(AssistantPayload {
 			content: "test content".to_string(),
 			session_id: "session_123".to_string(),
+			step: None,
 		});
 
 		// Note: In real test, you'd capture stdout
@@ -271,6 +273,7 @@ mod tests {
 		let msg = ServerMessage::Assistant(AssistantPayload {
 			content: "test".to_string(),
 			session_id: "session_123".to_string(),
+			step: None,
 		});
 
 		sink.emit(msg);
@@ -293,6 +296,7 @@ mod tests {
 		let msg = ServerMessage::Assistant(AssistantPayload {
 			content: "test".to_string(),
 			session_id: "session_123".to_string(),
+			step: None,
 		});
 
 		// Should not panic when channel is closed

--- a/src/websocket/protocol.rs
+++ b/src/websocket/protocol.rs
@@ -105,6 +105,10 @@ impl ClientMessage {
 pub struct AssistantPayload {
 	pub content: String,
 	pub session_id: String,
+	/// Workflow step name this message originated from. Omitted for
+	/// single-session `run` output; set per step by `octomind workflow`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub step: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -449,6 +453,7 @@ mod tests {
 		let msg = ServerMessage::Assistant(AssistantPayload {
 			content: "Response".to_string(),
 			session_id: "sess_123".to_string(),
+			step: None,
 		});
 		let json = serde_json::to_string(&msg).unwrap();
 		assert!(json.contains("\"type\":\"assistant\""));

--- a/src/workflow/run.rs
+++ b/src/workflow/run.rs
@@ -32,6 +32,8 @@ use super::schema::{
 use super::validate;
 use crate::config::Config;
 use crate::session::chat::markdown::{is_markdown_content, MarkdownRenderer};
+use crate::session::{JsonlSink, OutputSink};
+use crate::websocket::{AssistantPayload, CostPayload, ServerMessage};
 
 /// Final summed totals printed once at the end.
 #[derive(Debug, Default, Clone, Copy)]
@@ -39,6 +41,8 @@ struct Totals {
 	duration: Duration,
 	cost: f64,
 	tokens: u64,
+	input_tokens: u64,
+	output_tokens: u64,
 	tools: u64,
 	tools_failed: u64,
 }
@@ -48,6 +52,8 @@ impl Totals {
 		self.duration += s.duration;
 		self.cost += s.cost;
 		self.tokens += s.total_tokens;
+		self.input_tokens += s.input_tokens;
+		self.output_tokens += s.output_tokens;
 		self.tools += s.tool_count;
 		self.tools_failed += s.tool_failed;
 	}
@@ -666,7 +672,13 @@ fn fmt_tools(count: u64, failed: u64) -> String {
 /// Each step's last assistant message is already printed (with markdown
 /// rendering when enabled) as it completes, so the workflow produces no
 /// stdout — callers consume per-step output from stderr instead.
-pub async fn execute(wf: &WorkflowDef, input: &str, config: &Config) -> Result<()> {
+pub async fn execute(
+	wf: &WorkflowDef,
+	input: &str,
+	config: &Config,
+	format: Option<&str>,
+) -> Result<()> {
+	let jsonl = matches!(format, Some("jsonl"));
 	let mut ex = Executor::new(wf.name.clone(), config);
 
 	// In TTY mode, suppress the controlling terminal's keypress echo for
@@ -720,6 +732,34 @@ pub async fn execute(wf: &WorkflowDef, input: &str, config: &Config) -> Result<(
 		tools = fmt_tools(ex.totals.tools, ex.totals.tools_failed),
 		b = bullet,
 	);
+
+	// In jsonl mode, emit structured events to stdout so callers (CI, the
+	// GitHub Action) can parse the final result and aggregated cost without
+	// scraping the human-readable stderr stream. There is no single resumable
+	// session for a workflow, so `session_id` is left empty.
+	if jsonl {
+		let final_output = ex
+			.last_step
+			.as_ref()
+			.and_then(|n| ex.outputs.get(n))
+			.cloned()
+			.unwrap_or_default();
+		let sink = JsonlSink;
+		sink.emit(ServerMessage::Assistant(AssistantPayload {
+			content: final_output,
+			session_id: String::new(),
+		}));
+		sink.emit(ServerMessage::Cost(CostPayload {
+			session_tokens: ex.totals.tokens,
+			session_cost: ex.totals.cost,
+			input_tokens: ex.totals.input_tokens,
+			output_tokens: ex.totals.output_tokens,
+			cache_read_tokens: 0,
+			cache_write_tokens: 0,
+			reasoning_tokens: 0,
+			session_id: String::new(),
+		}));
+	}
 
 	// Drop any keypresses the user typed during animation so they don't
 	// leak into the shell's input queue when control returns.

--- a/src/workflow/run.rs
+++ b/src/workflow/run.rs
@@ -81,10 +81,13 @@ struct Executor {
 	markdown_enabled: bool,
 	/// Theme name from `config.markdown_theme` (parsed lazily).
 	markdown_theme: String,
+	/// `--format jsonl` — emit a per-step `assistant` event to stdout as each
+	/// step completes, plus an aggregated `cost` event at the end.
+	jsonl: bool,
 }
 
 impl Executor {
-	fn new(wf_name: String, config: &Config) -> Self {
+	fn new(wf_name: String, config: &Config, jsonl: bool) -> Self {
 		Self {
 			outputs: HashMap::new(),
 			session_ids: HashMap::new(),
@@ -96,6 +99,21 @@ impl Executor {
 			started: Instant::now(),
 			markdown_enabled: config.enable_markdown_rendering,
 			markdown_theme: config.markdown_theme.clone(),
+			jsonl,
+		}
+	}
+
+	/// Emit a completed step's result as a JSONL `assistant` event on stdout
+	/// when running with `--format jsonl`. Mirrors the per-step response the
+	/// human display writes to stderr, so machine consumers see each step's
+	/// outcome — not just the final one. `step` carries the step name.
+	fn emit_step(&self, name: &str, content: &str) {
+		if self.jsonl {
+			JsonlSink.emit(ServerMessage::Assistant(AssistantPayload {
+				content: content.to_string(),
+				session_id: String::new(),
+				step: Some(name.to_string()),
+			}));
 		}
 	}
 
@@ -251,6 +269,7 @@ impl Executor {
 					}
 					box_close_ok(&s.name.bright_white(), &fmt_stats(&stats));
 					print_response(&stats.output, self.markdown_enabled, &self.markdown_theme);
+					self.emit_step(&s.name, &stats.output);
 					self.totals.add(&stats);
 					return Ok(stats);
 				}
@@ -403,6 +422,7 @@ impl Executor {
 				eprintln!("{}", format!("── {name} ──").bright_black());
 				print_response(t, self.markdown_enabled, &self.markdown_theme);
 			}
+			self.emit_step(name, out);
 		}
 		eprintln!();
 		Ok(())
@@ -679,7 +699,7 @@ pub async fn execute(
 	format: Option<&str>,
 ) -> Result<()> {
 	let jsonl = matches!(format, Some("jsonl"));
-	let mut ex = Executor::new(wf.name.clone(), config);
+	let mut ex = Executor::new(wf.name.clone(), config, jsonl);
 
 	// In TTY mode, suppress the controlling terminal's keypress echo for
 	// the lifetime of the workflow so stray Enter / Ctrl-C presses don't
@@ -733,23 +753,12 @@ pub async fn execute(
 		b = bullet,
 	);
 
-	// In jsonl mode, emit structured events to stdout so callers (CI, the
-	// GitHub Action) can parse the final result and aggregated cost without
-	// scraping the human-readable stderr stream. There is no single resumable
-	// session for a workflow, so `session_id` is left empty.
+	// In jsonl mode, each step already emitted its own `assistant` event as it
+	// completed (so the final result is the last such event). Close the stream
+	// with one aggregated `cost` event. There is no single resumable session
+	// for a workflow, so `session_id` is left empty.
 	if jsonl {
-		let final_output = ex
-			.last_step
-			.as_ref()
-			.and_then(|n| ex.outputs.get(n))
-			.cloned()
-			.unwrap_or_default();
-		let sink = JsonlSink;
-		sink.emit(ServerMessage::Assistant(AssistantPayload {
-			content: final_output,
-			session_id: String::new(),
-		}));
-		sink.emit(ServerMessage::Cost(CostPayload {
+		JsonlSink.emit(ServerMessage::Cost(CostPayload {
 			session_tokens: ex.totals.tokens,
 			session_cost: ex.totals.cost,
 			input_tokens: ex.totals.input_tokens,


### PR DESCRIPTION
- Add --format jsonl flag to workflow command
- Emit structured assistant and cost events to stdout
- Update CLI reference documentation
- Track detailed input and output token totals