### PR TITLE
feat(workflow): implement parallel fan-out and aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "antithesis_sdk"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
 dependencies = [
  "libc",
  "libloading",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1302,7 +1302,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1376,7 +1375,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
 ]
@@ -2118,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2752,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3000,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -3304,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "octolib"
-version = "0.23.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6b7304db26f786898b5237838f97f4e2d4ca4dd27ad5ba85063e1307737d23"
+checksum = "ae45a43f3a04c8b1c091c409824bcc199a42995697573ae670c262aec56b9224"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3396,7 +3395,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "viuer",
- "which 8.0.3",
+ "which 8.0.4",
  "zstd",
 ]
 
@@ -4794,9 +4793,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -4937,9 +4936,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5161,12 +5160,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5176,15 +5174,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5892,9 +5890,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -5910,9 +5908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5923,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5933,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5943,9 +5941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5956,9 +5954,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -6012,9 +6010,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6032,18 +6030,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6068,9 +6066,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]
@@ -6548,18 +6546,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ overflow-checks = false # Disable overflow checks in release mode
 
 [dependencies]
 # octolib = { path = "../octolib", default-features = false, features = ["huggingface"] }
-octolib = { version = "0.23.0", default-features = false, features = ["huggingface"] }
+octolib = { version = "0.23.3", default-features = false, features = ["huggingface"] }
 rmcp = { version = "1.7.0", default-features = false }
 
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "time", "process", "fs", "sync", "signal", "io-std", "net"] }

--- a/README.md
+++ b/README.md
@@ -375,9 +375,12 @@ echo "List TODO items" | octomind run developer:general --format jsonl
 # Daemon — keep a session alive and inject messages into it from anywhere
 echo "first task" | octomind run --name watcher --daemon --format jsonl
 octomind send --name watcher "now run the test suite"
+
+# Structured output — constrain replies to a JSON Schema (structured-output models only)
+echo "List TODO items as JSON" | octomind run developer:general --format jsonl --schema todos.schema.json
 ```
 
-`octomind run` has **no message argument** — when `--format` is set, input comes from piped stdin. `--format` is `run`-only (it accepts only `plain` or `jsonl`; `server` and `acp` do not take it). Setting `--format` triggers non-interactive mode only when stdin is *not* a terminal: `octomind run developer:general --format plain` typed at a TTY stays interactive, while piping into it runs once and exits.
+`octomind run` has **no message argument** — when `--format` is set, input comes from piped stdin. `--format` is `run`-only (it accepts only `plain` or `jsonl`; `server` and `acp` do not take it). Setting `--format` triggers non-interactive mode only when stdin is *not* a terminal: `octomind run developer:general --format plain` typed at a TTY stays interactive, while piping into it runs once and exits. Pass `--schema <file.json>` to force replies to match a JSON Schema (requires a structured-output-capable model — Anthropic models error out); see the [CLI reference](doc/reference/01-cli-reference.md).
 
 See [WebSocket Server](doc/integration/01-websocket-server.md), [ACP Protocol](doc/integration/02-acp-protocol.md), and [Daemon & Hooks](doc/integration/03-daemon-and-hooks.md) for the integration modes.
 

--- a/config-templates/todos.schema.json
+++ b/config-templates/todos.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TodoList",
+  "description": "Example schema for `octomind run --schema todos.schema.json`. Constrains the model's reply to a structured TODO list. Requires a structured-output-capable model (e.g. an OpenAI-family model); Anthropic models are rejected up front. Strict-mode friendly: every property is `required` and `additionalProperties` is false, with optional fields expressed as a `null` union. Pair with `--format jsonl`: echo \"List TODO items in the auth module\" | octomind run developer:general --format jsonl --schema todos.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["todos"],
+  "properties": {
+    "todos": {
+      "type": "array",
+      "description": "The extracted TODO items, most important first.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "priority", "file"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Short imperative description of the task."
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["high", "medium", "low"],
+            "description": "Relative urgency of the task."
+          },
+          "file": {
+            "type": ["string", "null"],
+            "description": "Path the task relates to, or null if not file-specific."
+          }
+        }
+      }
+    }
+  }
+}

--- a/config-templates/workflow-fanout.toml
+++ b/config-templates/workflow-fanout.toml
@@ -1,0 +1,65 @@
+# Fan-out → aggregate: run the same task on several branches in parallel, then
+# have one step merge the results.
+#
+#   stdin ─► [ branch A | branch B | branch C ]  ─►  aggregator
+#
+# Branches are plain named sub-steps — each carries its own `model` and `prompt`,
+# so the SAME pattern covers both "same task, different models" and "same model,
+# different prompts". Names are unique, so the aggregator references each branch
+# (or the whole block) by name.
+#
+# Run:
+#   echo "build a JSON-to-CSV CLI in Rust" | octomind workflow workflow-fanout.toml
+#   octomind workflow workflow-fanout.toml --dry-run   # validate without spending
+#
+# See doc/usage/09-workflows.md for the full reference.
+
+name        = "fan-out-aggregate"
+description = "Same task on three models in parallel, one judge synthesizes the best"
+# max_cost  = 5.00   # optional hard USD ceiling for the whole run
+
+# ── Fan out: the SAME prompt, three different models, in parallel ─────────────
+# `min_success = 2` lets one branch fail without aborting the workflow.
+# (For SAME model + different prompts: keep one `model` and vary `prompt`.)
+[[steps]]
+name        = "candidates"
+parallel    = true
+min_success = 2
+# max_parallel = 2     # optional: cap how many branches run at once
+
+  [[steps.run]]
+  name    = "opus"
+  role    = "developer:general"
+  model   = "anthropic:claude-opus-4-8"
+  timeout = 600
+  prompt  = "Solve this task completely and correctly. Return only the solution.\n\n{{input}}"
+
+  [[steps.run]]
+  name    = "gpt"
+  role    = "developer:general"
+  model   = "openai:gpt-5"
+  timeout = 600
+  prompt  = "Solve this task completely and correctly. Return only the solution.\n\n{{input}}"
+
+  [[steps.run]]
+  name    = "gemini"
+  role    = "developer:general"
+  model   = "google:gemini-3-pro"
+  timeout = 600
+  prompt  = "Solve this task completely and correctly. Return only the solution.\n\n{{input}}"
+
+# ── Aggregate: one judge sees every branch and synthesizes the best ──────────
+# `{{candidates}}` (the block name) expands to all branch outputs joined under
+# `── opus ──`, `── gpt ──`, `── gemini ──` headers. You could instead reference
+# each branch by name: {{opus}}, {{gpt}}, {{gemini}}.
+[[steps]]
+name   = "judge"
+role   = "developer:general"
+prompt = """
+Independent solutions to the same task, one per model:
+
+{{candidates}}
+
+Compare them. Pick the strongest, correct any flaws, and produce a single final
+answer. Do not mention the comparison — output only the result.
+"""

--- a/config-templates/workflow-research.toml
+++ b/config-templates/workflow-research.toml
@@ -1,0 +1,66 @@
+# Dynamic fan-out: a planner step emits a list, then ONE branch runs per item in
+# parallel, and a final step synthesizes. The number of branches is decided at
+# run time by the planner's output — not fixed in this file.
+#
+#   stdin ─► plan (list)  ─►  [ research item 1 | item 2 | … ]  ─►  summary
+#
+# How: the parallel block has a `match` regex applied to the PREVIOUS step's
+# output. `match` splits that output into items and loops the single sub-step
+# over them. The block's own name (`research`) is the loop variable: inside the
+# template `{{research}}` is THIS branch's one task. Each branch's output
+# accumulates under the SUB-STEP's name (`researcher`), so the summary reads
+# `{{researcher}}` to get every branch joined.
+#
+# Run:
+#   echo "the state of WASM component model in 2026" \
+#     | octomind workflow workflow-research.toml
+#   octomind workflow workflow-research.toml --dry-run   # validate, no spend
+#
+# See doc/usage/09-workflows.md#dynamic-fan-out-match for the reference.
+
+name        = "research"
+description = "Plan research tasks, run each in parallel, synthesize a report"
+max_cost    = 5.00   # branch count is dynamic — bound total spend here
+
+# ── 1. Plan: emit one task per <task>…</task> block ─────────────────────────
+[[steps]]
+name   = "plan"
+role   = "researcher:general"
+prompt = """
+Break this research request into 3–7 independent sub-questions.
+Output ONLY the sub-questions, each wrapped exactly as <task>…</task>:
+
+{{input}}
+"""
+
+# ── 2. Research: ONE branch per <task> match, in parallel ───────────────────
+# `match` flips this block to dynamic. The single sub-step is the per-item
+# template. Inside it, `{{research}}` (the block's own name = loop variable)
+# resolves to THIS branch's matched task. `max_parallel` caps concurrency,
+# `min_success` tolerates a flaky branch.
+[[steps]]
+name         = "research"
+parallel     = true
+match        = "(?s)<task>(.*?)</task>"
+max_parallel = 4
+min_success  = 1
+
+  [[steps.run]]
+  name    = "researcher"
+  role    = "researcher:general"
+  timeout = 600
+  prompt  = """
+Research this sub-question thoroughly and report findings with sources:
+
+{{research}}
+"""
+
+# ── 3. Summarize: every branch's output joined under {{researcher}} ─────────
+[[steps]]
+name   = "summary"
+role   = "developer:general"
+prompt = """
+Synthesize these independent findings into one coherent report:
+
+{{researcher}}
+"""

--- a/doc/reference/01-cli-reference.md
+++ b/doc/reference/01-cli-reference.md
@@ -51,6 +51,7 @@ Start an interactive or non-interactive AI session.
 | `--daemon` | | Keep the session alive for injected messages. Implies non-interactive mode — pair with `--format` (e.g. `--format jsonl`) and deliver messages with `octomind send`. |
 | `--sandbox` | | Restrict filesystem writes to the working directory. See [Sandbox](#sandbox). |
 | `--hook` | | Activate webhook hook(s) by name (defined in `[[hooks]]` config). Repeatable. See [Daemon & Hooks](../integration/03-daemon-and-hooks.md). |
+| `--schema` | | Path to a JSON Schema **object** file. Constrains the model's output to match it (structured output). The resolved model must support structured output, or the run fails fast. See note below. |
 
 **Interactivity and `--format`:** `--format` is unset by default. If it is omitted and stdin is a TTY, the
 session runs **interactively**. If `--format` is given (`plain` or `jsonl`) **or** stdin is piped, the session
@@ -59,6 +60,14 @@ runs **non-interactively**, reading the input from stdin. Internally, an unset f
 **Daemon mode:** `--daemon` is non-interactive and effectively requires `--format` — when a daemon is launched
 attached to a terminal, the piped input is forced empty. While the session is alive, inject further messages with
 [`octomind send --name <name>`](#octomind-send). See [Daemon & Hooks](../integration/03-daemon-and-hooks.md).
+
+**Structured output (`--schema`):** pass a path to a JSON Schema **object** file to constrain the model's output.
+The schema applies to every assistant reply for the session's lifetime — across multi-turn sessions, resumes, and
+daemon mode — while tool calls still flow normally underneath (only the final text is constrained). If the
+resolved model lacks structured-output support (e.g. Anthropic models), the run fails fast with a clear error; use
+an OpenAI-family or other structured-output-capable model. The schema is a runtime override — like `--model`, it
+is not persisted, so pass it again when resuming. Most useful with `--format jsonl`. A ready-to-use example ships
+at [`config-templates/todos.schema.json`](../../config-templates/todos.schema.json).
 
 **Examples:**
 ```bash
@@ -86,6 +95,9 @@ octomind run --name ci-watcher --daemon --format jsonl --hook github-push
 
 # Model override
 octomind run -m anthropic:claude-sonnet-4
+
+# Structured output — constrain replies to a JSON Schema (structured-output models only)
+echo "List the top 3 TODOs" | octomind run developer:general --format jsonl --schema todos.schema.json
 ```
 
 ## `octomind server [TAG]`

--- a/doc/usage/09-workflows.md
+++ b/doc/usage/09-workflows.md
@@ -131,6 +131,7 @@ Every step prompt is resolved in **three passes**, in order, exactly like the in
 |--------------------|------------------------------------------------------------------------|
 | `{{input}}`        | The raw stdin content (trimmed)                                        |
 | `{{step_name}}`    | The full text output of a previously completed step (by name)          |
+| `{{parallel_step}}`| A parallel **block's** name → every sub-step's output joined; an expanded sub-step's name → all its replica outputs joined (see [Parallel](#parallel-parallel--true)) |
 
 An unknown `{{var}}` is left **untouched** in this pass so the next pass can claim it as a built-in.
 
@@ -174,6 +175,54 @@ Optional fields on any sequential step (including sub-steps inside parallel/loop
 Sub-steps run concurrently via `tokio::join_all`. The next top-level step starts only after every sub-step completes. Sub-steps cannot reference each other; only outer scope.
 
 A `session = "continue"` field on a parallel sub-step is **silently ignored** — parallel sub-steps always run with a fresh session. Continue-session state only makes sense across the sequential iterations of a loop.
+
+**Block fields** (on the `[[steps]]` table with `parallel = true`):
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `min_success` | _(all)_ | Minimum replicas (counted across the whole block, after `count` expansion) that must succeed for the block to pass. Lets a fan-out tolerate a flaky branch. Out of range → pre-flight error. |
+| `max_parallel` | _(unbounded)_ | Cap on how many replicas run concurrently (semaphore-throttled). Omit to launch all at once. Must be ≥ 1. |
+
+**Different models / different prompts** are just plain named sub-steps — each carries its own `model` and `prompt`. There is no special "model sweep" field; copy a `[[steps.run]]` block per branch (names are unique, so each branch is referenceable). The only fan-out field is `count`, for repeating one identical sub-step:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `count` | _(1)_ | Run this sub-step N times **unchanged** — same `role`, `model`, and `prompt`. The model is non-deterministic, so the N runs differ; an aggregator then picks/merges the best (best-of-N sampling). Just shorthand for copy-pasting the same block N times. Must be ≥ 2. Valid **only** on a parallel sub-step; rejected elsewhere. |
+
+```toml
+[[steps]]
+name        = "candidates"
+parallel    = true
+min_success = 2          # tolerate one failed branch
+# max_parallel = 4       # optional concurrency cap
+
+  # Same task on two different models → two named sub-steps.
+  [[steps.run]]
+  name   = "opus"
+  role   = "developer:general"
+  model  = "anthropic:claude-opus-4-8"
+  prompt = "Solve:\n{{input}}"
+
+  [[steps.run]]
+  name   = "gpt"
+  role   = "developer:general"
+  model  = "openai:gpt-5"
+  prompt = "Solve:\n{{input}}"
+
+  # Best-of-3 with one model + prompt → use count instead of copy-pasting.
+  [[steps.run]]
+  name   = "sampler"
+  role   = "developer:general"
+  prompt = "Solve:\n{{input}}"
+  count  = 3
+```
+
+**Aggregation variables.** After a parallel block completes, two kinds of `{{var}}` become available to later steps:
+
+- `{{<sub-step-name>}}` — a sub-step with `count` resolves to **all its replica outputs joined** under `── <name> #N ──` headers. A plain sub-step resolves to its single raw output, exactly as before.
+- `{{<parallel-step-name>}}` — resolves to **every sub-step's (aggregated) output joined**, so an aggregator can reference the whole block at once instead of listing each branch. (Previously this name validated but resolved to empty; it now carries the joined content.)
+
+Failed replicas (under `min_success`) are skipped in both joins.
 
 ### Loop (`loop = true`)
 Sub-steps run sequentially within each iteration. Between iterations, `exit_when` is checked against the named step's output:
@@ -276,6 +325,8 @@ Pre-flight checks (all hard-fail before any step runs):
 - Regex patterns in `matches` compile.
 - `model`, when specified on any step, must not be an empty string.
 - `max_cost`, when set, is a positive finite number.
+- `count` appears only on parallel sub-steps and is ≥ 2.
+- `min_success`, when set, is between 1 and the block's total replica count; `max_parallel`, when set, is ≥ 1.
 
 ## End-to-end example
 
@@ -325,6 +376,60 @@ Run it:
 
 ```bash
 echo "JSON-to-CSV CLI in Rust" | octomind workflow gan.toml
+```
+
+### Fan-out → aggregate (across models)
+
+Run the same task on three models in parallel, tolerate one failure, then have an
+aggregator pick and synthesize the best answer. Each branch is a plain named
+sub-step with its own `model`. A ready-to-run copy lives at
+[`config-templates/workflow-fanout.toml`](../../config-templates/workflow-fanout.toml).
+
+```toml
+name        = "fan-out-aggregate"
+description = "Same task on three models in parallel, one judge synthesizes"
+
+[[steps]]
+name        = "candidates"
+parallel    = true
+min_success = 2                     # one model may fail; two is enough
+
+  [[steps.run]]
+  name   = "opus"
+  role   = "developer:general"
+  model  = "anthropic:claude-opus-4-8"
+  prompt = "Solve this. Be complete and correct:\n{{input}}"
+
+  [[steps.run]]
+  name   = "gpt"
+  role   = "developer:general"
+  model  = "openai:gpt-5"
+  prompt = "Solve this. Be complete and correct:\n{{input}}"
+
+  [[steps.run]]
+  name   = "gemini"
+  role   = "developer:general"
+  model  = "google:gemini-3-pro"
+  prompt = "Solve this. Be complete and correct:\n{{input}}"
+
+[[steps]]
+name   = "judge"
+role   = "developer:general"
+prompt = """
+Independent solutions to the same task, one per model:
+
+{{candidates}}
+
+Pick the strongest, fix any flaws, and produce one final answer.
+"""
+```
+
+`{{candidates}}` (the block name) expands to all three branch outputs joined under
+`── opus ──`, `── gpt ──`, `── gemini ──` headers; or reference each branch directly
+as `{{opus}}` / `{{gpt}}` / `{{gemini}}`. Run it:
+
+```bash
+echo "JSON-to-CSV CLI in Rust" | octomind workflow config-templates/workflow-fanout.toml
 ```
 
 ## Best practices

--- a/doc/usage/09-workflows.md
+++ b/doc/usage/09-workflows.md
@@ -131,7 +131,7 @@ Every step prompt is resolved in **three passes**, in order, exactly like the in
 |--------------------|------------------------------------------------------------------------|
 | `{{input}}`        | The raw stdin content (trimmed)                                        |
 | `{{step_name}}`    | The full text output of a previously completed step (by name)          |
-| `{{parallel_step}}`| A parallel **block's** name → every sub-step's output joined; an expanded sub-step's name → all its replica outputs joined (see [Parallel](#parallel-parallel--true)) |
+| `{{parallel_step}}`| A parallel **block's** name → every sub-step's output joined; an expanded sub-step's name → all its replica outputs joined (see [Parallel](#parallel-parallel--true)). In a **dynamic parallel block** (with `match`), the block's own name is the *loop variable* — inside the template it resolves to this branch's matched item; the accumulated output is read downstream via the **sub-step's** name (see [Dynamic fan-out](#dynamic-fan-out-match)). |
 
 An unknown `{{var}}` is left **untouched** in this pass so the next pass can claim it as a built-in.
 
@@ -223,6 +223,44 @@ min_success = 2          # tolerate one failed branch
 - `{{<parallel-step-name>}}` — resolves to **every sub-step's (aggregated) output joined**, so an aggregator can reference the whole block at once instead of listing each branch. (Previously this name validated but resolved to empty; it now carries the joined content.)
 
 Failed replicas (under `min_success`) are skipped in both joins.
+
+#### Dynamic fan-out (`match`)
+
+Everything above is **static** — branches are fixed in the file. To fan out a
+**runtime-determined** number of branches (e.g. a planner step emits a list, and
+you want one branch per item), add a `match` regex to the parallel block. Its
+presence flips the block to **dynamic** mode:
+
+- `match` is a regex applied to the **previous step's output**. Each match is one branch.
+- The block has **exactly one** sub-step — the per-item template.
+- The block's own name is the **loop variable**. Inside the template, `{{<block-name>}}` resolves to *this branch's matched item* (one task). Each branch's output accumulates under the **sub-step's name**, so a later step reads `{{<sub-step-name>}}` to get *all branches joined*.
+- Item text = **capture group 1** of the regex (the regex must define one — `{{...}}`-style content). Trimmed; empty matches dropped.
+- Branch count is unknown until runtime, so concurrency / spend are bounded by the existing `max_parallel` and top-level `max_cost`; `min_success` is an absolute count.
+
+```toml
+[[steps]]
+name   = "plan"
+role   = "researcher:general"
+prompt = "Break this into independent research tasks, each wrapped in <task>…</task>:\n{{input}}"
+
+[[steps]]
+name         = "research"
+parallel     = true
+match        = "(?s)<task>(.*?)</task>"   # one branch per <task> block
+max_parallel = 4
+min_success  = 1
+  [[steps.run]]
+  name   = "researcher"
+  role   = "researcher:general"
+  prompt = "Research this task thoroughly:\n{{research}}"     # {{research}} = THIS branch's one task
+
+[[steps]]
+name   = "summary"
+role   = "developer:general"
+prompt = "Synthesize all findings:\n\n{{researcher}}"         # {{researcher}} = every branch's output joined
+```
+
+`(?s)` lets a task body span lines; `(.*?)` is non-greedy so each `<task>…</task>` is its own item. The two names play distinct roles: `{{research}}` (the block) is the loop variable — one matched task per branch — while `{{researcher}}` (the sub-step) is every branch's output accumulated. Downstream steps read the sub-step name to get the joined result; the block name is scoped to the template only. A ready-to-run copy is at [`config-templates/workflow-research.toml`](../../config-templates/workflow-research.toml).
 
 ### Loop (`loop = true`)
 Sub-steps run sequentially within each iteration. Between iterations, `exit_when` is checked against the named step's output:
@@ -327,6 +365,7 @@ Pre-flight checks (all hard-fail before any step runs):
 - `max_cost`, when set, is a positive finite number.
 - `count` appears only on parallel sub-steps and is ≥ 2.
 - `min_success`, when set, is between 1 and the block's total replica count; `max_parallel`, when set, is ≥ 1.
+- A parallel block with `match` (dynamic): the regex compiles, it has **exactly one** sub-step, is **not** the first step, and its template does not use `count`. `min_success` (when set) is ≥ 1.
 
 ## End-to-end example
 

--- a/doc/usage/09-workflows.md
+++ b/doc/usage/09-workflows.md
@@ -1,8 +1,8 @@
 # Workflows
 
-`octomind workflow <file.toml>` is an external orchestrator that chains multiple `octomind run` invocations into a multi-step process. Each step is an independent subprocess; outputs flow between steps by name; everything you see — per-step responses, progress, costs, totals — is written to **stderr** for a human to watch.
+`octomind workflow <file.toml>` is an external orchestrator that chains multiple `octomind run` invocations into a multi-step process. Each step is an independent subprocess; outputs flow between steps by name; per-step responses, progress, costs, and totals are written to **stderr** for a human to watch (stdout stays empty unless you pass `--format jsonl`).
 
-> **There is no machine-readable stdout result.** A real run prints nothing to stdout; stdout is used *only* by `--dry-run` to print the execution plan. Don't build shell pipelines that consume the workflow's stdout — they will get nothing. If you need a step's text downstream, read it from stderr or have the final step write to a file itself.
+> **By default a real run writes nothing to stdout** — the human view is on stderr, and stdout carries only the `--dry-run` plan. For a machine-readable result, pass **`--format jsonl`**: each step emits an `assistant` JSON line to stdout as it completes (the last is the final result), followed by an aggregated `cost` line (see [Machine-readable output](#machine-readable-output---format-jsonl)). Without that flag, a shell pipeline reading the workflow's stdout gets nothing — use `--format jsonl`, read stderr, or have the final step write a file itself.
 
 > **In-session input preprocessing** via `[[pipe]]` in `.agents/guardrails.toml` runs before the model — see [Guardrails](18-guardrails.md#pipe--pre-model-input-transform). Workflows sit *above* sessions; pipes sit *inside* one.
 
@@ -16,8 +16,8 @@ stdin ─► octomind workflow file.toml
                     └── step "tester"    → octomind run (subprocess)  ─┘  loop
                     │
                     ▼
-        stderr: per-step responses + progress, cost, tokens, totals
-        stdout: (nothing — only --dry-run prints the plan here)
+        stderr: per-step responses + progress, cost, tokens, totals (human)
+        stdout: empty by default · --format jsonl → per-step + cost events · --dry-run → plan
 ```
 
 A workflow file is a portable TOML document — no edits to `default.toml` or any role config are needed. Each step invokes `octomind run --format jsonl`, streams the JSONL event log, accumulates assistant text and cost/token totals, then hands the captured output to the next step.
@@ -33,7 +33,7 @@ octomind workflow myflow.toml --dry-run
 
 - The file is read, TOML-parsed, and fully validated **before** anything else — including before stdin is touched. `--dry-run` therefore never reads stdin.
 - stdin is required for a real run (not for `--dry-run`). Both a terminal stdin (nothing piped) and an empty piped stdin (empty after trimming) fail with the same error: `workflow requires input via stdin`.
-- stderr receives each step's assistant message (rendered as markdown when `enable_markdown_rendering` is on), progress lines, per-step stats, warnings, and the final total. **stdout carries nothing except the `--dry-run` plan.**
+- stderr receives each step's assistant message (rendered as markdown when `enable_markdown_rendering` is on), progress lines, per-step stats, warnings, and the final total — the human view. **stdout is empty by default**; pass `--format jsonl` for a machine-readable result on stdout (per-step `assistant` + final `cost` events — see [Machine-readable output](#machine-readable-output---format-jsonl)), or `--dry-run` to print the plan.
 
 ## File format
 
@@ -347,9 +347,24 @@ total · 15.5s  · $0.0305  · 6788 tok  · ⚒17
 
 > **Continue-session steps report per-invocation deltas.** A `session = "continue"` step's subprocess reports *cumulative* session cost/tokens every time it resumes (each loop iteration or retry). The orchestrator subtracts the per-step running baseline so the per-step line, the footer total, and `max_cost` each count a turn's spend exactly once — without this, an N-iteration refine loop would over-count cost ~N× (compounding). Fresh and parallel steps are a new session each invocation and are reported as-is.
 
+## Machine-readable output (`--format jsonl`)
+
+A plain run writes nothing to stdout — it is meant to be watched on stderr. To consume a workflow's result programmatically, pass `--format jsonl`:
+
+```bash
+echo "build a JSON-to-CSV CLI in Rust" | octomind workflow myflow.toml --format jsonl
+```
+
+stdout then carries newline-delimited JSON:
+
+- One `assistant` event **per step**, emitted as that step completes: `{"type":"assistant","content":"…","step":"<step-name>","session_id":""}`. The **last** `assistant` event is the workflow's final result. In a parallel block, one event is emitted per sub-step (keyed by sub-step name) carrying that sub-step's accumulated output; the block-level aggregate and a dynamic `match` block's loop variable are not emitted.
+- A single trailing `cost` event with the aggregated totals (`session_tokens`, `session_cost`, and the input/output/cache/reasoning token breakdown). Its `session_id` is empty — a workflow has no single resumable session.
+
+Per-step progress still goes to stderr in both modes. Only `jsonl` produces stdout output; any other `--format` value (or omitting it) leaves stdout empty.
+
 ## --dry-run
 
-`octomind workflow file.toml --dry-run` validates the file, resolves the execution graph, and prints the plan to **stdout** — the one and only thing a workflow ever writes to stdout. It spawns no `octomind run` processes and never reads stdin (validation runs before the stdin step, and `--dry-run` returns immediately after). Use it to sanity-check a workflow before paying for tokens.
+`octomind workflow file.toml --dry-run` validates the file, resolves the execution graph, and prints the plan to **stdout**. (That plan is the only stdout a *default* run produces; `--format jsonl` additionally streams per-step `assistant` + `cost` events — see above.) It spawns no `octomind run` processes and never reads stdin (validation runs before the stdin step, and `--dry-run` returns immediately after). Use it to sanity-check a workflow before paying for tokens.
 
 ## Validation
 
@@ -490,4 +505,3 @@ Intentionally not supported (use shell composition or call `octomind run` direct
 - Named workflow lookup by short name (explicit path only)
 - Cross-invocation session persistence for `continue` sessions
 - Step artifacts written to disk
-- Any machine-readable stdout result. Everything is human-facing on stderr; stdout only ever carries the `--dry-run` plan.

--- a/doc/use-cases/03-custom-development-workflow.md
+++ b/doc/use-cases/03-custom-development-workflow.md
@@ -104,7 +104,7 @@ A step **fails** when its `octomind run` subprocess exits non-zero, produces no 
 echo "fix the login bug" | octomind workflow dev.toml
 ```
 
-Each step's assistant message is rendered to **stderr** as it completes (with markdown rendering when enabled), alongside per-step timing, cost, and tokens. The run produces **no stdout** — see [Key Points](#key-points). A run looks like this (color stripped):
+Each step's assistant message is rendered to **stderr** as it completes (with markdown rendering when enabled), alongside per-step timing, cost, and tokens. A plain run produces **no stdout** (pass `--format jsonl` for a machine-readable result on stdout) — see [Key Points](#key-points). A run looks like this (color stripped):
 
 ```
 workflow · dev
@@ -204,7 +204,7 @@ Each step is a separate `octomind run` invocation, so you can match the model to
 - If a loop reaches `max_iterations` without `exit_when` matching, it prints a `⚠ … reached max_iterations` warning to stderr and continues with the last iteration's outputs — the workflow does **not** fail
 - A step **fails** on non-zero exit, empty assistant output, or `timeout`. `retries = N` gives `N+1` total attempts; when all are exhausted the workflow exits non-zero with `step '<name>' failed after <N> attempts: <reason>`
 - Stdin → `{{input}}`; each step's last assistant message prints to **stderr** as it completes (with markdown rendering when enabled)
-- All progress, timing, cost, tokens also print to **stderr**; a real run produces **no stdout**
-- `--dry-run` validates the file and prints the execution plan to **stdout** (the only stdout the command ever produces), then exits — it never reads stdin and spawns no sessions
+- All progress, timing, cost, tokens print to **stderr**; a plain run produces **no stdout** — pass `--format jsonl` to stream per-step `assistant` + a final `cost` event to stdout for machine parsing
+- `--dry-run` validates the file and prints the execution plan to **stdout** (the only stdout a *default* run produces; `--format jsonl` adds per-step + cost events), then exits — it never reads stdin and spawns no sessions
 - Pre-flight validation (before any step runs) rejects: empty workflows, duplicate step names, a step named `input` (reserved), forward references to a not-yet-completed step, parallel blocks with fewer than 2 sub-steps, loops missing `exit_when`, an invalid `matches` regex, and an empty `model` string
 - This page covers sequential and loop steps; for **parallel** and **conditional** steps see [Workflows](../usage/09-workflows.md#step-types)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -60,6 +60,12 @@ pub struct RunArgs {
 	/// Can be specified multiple times for multiple hooks.
 	#[arg(long = "hook", value_name = "NAME")]
 	pub hooks: Vec<String>,
+
+	/// Enforce structured output: path to a JSON Schema file. The model's final
+	/// response is constrained to match it. Fails if the resolved model has no
+	/// structured-output support.
+	#[arg(long = "schema", value_name = "PATH")]
+	pub schema: Option<String>,
 }
 pub async fn execute(args: &RunArgs, config: &Config) -> Result<()> {
 	// Daemon mode: no spinner, but still use readline if terminal input available.
@@ -78,6 +84,13 @@ pub async fn execute(args: &RunArgs, config: &Config) -> Result<()> {
 		None
 	};
 
+	// Load + validate the structured-output schema file (if any) before init.
+	// Model-capability support is checked once the session resolves a model.
+	let schema = match &args.schema {
+		Some(path) => Some(session::load_structured_output_schema(path)?),
+		None => None,
+	};
+
 	// Resolve config and role (tap/dep resolution only — MCP init happens after session ID is set)
 	let (run_config, role) =
 		octomind::agent::resolver::resolve_config_and_role(args.tag.as_deref(), config, None)
@@ -92,6 +105,7 @@ pub async fn execute(args: &RunArgs, config: &Config) -> Result<()> {
 		model: args.model.clone(),
 		daemon: args.daemon,
 		hooks: args.hooks.clone(),
+		schema,
 		..Default::default()
 	};
 

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -45,9 +45,10 @@ pub struct WorkflowArgs {
 	#[arg(long)]
 	pub dry_run: bool,
 
-	/// Output format for the final result on stdout. With `jsonl`, emit
-	/// structured `assistant` (final result) and `cost` (aggregated totals)
-	/// events for machine parsing. Per-step progress always goes to stderr.
+	/// Machine-readable output on stdout. With `jsonl`, emit one structured
+	/// `assistant` event per step as it completes (the last is the final result)
+	/// plus a trailing aggregated `cost` event. Without it, stdout is empty
+	/// (except the `--dry-run` plan). Per-step progress always goes to stderr.
 	#[arg(long = "format")]
 	pub format: Option<String>,
 }

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -197,14 +197,23 @@ fn print_step(idx: usize, step: &Step, depth: usize) {
 			println!("{indent}   prompt: {}", truncate(&s.prompt, 120));
 		}
 		Step::Parallel(p) => {
+			let kind = if p.match_pattern.is_some() {
+				"[parallel · dynamic]"
+			} else {
+				"[parallel]"
+			};
 			println!(
 				"{indent}{idx}. {name}  {kind}",
 				idx = idx,
 				name = p.name.bright_white(),
-				kind = "[parallel]".bright_magenta(),
+				kind = kind.bright_magenta(),
 			);
-			let total: u32 = p.run.iter().map(|s| s.replica_count()).sum();
-			let mut meta = format!("sub-steps={}  total_runs={total}", p.run.len());
+			let mut meta = if let Some(pat) = &p.match_pattern {
+				format!("match={pat:?}  runs=per-match (over previous step)")
+			} else {
+				let total: u32 = p.run.iter().map(|s| s.replica_count()).sum();
+				format!("sub-steps={}  total_runs={total}", p.run.len())
+			};
 			if let Some(m) = p.min_success {
 				meta = format!("{meta}  min_success={m}");
 			}

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -203,6 +203,15 @@ fn print_step(idx: usize, step: &Step, depth: usize) {
 				name = p.name.bright_white(),
 				kind = "[parallel]".bright_magenta(),
 			);
+			let total: u32 = p.run.iter().map(|s| s.replica_count()).sum();
+			let mut meta = format!("sub-steps={}  total_runs={total}", p.run.len());
+			if let Some(m) = p.min_success {
+				meta = format!("{meta}  min_success={m}");
+			}
+			if let Some(mp) = p.max_parallel {
+				meta = format!("{meta}  max_parallel={mp}");
+			}
+			println!("{indent}   {meta}");
 			for (i, sub) in p.run.iter().enumerate() {
 				print_sub(i + 1, sub, depth + 1);
 			}
@@ -260,6 +269,9 @@ fn print_sub(idx: usize, s: &octomind::workflow::schema::Sequential, depth: usiz
 	}
 	if let Some(w) = &s.workdir {
 		meta = format!("{meta}  workdir={w}");
+	}
+	if let Some(c) = s.count {
+		meta = format!("{meta}  count={c}");
 	}
 	println!(
 		"{indent}{idx}. {name}  {meta}",

--- a/src/session/chat/response/tool_result_processor.rs
+++ b/src/session/chat/response/tool_result_processor.rs
@@ -497,6 +497,16 @@ async fn make_follow_up_api_call(
 	)
 	.with_max_retries(chat_session.max_retries)
 	.with_cancellation_token(cancellation_token);
+
+	// Carry the structured-output schema onto every follow-up turn too. Without
+	// this the schema only applies to the first call (which returns a tool call,
+	// not the answer), so the final post-tool reply is unconstrained. The schema
+	// is native `response_format` and coexists with tool calling.
+	let validation_params = if let Some(schema) = chat_session.schema.clone() {
+		validation_params.with_schema(schema)
+	} else {
+		validation_params
+	};
 	crate::session::chat_completion_with_validation(validation_params).await
 }
 

--- a/src/session/chat/session/params.rs
+++ b/src/session/chat/session/params.rs
@@ -35,6 +35,10 @@ pub struct GenericSessionArgs {
 	pub daemon: bool,
 	/// Webhook hook names to activate for this session.
 	pub hooks: Vec<String>,
+	/// Optional JSON Schema for structured output (set via `run --schema <path>`).
+	/// When present, the session's completions are constrained to match it. The
+	/// resolved model must support structured output or session setup fails.
+	pub schema: Option<serde_json::Value>,
 }
 
 impl GenericSessionArgs {

--- a/src/session/chat/session/setup.rs
+++ b/src/session/chat/session/setup.rs
@@ -116,6 +116,12 @@ pub async fn setup_and_initialize_session(
 		.or(role_config.model.as_deref())
 		.unwrap_or(&config.model);
 
+	// Fail fast: --schema enforcement needs a model that supports structured output.
+	// Checked before the spinner starts so the error surfaces cleanly.
+	if args.schema.is_some() {
+		crate::session::ensure_structured_output_support(effective_model)?;
+	}
+
 	// Print startup banner before the spinner so the icon stays visible above the
 	// transient spinner line. Interactive TTY + plain output mode only.
 	let banner_printed = is_interactive
@@ -281,6 +287,12 @@ pub async fn setup_and_initialize_session(
 			"Using runtime max_retries override: {}",
 			runtime_max_retries
 		);
+	}
+
+	// Apply structured-output schema override (from `run --schema <path>`). The
+	// model's capability was already validated above before the session started.
+	if let Some(schema) = &args.schema {
+		chat_session.schema = Some(schema.clone());
 	}
 
 	// Track if the first message has been processed through layers

--- a/src/session/completion.rs
+++ b/src/session/completion.rs
@@ -145,6 +145,12 @@ pub async fn chat_completion_with_validation(
 	// Parse the model string and get the appropriate provider
 	let (provider, actual_model) = ProviderFactory::get_provider_for_model(params.model)?;
 
+	// Fail fast if a schema is requested but the model can't enforce structured
+	// output. Covers mid-session model swaps that bypass the up-front setup check.
+	if params.schema.is_some() {
+		ensure_structured_output_support(params.model)?;
+	}
+
 	// Get maximum input tokens for this provider/model (actual context window)
 	let max_input_tokens = provider.get_max_input_tokens(&actual_model);
 
@@ -229,13 +235,9 @@ pub async fn chat_completion_with_provider(
 	// Parse the model string and get the appropriate provider
 	let (provider, actual_model) = ProviderFactory::get_provider_for_model(params.model)?;
 
-	// Fail fast if schema requested but provider doesn't support structured output
-	if params.schema.is_some() && !provider.supports_structured_output(&actual_model) {
-		return Err(anyhow::anyhow!(
-			"Provider '{}' does not support structured output for model '{}'. Remove the schema parameter or use a compatible provider.",
-			provider.name(),
-			actual_model
-		));
+	// Fail fast if a schema is requested but the model can't enforce structured output
+	if params.schema.is_some() {
+		ensure_structured_output_support(params.model)?;
 	}
 
 	let chat_params = ChatCompletionParams::new(
@@ -267,4 +269,105 @@ pub async fn chat_completion_with_provider(
 	Ok(crate::providers::convert_response_from_octolib(
 		octolib_response,
 	))
+}
+
+/// Validate that the provider for `model` can enforce structured output (JSON
+/// schema). Fails fast with a clear, actionable error otherwise. The single
+/// source of truth for the capability gate — used by the CLI `run --schema`
+/// path (checked up front in session setup) and both completion entry points.
+pub fn ensure_structured_output_support(model: &str) -> Result<()> {
+	let (provider, actual_model) = ProviderFactory::get_provider_for_model(model)?;
+	if !provider.supports_structured_output(&actual_model) {
+		return Err(anyhow::anyhow!(
+			"Model '{model}' (provider '{}') does not support structured output — a JSON schema cannot be enforced. Use a structured-output-capable model.",
+			provider.name()
+		));
+	}
+	Ok(())
+}
+
+/// Load and validate a JSON Schema document from `path` (for `run --schema`).
+/// Reads the file, parses it as JSON, and requires a top-level object — the only
+/// shape usable for structured output. Finer schema errors surface via the
+/// provider's strict-mode validation at request time.
+pub fn load_structured_output_schema(path: &str) -> Result<serde_json::Value> {
+	let raw = std::fs::read_to_string(path)
+		.map_err(|e| anyhow::anyhow!("Failed to read schema file '{path}': {e}"))?;
+	let schema: serde_json::Value = serde_json::from_str(&raw)
+		.map_err(|e| anyhow::anyhow!("Invalid JSON in schema file '{path}': {e}"))?;
+	if !schema.is_object() {
+		return Err(anyhow::anyhow!(
+			"Schema file '{path}' must contain a JSON object (a JSON Schema document)"
+		));
+	}
+	Ok(schema)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{ensure_structured_output_support, load_structured_output_schema};
+	use std::io::Write;
+
+	#[test]
+	fn structured_output_supported_for_openai() {
+		// OpenAI reports structured-output support for all of its models.
+		assert!(ensure_structured_output_support("openai:gpt-4.1").is_ok());
+	}
+
+	#[test]
+	fn structured_output_unsupported_for_anthropic() {
+		let err = ensure_structured_output_support("anthropic:claude-sonnet-4-6")
+			.expect_err("anthropic must be rejected")
+			.to_string();
+		assert!(
+			err.contains("does not support structured output"),
+			"unexpected error: {err}"
+		);
+	}
+
+	#[test]
+	fn loads_valid_object_schema() {
+		let mut f = tempfile::NamedTempFile::new().unwrap();
+		f.write_all(br#"{"type":"object","properties":{"x":{"type":"string"}}}"#)
+			.unwrap();
+		f.flush().unwrap();
+		let schema = load_structured_output_schema(f.path().to_str().unwrap()).unwrap();
+		assert_eq!(schema["type"].as_str(), Some("object"));
+	}
+
+	#[test]
+	fn rejects_non_object_schema() {
+		let mut f = tempfile::NamedTempFile::new().unwrap();
+		f.write_all(b"[1, 2, 3]").unwrap();
+		f.flush().unwrap();
+		let err = load_structured_output_schema(f.path().to_str().unwrap())
+			.expect_err("array must be rejected")
+			.to_string();
+		assert!(
+			err.contains("must contain a JSON object"),
+			"unexpected error: {err}"
+		);
+	}
+
+	#[test]
+	fn rejects_invalid_json() {
+		let mut f = tempfile::NamedTempFile::new().unwrap();
+		f.write_all(b"{not valid json").unwrap();
+		f.flush().unwrap();
+		let err = load_structured_output_schema(f.path().to_str().unwrap())
+			.expect_err("invalid json must be rejected")
+			.to_string();
+		assert!(err.contains("Invalid JSON"), "unexpected error: {err}");
+	}
+
+	#[test]
+	fn reports_missing_schema_file() {
+		let err = load_structured_output_schema("/nonexistent/path/schema-xyzzy.json")
+			.expect_err("missing file must error")
+			.to_string();
+		assert!(
+			err.contains("Failed to read schema file"),
+			"unexpected error: {err}"
+		);
+	}
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -456,7 +456,8 @@ pub mod prompt;
 pub use prompt::{add_compression_hints_to_prompt, create_system_prompt};
 pub mod completion;
 pub use completion::{
-	chat_completion_with_provider, chat_completion_with_validation, ChatCompletionProviderParams,
+	chat_completion_with_provider, chat_completion_with_validation,
+	ensure_structured_output_support, load_structured_output_schema, ChatCompletionProviderParams,
 	ChatCompletionWithValidationParams,
 };
 

--- a/src/workflow/run.rs
+++ b/src/workflow/run.rs
@@ -22,7 +22,9 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::Semaphore;
 use uuid::Uuid;
 
 use super::proc::{run_step, send_done, RunOutcome, RunStepArgs, StepStats};
@@ -377,58 +379,68 @@ impl Executor {
 	}
 
 	async fn exec_parallel(&mut self, p: &ParallelStep, input: &str) -> Result<()> {
-		// Substitute every sub-step's prompt up-front against the SAME
-		// outer scope — sub-steps cannot reference each other. Each
-		// substitution may touch disk (project context placeholders), so
-		// we collect sequentially before kicking off the parallel tasks.
-		// Workdirs resolve here too — a bad one fails the whole parallel
-		// step before any subprocess spawns.
-		let mut prepared: Vec<(Sequential, String, Option<PathBuf>)> =
-			Vec::with_capacity(p.run.len());
+		// Substitute every sub-step's prompt up-front against the SAME outer
+		// scope — sub-steps cannot reference each other. Substitution may touch
+		// disk (project context placeholders) and workdirs resolve here too, so a
+		// bad one fails the whole block before any subprocess spawns. Each
+		// sub-step then expands into its replicas (`count` / `models`).
+		let mut replicas: Vec<PreparedReplica> = Vec::new();
 		for s in &p.run {
-			let resolved = self.substitute(&s.prompt, input, &s.role).await;
+			let prompt = self.substitute(&s.prompt, input, &s.role).await;
 			let workdir = resolve_workdir(&s.name, s.workdir.as_deref())?;
-			prepared.push((s.clone(), resolved, workdir));
+			for rep in expand_substep(s) {
+				replicas.push(PreparedReplica {
+					base: s.name.clone(),
+					label: rep.label,
+					seq: rep.seq,
+					prompt: prompt.clone(),
+					workdir: workdir.clone(),
+				});
+			}
 		}
 
-		// We can't borrow &mut self across the join, so run each sub-step
-		// in isolation here and collect into a tiny snapshot.
-		// Implementation: launch all in parallel using join_all, but each
-		// task owns its own Sequential copy and we DON'T touch self.
+		let total = replicas.len();
+		// `max_parallel` throttles concurrency via a semaphore; None = unbounded.
+		let sem = p.max_parallel.map(|n| Arc::new(Semaphore::new(n.max(1))));
+
+		// We can't borrow &mut self across the join, so each task owns its own
+		// data and we DON'T touch self. Parallel sub-steps always get a fresh
+		// session — `session = "continue"` only makes sense across loop iters.
 		let mut handles = Vec::new();
-		for (s, prompt, workdir) in prepared {
-			let sname = s.name.clone();
-			let role = s.role.clone();
-			let timeout = s.timeout;
-			let retries = s.retries;
-			let model = s.model.clone();
-			// Parallel sub-steps cannot use `session = "continue"` semantics
-			// across iterations of an outer loop because there is no outer
-			// loop concept here — they get fresh sessions per call.
+		for r in replicas {
+			let sem = sem.clone();
 			handles.push(tokio::spawn(async move {
+				let _permit = match &sem {
+					Some(s) => Some(s.clone().acquire_owned().await.expect("semaphore open")),
+					None => None,
+				};
+				let max_attempts = r.seq.retries + 1;
 				let mut last_err: Option<String> = None;
-				let max_attempts = retries + 1;
 				for attempt in 1..=max_attempts {
 					let args = RunStepArgs {
-						role: role.clone(),
-						prompt: prompt.clone(),
+						role: r.seq.role.clone(),
+						prompt: r.prompt.clone(),
 						session_name: None,
-						model: model.clone(),
-						workdir: workdir.clone(),
-						timeout_secs: timeout,
+						model: r.seq.model.clone(),
+						workdir: r.workdir.clone(),
+						timeout_secs: r.seq.timeout,
 						event_prefix: None,
 						spinner: None,
 						wf_start: Instant::now(),
 						prior_cost: 0.0,
 						prior_tools: 0,
 					};
-					let outcome = run_step(args).await;
-					match outcome {
-						RunOutcome::Ok(stats) => return Ok::<_, String>((sname, stats)),
-						RunOutcome::Empty(s) => {
+					match run_step(args).await {
+						RunOutcome::Ok(stats) => {
+							return ParallelResult {
+								base: r.base,
+								label: r.label,
+								outcome: Ok(stats),
+							}
+						}
+						RunOutcome::Empty(_) => {
 							last_err =
 								Some(format!("empty output (attempt {attempt}/{max_attempts})"));
-							let _ = s;
 						}
 						RunOutcome::NonZero { code, .. } => {
 							last_err = Some(format!(
@@ -446,48 +458,121 @@ impl Executor {
 						}
 					}
 				}
-				Err(format!("'{sname}' {}", last_err.unwrap_or_default()))
+				ParallelResult {
+					base: r.base,
+					label: r.label,
+					outcome: Err(last_err.unwrap_or_default()),
+				}
 			}));
 		}
 
+		let tag = if total == p.run.len() {
+			format!("({total} in parallel)")
+		} else {
+			format!("({} sub-steps → {total} runs in parallel)", p.run.len())
+		};
 		box_open(&format!(
 			"{name}  {tag}",
 			name = p.name.bright_white(),
-			tag = format!("({} in parallel)", p.run.len()).bright_black(),
+			tag = tag.bright_black(),
 		));
 
-		let results = futures::future::join_all(handles).await;
-		let mut sub_outputs: Vec<(String, String)> = Vec::new();
-		for r in results {
-			match r {
-				Ok(Ok((name, stats))) => {
+		// Group results by sub-step base name in declaration order so a base's
+		// replicas aggregate together and the block aggregates bases in order.
+		let mut by_base: Vec<(String, Vec<(String, String)>)> =
+			p.run.iter().map(|s| (s.name.clone(), Vec::new())).collect();
+		let idx_of: HashMap<&str, usize> = p
+			.run
+			.iter()
+			.enumerate()
+			.map(|(i, s)| (s.name.as_str(), i))
+			.collect();
+
+		let mut succeeded = 0usize;
+		for res in futures::future::join_all(handles).await {
+			let res = match res {
+				Ok(r) => r,
+				Err(e) => bail!("parallel step '{}' panicked: {}", p.name, e),
+			};
+			match res.outcome {
+				Ok(stats) => {
 					box_line(&format!(
-						"{tick} {name}  {stats}",
+						"{tick} {label}  {stats}",
 						tick = "✓".green(),
-						name = name.bright_white(),
+						label = res.label.bright_white(),
 						stats = fmt_stats(&stats),
 					));
 					self.totals.add(&stats);
-					sub_outputs.push((name.clone(), stats.output.clone()));
-					self.outputs.insert(name.clone(), stats.output);
-					self.last_step = Some(name);
+					succeeded += 1;
+					by_base[idx_of[res.base.as_str()]]
+						.1
+						.push((res.label, stats.output));
 				}
-				Ok(Err(e)) => bail!("parallel step '{}' failed: {}", p.name, e),
-				Err(e) => bail!("parallel step '{}' panicked: {}", p.name, e),
+				Err(msg) => {
+					box_line(&format!(
+						"{cross} {label}  {msg}",
+						cross = "✗".red(),
+						label = res.label.bright_white(),
+						msg = msg.red(),
+					));
+				}
 			}
 		}
-		box_close_ok(&p.name.bright_white(), "done");
-		// Print each sub-step's response under a dim label so the user
-		// can see what each branch produced. Final blank line separates
-		// from the next top-level step.
-		for (name, out) in &sub_outputs {
+
+		// `min_success` (None = all) sets how many replicas must succeed.
+		let threshold = p.min_success.map_or(total, |m| m as usize);
+		if succeeded < threshold {
+			box_close_err(
+				&p.name.bright_white(),
+				&format!("{succeeded}/{total} succeeded (need {threshold})"),
+			);
+			eprintln!();
+			self.enforce_budget(&p.name)?;
+			bail!(
+				"parallel step '{}': only {}/{} replicas succeeded (min_success {})",
+				p.name,
+				succeeded,
+				total,
+				threshold,
+			);
+		}
+		box_close_ok(
+			&p.name.bright_white(),
+			&format!("{succeeded}/{total} succeeded"),
+		);
+
+		// Wire outputs. A base sub-step expanded into replicas (`count`/`models`)
+		// aggregates its replica outputs under `── label ──` headers; a single
+		// un-expanded sub-step maps straight to its raw output (legacy behaviour).
+		// The parallel step's own name aggregates every base — this is what makes
+		// `{{<parallel-step-name>}}` resolve (previously it leaked literally).
+		let mut block_parts: Vec<(String, String)> = Vec::new();
+		for (i, (base, reps)) in by_base.iter().enumerate() {
+			let expanded = p.run[i].replica_count() > 1;
+			let agg = if reps.is_empty() {
+				String::new()
+			} else if expanded {
+				join_labeled(reps)
+			} else {
+				reps[0].1.clone()
+			};
+			self.outputs.insert(base.clone(), agg.clone());
+			block_parts.push((base.clone(), agg));
+		}
+		self.outputs
+			.insert(p.name.clone(), join_labeled(&block_parts));
+		self.last_step = Some(p.name.clone());
+
+		// Print each base's aggregated response under a dim label + emit jsonl.
+		for (base, _) in &by_base {
+			let out = self.outputs.get(base).cloned().unwrap_or_default();
 			let t = out.trim();
 			if !t.is_empty() {
 				eprintln!();
-				eprintln!("{}", format!("── {name} ──").bright_black());
+				eprintln!("{}", format!("── {base} ──").bright_black());
 				print_response(t, self.markdown_enabled, &self.markdown_theme);
 			}
-			self.emit_step(name, out);
+			self.emit_step(base, &out);
 		}
 		eprintln!();
 		self.enforce_budget(&p.name)?;
@@ -613,6 +698,62 @@ fn resolve_workdir(step_name: &str, workdir: Option<&str>) -> Result<Option<Path
 		);
 	}
 	Ok(Some(abs))
+}
+
+/// One concrete run produced by expanding a parallel sub-step.
+struct Replica {
+	/// Human-facing label shown in progress lines / response headers.
+	label: String,
+	/// The sub-step to run, with its model forced for `models`-mode replicas.
+	seq: Sequential,
+}
+
+/// A [`Replica`] with its prompt and workdir resolved, ready to spawn.
+struct PreparedReplica {
+	/// The declaring sub-step's name — replicas of the same base aggregate
+	/// under it.
+	base: String,
+	label: String,
+	seq: Sequential,
+	prompt: String,
+	workdir: Option<PathBuf>,
+}
+
+/// Result handed back from a spawned replica task.
+struct ParallelResult {
+	base: String,
+	label: String,
+	outcome: std::result::Result<StepStats, String>,
+}
+
+/// Expand a parallel sub-step into its replicas:
+/// - `count = N` → N identical replicas (same role/model/prompt) for best-of-N
+/// - none        → the single step as-is
+fn expand_substep(s: &Sequential) -> Vec<Replica> {
+	if let Some(c) = s.count {
+		(1..=c)
+			.map(|i| Replica {
+				label: format!("{} #{i}", s.name),
+				seq: s.clone(),
+			})
+			.collect()
+	} else {
+		vec![Replica {
+			label: s.name.clone(),
+			seq: s.clone(),
+		}]
+	}
+}
+
+/// Join labeled outputs with `── label ──` headers, blank-line separated.
+/// Entries whose output trims to empty (e.g. a failed replica) are skipped.
+fn join_labeled(parts: &[(String, String)]) -> String {
+	parts
+		.iter()
+		.filter(|(_, out)| !out.trim().is_empty())
+		.map(|(label, out)| format!("── {label} ──\n{}", out.trim()))
+		.collect::<Vec<_>>()
+		.join("\n\n")
 }
 
 /// Subtract `base` (the last cumulative snapshot for a continue-session step)
@@ -905,6 +1046,52 @@ mod tests {
 		let summed = d1.cost + d2.cost + d3.cost;
 		assert!((summed - 0.45).abs() < 1e-9, "summed={summed}");
 		assert_eq!(d1.total_tokens + d2.total_tokens + d3.total_tokens, 450);
+	}
+
+	fn seq(name: &str) -> Sequential {
+		Sequential {
+			name: name.to_string(),
+			role: "developer:general".to_string(),
+			prompt: "{{input}}".to_string(),
+			session: SessionMode::Fresh,
+			timeout: 0,
+			retries: 0,
+			model: None,
+			workdir: None,
+			count: None,
+		}
+	}
+
+	#[test]
+	fn expand_count_replicates_with_own_model() {
+		let mut s = seq("candidate");
+		s.count = Some(3);
+		s.model = Some("openai:gpt-5".into());
+		let reps = expand_substep(&s);
+		assert_eq!(reps.len(), 3);
+		assert!(reps
+			.iter()
+			.all(|r| r.seq.model.as_deref() == Some("openai:gpt-5")));
+		assert_eq!(reps[2].label, "candidate #3");
+	}
+
+	#[test]
+	fn expand_none_is_single_passthrough() {
+		let reps = expand_substep(&seq("solo"));
+		assert_eq!(reps.len(), 1);
+		assert_eq!(reps[0].label, "solo");
+		assert!(reps[0].seq.model.is_none());
+	}
+
+	#[test]
+	fn join_labeled_skips_empty_and_headers_rest() {
+		let parts = vec![
+			("a".to_string(), "one".to_string()),
+			("b".to_string(), "   ".to_string()),
+			("c".to_string(), "two".to_string()),
+		];
+		let joined = join_labeled(&parts);
+		assert_eq!(joined, "── a ──\none\n\n── c ──\ntwo");
 	}
 
 	#[test]

--- a/src/workflow/run.rs
+++ b/src/workflow/run.rs
@@ -186,8 +186,19 @@ impl Executor {
 	///    file contents rendered as XML, same as chat's compression /
 	///    file-context path. Lets a step emit a context block in its
 	///    response and have the next step receive the inlined file.
+	///
+	/// Substitution reads `self.outputs`; it does not mutate it. In a dynamic
+	/// `match` block the executor binds the block's own name to each branch's
+	/// matched item (the loop variable) for that branch's substitution; the
+	/// accumulated output lands under the sub-step's name. From this function's
+	/// perspective, all of that is just `self.outputs.get(name)`.
 	async fn substitute(&self, prompt: &str, input: &str, role: &str) -> String {
 		let re = validate::var_regex();
+		// `{{name}}` resolves against `self.outputs`; `{{input}}` resolves to the
+		// workflow stdin. That is the entire substitution contract. A dynamic
+		// `match` block manages `self.outputs` itself: the block name holds the
+		// per-branch item during fan-out; each branch's output accumulates under
+		// the sub-step's name. This function does not know about any of that.
 		let after_wf = re
 			.replace_all(prompt, |caps: &regex::Captures| {
 				let var = &caps[1];
@@ -379,23 +390,78 @@ impl Executor {
 	}
 
 	async fn exec_parallel(&mut self, p: &ParallelStep, input: &str) -> Result<()> {
-		// Substitute every sub-step's prompt up-front against the SAME outer
-		// scope — sub-steps cannot reference each other. Substitution may touch
-		// disk (project context placeholders) and workdirs resolve here too, so a
-		// bad one fails the whole block before any subprocess spawns. Each
-		// sub-step then expands into its replicas (`count` / `models`).
+		// Build the branch list, substituting prompts up-front against the SAME
+		// outer scope (sub-steps cannot reference each other). Substitution may
+		// touch disk and workdirs resolve here too, so a bad one fails the whole
+		// block before any subprocess spawns. Two sourcing modes:
+		//   - dynamic (`match` set): `match` splits the previous step's output
+		//     into items and loops the single listed sub-step over them. The
+		//     block's own name is the loop variable: for each branch the executor
+		//     binds `self.outputs[block_name]` to that branch's matched item, so
+		//     the template's `{{<block_name>}}` resolves to the one task. Each
+		//     branch's output accumulates under the sub-step's name — that is what
+		//     downstream steps read.
+		//   - static: each listed sub-step, expanded by its `count`.
+		let is_dynamic = p.match_pattern.is_some();
 		let mut replicas: Vec<PreparedReplica> = Vec::new();
-		for s in &p.run {
-			let prompt = self.substitute(&s.prompt, input, &s.role).await;
-			let workdir = resolve_workdir(&s.name, s.workdir.as_deref())?;
-			for rep in expand_substep(s) {
+		if let Some(pattern) = &p.match_pattern {
+			// Pre-flight guarantees exactly one sub-step and a non-first step.
+			let template = &p.run[0];
+			let source_name = self
+				.last_step
+				.as_ref()
+				.expect("validator guarantees a preceding step for dynamic parallel");
+			let source = self
+				.outputs
+				.get(source_name)
+				.expect("preceding step output exists");
+			let re = Regex::new(pattern).map_err(|e| {
+				anyhow::anyhow!("dynamic parallel '{}': invalid match regex: {e}", p.name)
+			})?;
+			let items = extract_items(&re, source);
+			if items.is_empty() {
+				bail!(
+					"dynamic parallel '{}': match pattern found 0 items in '{}' output",
+					p.name,
+					source_name,
+				);
+			}
+			let workdir = resolve_workdir(&template.name, template.workdir.as_deref())?;
+			for (i, item) in items.iter().enumerate() {
+				// The block's own name is the loop variable: bind it to this
+				// branch's matched item so the template's `{{<block_name>}}`
+				// resolves to the one task. The branch's output is collected and
+				// accumulated under the sub-step's name once all branches finish.
+				self.outputs.insert(p.name.clone(), item.clone());
+				let prompt = self
+					.substitute(&template.prompt, input, &template.role)
+					.await;
+				// One replica per match. `count` on the dynamic template is
+				// ignored — the number of replicas is exactly the number of
+				// matches, which is the user's knob for fan-out. Labels stay
+				// stable: "researcher #1", "researcher #2", ... regardless of
+				// `count`.
 				replicas.push(PreparedReplica {
-					base: s.name.clone(),
-					label: rep.label,
-					seq: rep.seq,
-					prompt: prompt.clone(),
+					base: template.name.clone(),
+					label: format!("{} #{}", template.name, i + 1),
+					seq: template.clone(),
+					prompt,
 					workdir: workdir.clone(),
 				});
+			}
+		} else {
+			for s in &p.run {
+				let prompt = self.substitute(&s.prompt, input, &s.role).await;
+				let workdir = resolve_workdir(&s.name, s.workdir.as_deref())?;
+				for rep in expand_substep(s) {
+					replicas.push(PreparedReplica {
+						base: s.name.clone(),
+						label: rep.label,
+						seq: rep.seq,
+						prompt: prompt.clone(),
+						workdir: workdir.clone(),
+					});
+				}
 			}
 		}
 
@@ -466,7 +532,9 @@ impl Executor {
 			}));
 		}
 
-		let tag = if total == p.run.len() {
+		let tag = if is_dynamic {
+			format!("({total} items in parallel)")
+		} else if total == p.run.len() {
 			format!("({total} in parallel)")
 		} else {
 			format!("({} sub-steps → {total} runs in parallel)", p.run.len())
@@ -541,14 +609,13 @@ impl Executor {
 			&format!("{succeeded}/{total} succeeded"),
 		);
 
-		// Wire outputs. A base sub-step expanded into replicas (`count`/`models`)
-		// aggregates its replica outputs under `── label ──` headers; a single
-		// un-expanded sub-step maps straight to its raw output (legacy behaviour).
-		// The parallel step's own name aggregates every base — this is what makes
-		// `{{<parallel-step-name>}}` resolve (previously it leaked literally).
+		// Wire outputs. Each sub-step's OUTPUT is stored under its OWN name:
+		// replicas (`count`, or dynamic `match` items) accumulate with
+		// `── label ──` headers; a single un-expanded sub-step maps straight to
+		// its raw output.
 		let mut block_parts: Vec<(String, String)> = Vec::new();
 		for (i, (base, reps)) in by_base.iter().enumerate() {
-			let expanded = p.run[i].replica_count() > 1;
+			let expanded = is_dynamic || p.run[i].replica_count() > 1;
 			let agg = if reps.is_empty() {
 				String::new()
 			} else if expanded {
@@ -559,9 +626,23 @@ impl Executor {
 			self.outputs.insert(base.clone(), agg.clone());
 			block_parts.push((base.clone(), agg));
 		}
-		self.outputs
-			.insert(p.name.clone(), join_labeled(&block_parts));
-		self.last_step = Some(p.name.clone());
+		if is_dynamic {
+			// Dynamic `match`: the block's own name is the loop variable (each
+			// branch's matched item, bound per branch above) — NOT an output. The
+			// accumulated result lives under the sub-step's name, so downstream
+			// steps read that; `last_step` points there too.
+			self.last_step = Some(by_base[0].0.clone());
+		} else {
+			// Static: the block's own name aggregates every sub-step so
+			// `{{<block-name>}}` resolves to all of them joined.
+			let block_agg = if block_parts.len() == 1 {
+				block_parts[0].1.clone()
+			} else {
+				join_labeled(&block_parts)
+			};
+			self.outputs.insert(p.name.clone(), block_agg);
+			self.last_step = Some(p.name.clone());
+		}
 
 		// Print each base's aggregated response under a dim label + emit jsonl.
 		for (base, _) in &by_base {
@@ -743,6 +824,16 @@ fn expand_substep(s: &Sequential) -> Vec<Replica> {
 			seq: s.clone(),
 		}]
 	}
+}
+
+/// Extract dynamic-fan-out items from `source` with `re`: one per match, the
+/// first capture group (the regex must define one — `{{...}}`-style content).
+/// Trimmed; empty items dropped.
+fn extract_items(re: &Regex, source: &str) -> Vec<String> {
+	re.captures_iter(source)
+		.filter_map(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
+		.filter(|s| !s.is_empty())
+		.collect()
 }
 
 /// Join labeled outputs with `── label ──` headers, blank-line separated.
@@ -1081,6 +1172,33 @@ mod tests {
 		assert_eq!(reps.len(), 1);
 		assert_eq!(reps[0].label, "solo");
 		assert!(reps[0].seq.model.is_none());
+	}
+
+	#[test]
+	fn extract_items_xml_capture_group() {
+		let re = Regex::new(r"(?s)<task>(.*?)</task>").unwrap();
+		let src = "Here are tasks:\n<task>research A\nspanning lines</task>\nnoise\n<task>research B</task>";
+		let items = extract_items(&re, src);
+		assert_eq!(items, vec!["research A\nspanning lines", "research B"]);
+	}
+
+	#[test]
+	fn extract_items_requires_capture_group() {
+		// No capture group → the regex matches but produces no items, because
+		// the caller has to express what part of the match is the item.
+		let re = Regex::new(r"\d+").unwrap();
+		assert!(extract_items(&re, "a1 b22 c333").is_empty());
+
+		// A capture group on a similar pattern yields the groups.
+		let re2 = Regex::new(r"(\d+)").unwrap();
+		assert_eq!(extract_items(&re2, "a1 b22 c333"), vec!["1", "22", "333"]);
+	}
+
+	#[test]
+	fn extract_items_skips_empty() {
+		let re = Regex::new(r"(?s)<t>(.*?)</t>").unwrap();
+		let items = extract_items(&re, "<t>keep</t><t>   </t><t>also</t>");
+		assert_eq!(items, vec!["keep", "also"]);
 	}
 
 	#[test]

--- a/src/workflow/schema.rs
+++ b/src/workflow/schema.rs
@@ -62,6 +62,21 @@ pub struct Sequential {
 	/// None = inherit the orchestrator's cwd.
 	#[serde(default)]
 	pub workdir: Option<String>,
+	/// Parallel-only: run this sub-step `count` times unchanged — same role,
+	/// model, and prompt. The model is non-deterministic, so the runs differ
+	/// (best-of-N sampling); shorthand for copy-pasting an identical block.
+	/// Must be >= 2. Rejected on non-parallel steps. None = a single run. For
+	/// different models or different prompts, write explicit named sub-steps —
+	/// each carries its own `model`/`prompt`.
+	#[serde(default)]
+	pub count: Option<u32>,
+}
+
+impl Sequential {
+	/// How many parallel replicas this sub-step expands to (1 unless `count` set).
+	pub fn replica_count(&self) -> u32 {
+		self.count.unwrap_or(1)
+	}
 }
 
 /// Pattern test against a step's output.
@@ -92,6 +107,14 @@ pub enum Step {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ParallelStep {
 	pub name: String,
+	/// Minimum number of replicas (counted across the whole block, after
+	/// `count`/`models` expansion) that must succeed for the block to pass.
+	/// None = strict: every replica must succeed.
+	#[serde(default)]
+	pub min_success: Option<u32>,
+	/// Cap on how many replicas run concurrently. None = unbounded (all at once).
+	#[serde(default)]
+	pub max_parallel: Option<usize>,
 	pub run: Vec<Sequential>,
 }
 

--- a/src/workflow/schema.rs
+++ b/src/workflow/schema.rs
@@ -107,8 +107,18 @@ pub enum Step {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ParallelStep {
 	pub name: String,
+	/// Dynamic fan-out: a regex applied to the PREVIOUS step's output, splitting
+	/// it into items (capture group 1 of each match; the regex must define one).
+	/// Each item becomes one branch running the single sub-step template. The
+	/// block's OWN name is the loop variable — within each branch it resolves to
+	/// that branch's item, so the template references `{{<block-name>}}` to get
+	/// the one task. The accumulated output lands under the sub-step's name.
+	/// Presence switches the block from static (the listed sub-steps) to dynamic
+	/// (one branch per match).
+	#[serde(default, rename = "match")]
+	pub match_pattern: Option<String>,
 	/// Minimum number of replicas (counted across the whole block, after
-	/// `count`/`models` expansion) that must succeed for the block to pass.
+	/// `count`/`match` expansion) that must succeed for the block to pass.
 	/// None = strict: every replica must succeed.
 	#[serde(default)]
 	pub min_success: Option<u32>,

--- a/src/workflow/validate.rs
+++ b/src/workflow/validate.rs
@@ -84,14 +84,37 @@ fn structural_check(step: &Step) -> Result<()> {
 	match step {
 		Step::Sequential(s) => {
 			validate_fields(s)?;
+			reject_expansion(s)?;
 			Ok(())
 		}
-		Step::Parallel(ParallelStep { name, run }) => {
+		Step::Parallel(ParallelStep {
+			name,
+			run,
+			min_success,
+			max_parallel,
+		}) => {
 			if run.len() < 2 {
 				bail!("parallel step '{}' must have at least 2 sub-steps", name);
 			}
 			for s in run {
 				validate_fields(s)?;
+				validate_expansion(s)?;
+			}
+			let total: u32 = run.iter().map(|s| s.replica_count()).sum();
+			if let Some(m) = min_success {
+				if *m == 0 || *m > total {
+					bail!(
+						"parallel step '{}': min_success {} must be between 1 and {} (total replicas)",
+						name,
+						m,
+						total
+					);
+				}
+			}
+			if let Some(mp) = max_parallel {
+				if *mp == 0 {
+					bail!("parallel step '{}': max_parallel must be >= 1", name);
+				}
 			}
 			Ok(())
 		}
@@ -106,6 +129,7 @@ fn structural_check(step: &Step) -> Result<()> {
 			}
 			for s in run {
 				validate_fields(s)?;
+				reject_expansion(s)?;
 			}
 			let exit_when = match exit_when {
 				Some(c) => c,
@@ -168,6 +192,7 @@ fn structural_check(step: &Step) -> Result<()> {
 			}
 			for s in run {
 				validate_fields(s)?;
+				reject_expansion(s)?;
 			}
 			Ok(())
 		}
@@ -184,6 +209,32 @@ fn validate_fields(s: &Sequential) -> Result<()> {
 		if w.trim().is_empty() {
 			bail!(
 				"step '{}': workdir must not be empty when specified",
+				s.name
+			);
+		}
+	}
+	Ok(())
+}
+
+/// `count` fans a sub-step into replicas — only meaningful inside a parallel
+/// block. Reject it anywhere else so the config fails loudly rather than
+/// silently ignoring the field.
+fn reject_expansion(s: &Sequential) -> Result<()> {
+	if s.count.is_some() {
+		bail!(
+			"step '{}': 'count' is only valid on parallel sub-steps",
+			s.name
+		);
+	}
+	Ok(())
+}
+
+/// Validate the `count` fan-out field on a parallel sub-step.
+fn validate_expansion(s: &Sequential) -> Result<()> {
+	if let Some(c) = s.count {
+		if c < 2 {
+			bail!(
+				"step '{}': count must be >= 2 (omit it for a single run)",
 				s.name
 			);
 		}
@@ -403,6 +454,123 @@ mod tests {
 			"#,
 		);
 		validate(&ok).expect("positive max_cost should pass");
+	}
+
+	#[test]
+	fn count_sweep_in_parallel_validates() {
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "candidates"
+			parallel = true
+			min_success = 2
+			  [[steps.run]]
+			  name = "candidate"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			  count = 3
+			  [[steps.run]]
+			  name = "other"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			"#,
+		);
+		validate(&wf).expect("count sweep + min_success in range should pass");
+	}
+
+	#[test]
+	fn expansion_fields_rejected_outside_parallel() {
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "s1"
+			role = "developer:general"
+			prompt = "{{input}}"
+			count = 3
+			"#,
+		);
+		let err = validate(&wf).expect_err("count on a sequential step must fail");
+		assert!(
+			err.to_string().contains("only valid on parallel"),
+			"got: {err}"
+		);
+	}
+
+	#[test]
+	fn count_below_two_fails() {
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "p"
+			parallel = true
+			  [[steps.run]]
+			  name = "a"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			  count = 1
+			  [[steps.run]]
+			  name = "b"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			"#,
+		);
+		assert!(validate(&wf).is_err(), "count = 1 must fail");
+	}
+
+	#[test]
+	fn min_success_out_of_range_fails() {
+		// One sub-step with count = 2 + one plain sub-step = 3 total replicas.
+		// min_success = 4 exceeds that.
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "p"
+			parallel = true
+			min_success = 4
+			  [[steps.run]]
+			  name = "a"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			  count = 2
+			  [[steps.run]]
+			  name = "b"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			"#,
+		);
+		let err = validate(&wf).expect_err("min_success > total replicas must fail");
+		assert!(err.to_string().contains("min_success"), "got: {err}");
+	}
+
+	#[test]
+	fn parallel_block_name_reference_resolves() {
+		// The parallel block's own name is referenceable downstream (it now
+		// aggregates every sub-step's output at runtime).
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "candidates"
+			parallel = true
+			  [[steps.run]]
+			  name = "a"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			  [[steps.run]]
+			  name = "b"
+			  role = "developer:general"
+			  prompt = "{{input}}"
+			[[steps]]
+			name = "judge"
+			role = "developer:general"
+			prompt = "Pick best:\n{{candidates}}"
+			"#,
+		);
+		validate(&wf).expect("reference to parallel block name should validate");
 	}
 
 	#[test]

--- a/src/workflow/validate.rs
+++ b/src/workflow/validate.rs
@@ -37,8 +37,19 @@ pub fn validate(wf: &WorkflowDef) -> Result<()> {
 	}
 
 	// Structural checks per step.
-	for step in &wf.steps {
+	for (i, step) in wf.steps.iter().enumerate() {
 		structural_check(step)?;
+		// A dynamic parallel maps over the PREVIOUS step's output, so it needs one.
+		if i == 0 {
+			if let Step::Parallel(p) = step {
+				if p.match_pattern.is_some() {
+					bail!(
+						"dynamic parallel '{}': needs a preceding step to map over (cannot be the first step)",
+						p.name
+					);
+				}
+			}
+		}
 	}
 
 	// Reference resolution — walk in execution order, tracking what names
@@ -89,26 +100,49 @@ fn structural_check(step: &Step) -> Result<()> {
 		}
 		Step::Parallel(ParallelStep {
 			name,
+			match_pattern,
 			run,
 			min_success,
 			max_parallel,
 		}) => {
-			if run.len() < 2 {
-				bail!("parallel step '{}' must have at least 2 sub-steps", name);
-			}
-			for s in run {
-				validate_fields(s)?;
-				validate_expansion(s)?;
-			}
-			let total: u32 = run.iter().map(|s| s.replica_count()).sum();
-			if let Some(m) = min_success {
-				if *m == 0 || *m > total {
+			if let Some(pattern) = match_pattern {
+				// Dynamic: exactly one template sub-step; branches come from
+				// matching the previous step at run time (count unknown here).
+				if run.len() != 1 {
 					bail!(
-						"parallel step '{}': min_success {} must be between 1 and {} (total replicas)",
-						name,
-						m,
-						total
+						"dynamic parallel '{}' (match set) must have exactly 1 sub-step (the per-item template)",
+						name
 					);
+				}
+				Regex::new(pattern).map_err(|e| {
+					anyhow::anyhow!("dynamic parallel '{}': invalid match regex: {}", name, e)
+				})?;
+				let template = &run[0];
+				validate_fields(template)?;
+				validate_expansion(template)?;
+				if let Some(m) = min_success {
+					if *m == 0 {
+						bail!("dynamic parallel '{}': min_success must be >= 1", name);
+					}
+				}
+			} else {
+				if run.len() < 2 {
+					bail!("parallel step '{}' must have at least 2 sub-steps", name);
+				}
+				for s in run {
+					validate_fields(s)?;
+					validate_expansion(s)?;
+				}
+				let total: u32 = run.iter().map(|s| s.replica_count()).sum();
+				if let Some(m) = min_success {
+					if *m == 0 || *m > total {
+						bail!(
+							"parallel step '{}': min_success {} must be between 1 and {} (total replicas)",
+							name,
+							m,
+							total
+						);
+					}
 				}
 			}
 			if let Some(mp) = max_parallel {
@@ -249,15 +283,30 @@ fn check_step_refs(step: &Step, available: &mut HashSet<String>) -> Result<()> {
 			available.insert(s.name.clone());
 		}
 		Step::Parallel(p) => {
-			// Sub-step prompts may reference outer scope but not each other.
-			let outer = available.clone();
-			for s in &p.run {
-				check_refs(&s.name, &s.prompt, &outer)?;
+			if p.match_pattern.is_some() {
+				// Dynamic `match`: splits the previous step's output into items and
+				// loops the single template over them. The block's own name is the
+				// loop variable — in scope only for the template, bound to each
+				// item at run time. The accumulated OUTPUT lives under the
+				// sub-step's name, which is the only name visible downstream.
+				let mut scope = available.clone();
+				scope.insert(p.name.clone());
+				let tpl = &p.run[0];
+				check_refs(&tpl.name, &tpl.prompt, &scope)?;
+				available.insert(tpl.name.clone());
+			} else {
+				// Static: sub-step prompts may reference outer scope but not each
+				// other. Both the sub-step names and the block's own name (which
+				// aggregates them) become available downstream.
+				let outer = available.clone();
+				for s in &p.run {
+					check_refs(&s.name, &s.prompt, &outer)?;
+				}
+				for s in &p.run {
+					available.insert(s.name.clone());
+				}
+				available.insert(p.name.clone());
 			}
-			for s in &p.run {
-				available.insert(s.name.clone());
-			}
-			available.insert(p.name.clone());
 		}
 		Step::Loop(l) => {
 			// Inside the loop, sub-steps run sequentially; each iteration
@@ -544,6 +593,107 @@ mod tests {
 		);
 		let err = validate(&wf).expect_err("min_success > total replicas must fail");
 		assert!(err.to_string().contains("min_success"), "got: {err}");
+	}
+
+	#[test]
+	fn dynamic_parallel_validates() {
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "plan"
+			role = "researcher:general"
+			prompt = "List tasks in <task>..</task>:\n{{input}}"
+			[[steps]]
+			name = "research"
+			parallel = true
+			match = "(?s)<task>(.*?)</task>"
+			max_parallel = 4
+			min_success = 1
+			  [[steps.run]]
+			  name = "researcher"
+			  role = "researcher:general"
+			  prompt = "Research:\n{{research}}"
+			[[steps]]
+			name = "summary"
+			role = "developer:general"
+			prompt = "Summarize:\n{{researcher}}"
+			"#,
+		);
+		validate(&wf)
+			.expect("dynamic parallel referencing its own name in the template should pass");
+	}
+
+	#[test]
+	fn dynamic_parallel_requires_single_template() {
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "plan"
+			role = "researcher:general"
+			prompt = "{{input}}"
+			[[steps]]
+			name = "research"
+			parallel = true
+			match = "(.+)"
+			  [[steps.run]]
+			  name = "a"
+			  role = "researcher:general"
+			  prompt = "{{research}}"
+			  [[steps.run]]
+			  name = "b"
+			  role = "researcher:general"
+			  prompt = "{{research}}"
+			"#,
+		);
+		let err = validate(&wf).expect_err("dynamic parallel with 2 sub-steps must fail");
+		assert!(err.to_string().contains("exactly 1 sub-step"), "got: {err}");
+	}
+
+	#[test]
+	fn dynamic_parallel_cannot_be_first_step() {
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "research"
+			parallel = true
+			match = "(.+)"
+			  [[steps.run]]
+			  name = "researcher"
+			  role = "researcher:general"
+			  prompt = "Research the item"
+			"#,
+		);
+		let err = validate(&wf).expect_err("dynamic parallel as first step must fail");
+		assert!(err.to_string().contains("preceding step"), "got: {err}");
+	}
+
+	#[test]
+	fn dynamic_parallel_invalid_regex_fails() {
+		let wf = parse(
+			r#"
+			name = "wf"
+			[[steps]]
+			name = "plan"
+			role = "researcher:general"
+			prompt = "{{input}}"
+			[[steps]]
+			name = "research"
+			parallel = true
+			match = "(unclosed"
+			  [[steps.run]]
+			  name = "researcher"
+			  role = "researcher:general"
+			  prompt = "Research:\n{{research}}"
+			"#,
+		);
+		let err = validate(&wf).expect_err("invalid match regex must fail");
+		assert!(
+			err.to_string().contains("invalid match regex"),
+			"got: {err}"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
- Add fan-out aggregate workflow templates and configurations
- Implement count-based replication for parallel sub-steps
- Add max_parallel concurrency throttling via semaphores
- Introduce min_success thresholds for parallel block completion
- Enable variable resolution and aggregation for replica outputs
- Add best-of-N sampling support via count field in sequential steps
- Update workflow visualization to display replica counts and limits
- Implement validation for parallel expansion and constraint logic
- Improve parallel execution logging and result grouping
- Add unit tests for expansion, validation, and output joining
- Document fan-out patterns and new configuration fields