### PR TITLE
feat(session): implement system-managed user messages

### DIFF
--- a/src/acp/agent.rs
+++ b/src/acp/agent.rs
@@ -386,7 +386,12 @@ fn spawn_inbox_monitor(
 						}
 					}
 
-					if let Err(e) = chat_session.add_user_message(&inbox_msg.content) {
+					let add_result = if inbox_msg.source.is_system_managed() {
+						chat_session.add_system_managed_user_message(&inbox_msg.content)
+					} else {
+						chat_session.add_user_message(&inbox_msg.content)
+					};
+					if let Err(e) = add_result {
 						log_error!("ACP monitor: failed to add inbox message: {}", e);
 						sessions
 							.borrow_mut()
@@ -918,7 +923,12 @@ impl OctomindAgent {
 							log_error!("ACP: failed to send injected-message notification: {}", e);
 						}
 					}
-					if let Err(e) = chat_session.add_user_message(&inbox_msg.content) {
+					let add_result = if inbox_msg.source.is_system_managed() {
+						chat_session.add_system_managed_user_message(&inbox_msg.content)
+					} else {
+						chat_session.add_user_message(&inbox_msg.content)
+					};
+					if let Err(e) = add_result {
 						log_error!("ACP: failed to add inbox message: {}", e);
 						continue;
 					}

--- a/src/mcp/runtime/capability.rs
+++ b/src/mcp/runtime/capability.rs
@@ -964,7 +964,7 @@ pub async fn auto_activate_capabilities(
 ) {
 	// Fire only on a fresh user message. Tool-loop iterations are skipped.
 	let intent = match session.session.messages.last() {
-		Some(m) if m.role == "user" => m.content.clone(),
+		Some(m) if crate::session::is_real_user_task_message(m) => m.content.clone(),
 		_ => return,
 	};
 

--- a/src/mcp/runtime/skill_auto.rs
+++ b/src/mcp/runtime/skill_auto.rs
@@ -115,7 +115,7 @@ pub async fn load_env_skills(session: &mut crate::session::chat::session::ChatSe
 		match super::skill::execute_skill_tool(&call).await {
 			Ok(_) => {
 				if let Some(content) = super::skill::take_silent_skill_content() {
-					let _ = session.add_user_message(&content);
+					let _ = session.add_system_managed_user_message(&content);
 				}
 				// Emit structured event for JSONL/WebSocket consumers
 				if let Some(sid) = &session_id {
@@ -598,7 +598,7 @@ async fn auto_activate_skill(
 	match super::skill::execute_skill_tool(&call).await {
 		Ok(_) => {
 			if let Some(content) = super::skill::take_silent_skill_content() {
-				let _ = session.add_user_message(&content);
+				let _ = session.add_system_managed_user_message(&content);
 			}
 
 			// Emit structured event for JSONL/WebSocket consumers

--- a/src/session/chat/conversation_compression/mod.rs
+++ b/src/session/chat/conversation_compression/mod.rs
@@ -286,10 +286,10 @@ pub enum CompressionTrigger {
 /// Main entry point: check if compression needed and perform if AI decides YES
 /// Returns true if compression was performed, false otherwise
 /// True when a USER-role message is one of OUR synthetic injections — a skill
-/// block, a continuation wrapper, or a supervisor `<supervisor>`/`<recall>`
+/// block, a continuation wrapper, or a supervisor `<system-reminder>`/`<recall>`
 /// control-plane note (steers, goal recitation, recalled lessons) — rather than a
 /// genuine user request. These must NEVER be summarized or captured as USER TASKS:
-/// e.g. a steered loop would otherwise turn "<supervisor> your results were
+/// e.g. a steered loop would otherwise turn "<system-reminder> your results were
 /// truncated…" into the recorded task and bury the real ask (the bug that ate the
 /// work). Centralized + unit-tested so the filter can't silently drift again.
 pub(super) fn is_synthetic_user_message(content: &str) -> bool {

--- a/src/session/chat/conversation_compression/mod.rs
+++ b/src/session/chat/conversation_compression/mod.rs
@@ -293,9 +293,7 @@ pub enum CompressionTrigger {
 /// truncated…" into the recorded task and bury the real ask (the bug that ate the
 /// work). Centralized + unit-tested so the filter can't silently drift again.
 pub(super) fn is_synthetic_user_message(content: &str) -> bool {
-	crate::mcp::runtime::skill::is_skill_message(content)
-		|| apply::is_continuation_message(content)
-		|| crate::supervisor::gate::is_supervisor_injection(content)
+	crate::session::is_system_managed_user_content(content)
 }
 
 pub async fn check_and_compress_conversation(
@@ -427,9 +425,8 @@ pub async fn check_and_compress_conversation(
 	//     (`apply::is_continuation_message`) — they're conversation
 	//     plumbing, not real user asks. Including them would let the
 	//     "Please continue."-style degradation chain reappear.
-	let user_msg_filter = |m: &&crate::session::Message| -> bool {
-		m.role == "user" && !m.content.trim().is_empty() && !is_synthetic_user_message(&m.content)
-	};
+	let user_msg_filter =
+		|m: &&crate::session::Message| -> bool { crate::session::is_real_user_task_message(m) };
 
 	let all_user_msgs: Vec<&crate::session::Message> = session.session.messages
 		[start_idx + 1..=end_idx]
@@ -549,7 +546,7 @@ pub async fn check_and_compress_conversation(
 			.session
 			.messages
 			.iter()
-			.filter(|m| m.role == "user")
+			.filter(|m| crate::session::is_real_user_task_message(m))
 			.count();
 		if user_msg_count >= config.supervisor.learning.min_messages_for_intermediate {
 			let role = crate::config::get_thread_role().unwrap_or_default();

--- a/src/session/chat/conversation_compression/range.rs
+++ b/src/session/chat/conversation_compression/range.rs
@@ -55,7 +55,11 @@ pub(super) fn find_compression_range(
 			m.role == "user" && m.content.trim_start().starts_with(INSTRUCTIONS_TAG_OPEN)
 		})
 		.map(|(i, _)| i)
-		.or_else(|| messages.iter().position(|m| m.role == "user"));
+		.or_else(|| {
+			messages
+				.iter()
+				.position(crate::session::is_real_user_task_message)
+		});
 
 	let start_idx = match anchor {
 		Some(i) => i,

--- a/src/session/chat/conversation_compression/tests.rs
+++ b/src/session/chat/conversation_compression/tests.rs
@@ -7,9 +7,18 @@ use crate::session::Message;
 use serde_json::json;
 
 fn msg(role: &str) -> Message {
+	// Real user turns always carry content — empty user messages never occur in
+	// production, and `is_real_user_task_message` (used for anchor selection)
+	// rejects empty content. Give user-role fixtures a generic task string so
+	// they model a genuine user request; other roles may stay empty.
+	let content = if role == "user" {
+		"user request".to_string()
+	} else {
+		String::new()
+	};
 	Message {
 		role: role.to_string(),
-		content: String::new(),
+		content,
 		..Default::default()
 	}
 }
@@ -44,6 +53,10 @@ fn synthetic_user_messages_excluded_from_tasks() {
 	// Recalled lessons.
 	assert!(is_synthetic_user_message(
 		"<recall>\n<lessons>...</lessons>\n</recall>"
+	));
+	// Custom instructions file content.
+	assert!(is_synthetic_user_message(
+		"<instructions>\nFollow project conventions.\n</instructions>"
 	));
 	// Skill block.
 	assert!(is_synthetic_user_message(

--- a/src/session/chat/conversation_compression/tests.rs
+++ b/src/session/chat/conversation_compression/tests.rs
@@ -44,11 +44,11 @@ fn synthetic_user_messages_excluded_from_tasks() {
 	use super::is_synthetic_user_message;
 	// Supervisor steer.
 	assert!(is_synthetic_user_message(
-		"<supervisor>\nSTOP — you are repeating the same call.\n</supervisor>"
+		"<system-reminder>\nThis is a loop: the same call keeps returning the same result.\n</system-reminder>"
 	));
-	// Goal recitation (also <supervisor>-wrapped).
+	// Goal recitation (also <system-reminder>-wrapped).
 	assert!(is_synthetic_user_message(
-		"<supervisor>\nStay anchored to the goal:\n<intent>x</intent>\n</supervisor>"
+		"<system-reminder>\nYou are deep in this session — re-anchor on your goal:\nGoal (fixed): <intent>x</intent>\n</system-reminder>"
 	));
 	// Recalled lessons.
 	assert!(is_synthetic_user_message(

--- a/src/session/chat/response.rs
+++ b/src/session/chat/response.rs
@@ -718,6 +718,7 @@ pub async fn process_response<S: OutputSink>(
 						params.chat_session.steer_pending = Some(
 							crate::supervisor::detect::steer_note(
 								round_signal,
+								params.chat_session.last_self_report,
 								params.chat_session.steer_attempt,
 							)
 							.to_string(),

--- a/src/session/chat/response.rs
+++ b/src/session/chat/response.rs
@@ -613,12 +613,7 @@ pub async fn process_response<S: OutputSink>(
 								.messages
 								.iter()
 								.rev()
-								.find(|m| {
-									m.role == "user"
-										&& !crate::supervisor::gate::is_supervisor_injection(
-											&m.content,
-										)
-								})
+								.find(|m| crate::session::is_real_user_task_message(m))
 								.map(|m| m.content.as_str())
 								.unwrap_or_default()
 								.hash(&mut h);

--- a/src/session/chat/response/tool_result_processor.rs
+++ b/src/session/chat/response/tool_result_processor.rs
@@ -366,11 +366,7 @@ pub async fn process_tool_results(
 		let hint_message = format!(
 			"⚠️ Tool usage notice:\n{bullet_list}\n\nPlease prefer the recommended tools going forward."
 		);
-		chat_session.session.messages.push(crate::session::Message {
-			role: "user".to_string(),
-			content: hint_message,
-			..Default::default()
-		});
+		chat_session.add_system_managed_user_message(&hint_message)?;
 	}
 
 	// Supervisor: deliver any queued steer note HERE — during the tool loop, before
@@ -380,11 +376,7 @@ pub async fn process_tool_results(
 	// saw the steer (it only landed when a real user message began a fresh turn). This
 	// is the round-by-round delivery that makes the steer reach the model in the loop.
 	if let Some(note) = chat_session.steer_pending.take() {
-		chat_session.session.messages.push(crate::session::Message {
-			role: "user".to_string(),
-			content: note,
-			..Default::default()
-		});
+		chat_session.add_system_managed_user_message(&note)?;
 		crate::log_debug!("Supervisor steer injected (tool loop)");
 	}
 

--- a/src/session/chat/session/api_executor.rs
+++ b/src/session/chat/session/api_executor.rs
@@ -25,6 +25,9 @@ use tokio::sync::watch;
 
 use crate::session::output::{OutputMode, OutputSink};
 
+const PREGATE_MARKER: &str = "octomind:pre_gate_unverified_mutation";
+const PREGATE_NOTE: &str = "<supervisor>\n<!-- octomind:pre_gate_unverified_mutation -->\nYou reported done, but you changed code and have not run a successful check (build / test / lint / whatever this project uses to verify) since your last change. Run that check and confirm it passes, or if no check applies here, say so explicitly. Then re-report your status.\n</supervisor>";
+
 /// Apply the verify-gate's verdict back to the entries recalled this trajectory:
 /// positive `delta` reinforces (the recall helped); negative decays (it may have
 /// misled). Clears the recalled set either way.
@@ -132,14 +135,10 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 			.unwrap_or("unknown")
 			.to_string();
 		// Most recent user message drives query-based scoped retrieval.
-		let user_input = chat_session
-			.session
-			.messages
-			.iter()
-			.rev()
-			.find(|m| m.role == "user")
-			.map(|m| m.content.clone())
-			.unwrap_or_default();
+		let user_input =
+			crate::session::latest_real_user_task_content(&chat_session.session.messages)
+				.unwrap_or_default()
+				.to_string();
 		animation_manager.set_phase("Recalling lessons …").await;
 		let (block, new_contents) = crate::supervisor::learning::inject::retrieve_and_format(
 			config,
@@ -153,7 +152,7 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 		.await;
 		animation_manager.clear_phase();
 		if !block.is_empty() {
-			chat_session.add_user_message(&block)?;
+			chat_session.add_system_managed_user_message(&block)?;
 			crate::supervisor::stats::recall();
 			crate::supervisor::notify(&format!(
 				"recalled {} lesson(s) into context",
@@ -171,7 +170,7 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 	// Supervisor: inject any queued steer note (advisory re-anchor) at the safe
 	// pre-request point — same message-ordering guarantees as recall above.
 	if let Some(note) = chat_session.steer_pending.take() {
-		chat_session.add_user_message(&note)?;
+		chat_session.add_system_managed_user_message(&note)?;
 		crate::log_debug!("Supervisor steer injected");
 	}
 
@@ -184,7 +183,7 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 		if let Some(note) =
 			crate::supervisor::recite::recite_note(&chat_session.session.info.anchor)
 		{
-			chat_session.add_user_message(&note)?;
+			chat_session.add_system_managed_user_message(&note)?;
 			crate::log_debug!("Supervisor goal recitation injected");
 		}
 	}
@@ -313,13 +312,21 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 		// completion right after a code change without re-running any check. Catch
 		// it deterministically before paying for the LLM verify-gate. Shares the
 		// gate_iterations budget, so it can't loop unbounded.
+		let already_nudged = chat_session
+			.session
+			.messages
+			.iter()
+			.rev()
+			.find(|m| m.role == "user")
+			.is_some_and(|m| m.content.contains(PREGATE_MARKER));
 		if config.supervisor.gate.require_check_after_mutation
 			&& chat_session.detectors.needs_verification()
+			&& !already_nudged
 		{
-			let note = "<supervisor>\nYou reported done, but you changed code and have not run a successful check (build / test / lint / whatever this project uses to verify) since your last change. Run that check and confirm it passes — or, if no check applies here, say so explicitly. Then re-report your status.\n</supervisor>";
-			chat_session.add_user_message(note)?;
+			chat_session.add_system_managed_user_message(PREGATE_NOTE)?;
 			chat_session.last_self_report = None; // force the re-run to re-evaluate
 			chat_session.gate_iterations += 1;
+			crate::supervisor::stats::pregate_block();
 			crate::supervisor::notify("done claimed without a check after changes — re-running");
 			if chat_session.gate_iterations < config.supervisor.gate.max_iterations {
 				crate::log_debug!(
@@ -364,9 +371,10 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 					note.push_str("»\n");
 				}
 				note.push_str("</supervisor>");
-				chat_session.add_user_message(&note)?;
+				chat_session.add_system_managed_user_message(&note)?;
 				chat_session.last_self_report = None; // force the re-run to re-evaluate
 				chat_session.gate_iterations += 1;
+				crate::supervisor::stats::claim_block();
 				crate::supervisor::notify(&format!(
 					"{} unverifiable citation(s) — re-running",
 					unverified.len()
@@ -398,9 +406,7 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 			.messages
 			.iter()
 			.rev()
-			.find(|m| {
-				m.role == "user" && !crate::supervisor::gate::is_supervisor_injection(&m.content)
-			})
+			.find(|m| crate::session::is_real_user_task_message(m))
 			.map(|m| m.content.clone())
 			.unwrap_or_default();
 		let result = chat_session.last_response.clone();
@@ -427,7 +433,7 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 			}
 			crate::supervisor::gate::GateVerdict::Gaps(gaps) => {
 				let note = crate::supervisor::gate::format_advisory(&gaps);
-				chat_session.add_user_message(&note)?;
+				chat_session.add_system_managed_user_message(&note)?;
 				chat_session.last_self_report = None; // force the re-run to re-evaluate
 				chat_session.gate_iterations += 1;
 				crate::log_debug!(

--- a/src/session/chat/session/api_executor.rs
+++ b/src/session/chat/session/api_executor.rs
@@ -26,7 +26,7 @@ use tokio::sync::watch;
 use crate::session::output::{OutputMode, OutputSink};
 
 const PREGATE_MARKER: &str = "octomind:pre_gate_unverified_mutation";
-const PREGATE_NOTE: &str = "<supervisor>\n<!-- octomind:pre_gate_unverified_mutation -->\nYou reported done, but you changed code and have not run a successful check (build / test / lint / whatever this project uses to verify) since your last change. Run that check and confirm it passes, or if no check applies here, say so explicitly. Then re-report your status.\n</supervisor>";
+const PREGATE_NOTE: &str = "<system-reminder>\n<!-- octomind:pre_gate_unverified_mutation -->\nYou may only report done after a verification has actually passed. You reported done with code changes still unverified, so that claim isn't trustworthy yet. Run this project's check (build / test / lint — whatever it uses), watch the result, and report the actual outcome: pass, fail, or — if this project has no such check — which command you tried and why none applies. Base the report on the observed result, not on what you expect.\n</system-reminder>";
 
 /// Apply the verify-gate's verdict back to the entries recalled this trajectory:
 /// positive `delta` reinforces (the recall helped); negative decays (it may have
@@ -363,14 +363,14 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 			);
 			if !unverified.is_empty() {
 				let mut note = String::from(
-					"<supervisor>\nThese cited quotes do not appear in any tool result you received — re-ground each against actual tool output, or retract the claim:\n",
+					"<system-reminder>\nEach quote below was presented as «verbatim» from a tool result, but none string-matches any output you received — so it is unsupported. For each, go back to the actual tool output (not your earlier answer): copy the exact lines that support the claim, then restate the claim from them. If no tool output contains them, say so and drop that claim — \"not found in tool output\" is the correct answer here; never invent a source. Unsupported quotes:\n",
 				);
 				for q in &unverified {
 					note.push_str("- «");
 					note.push_str(q);
 					note.push_str("»\n");
 				}
-				note.push_str("</supervisor>");
+				note.push_str("</system-reminder>");
 				chat_session.add_system_managed_user_message(&note)?;
 				chat_session.last_self_report = None; // force the re-run to re-evaluate
 				chat_session.gate_iterations += 1;

--- a/src/session/chat/session/commands/display.rs
+++ b/src/session/chat/session/commands/display.rs
@@ -598,6 +598,8 @@ pub fn display_info(output: &CommandOutput) {
 			let gate_pass = get_u64("gate_pass");
 			let gate_fail = get_u64("gate_fail");
 			let steers = get_u64("steers");
+			let pregate_blocks = get_u64("pregate_blocks");
+			let claim_blocks = get_u64("claim_blocks");
 			let lessons = get_u64("lessons_stored");
 			let orientation = get_u64("orientation_stored");
 			let recalls = get_u64("recalls_injected");
@@ -611,6 +613,12 @@ pub fn display_info(output: &CommandOutput) {
 			}
 			if steers > 0 {
 				activity.push(format!("{} steers", steers));
+			}
+			if pregate_blocks > 0 {
+				activity.push(format!("{} check-blocks", pregate_blocks));
+			}
+			if claim_blocks > 0 {
+				activity.push(format!("{} claim-blocks", claim_blocks));
 			}
 			if lessons > 0 {
 				activity.push(format!("{} lessons", lessons));

--- a/src/session/chat/session/commands/run.rs
+++ b/src/session/chat/session/commands/run.rs
@@ -74,7 +74,7 @@ pub async fn handle_run(
 			.session
 			.messages
 			.iter()
-			.rfind(|m| m.role == "user")
+			.rfind(|m| crate::session::is_real_user_task_message(m))
 			.map(|m| m.content.clone())
 			.unwrap_or_else(|| "No recent user input found".to_string())
 	};

--- a/src/session/chat/session/commands/skill.rs
+++ b/src/session/chat/session/commands/skill.rs
@@ -211,7 +211,7 @@ async fn handle_use(session: &mut ChatSession, name: &str) -> Result<CommandResu
 	match crate::mcp::runtime::skill::execute_skill_tool(&call).await {
 		Ok(_) => {
 			if let Some(content) = crate::mcp::runtime::skill::take_silent_skill_content() {
-				let _ = session.add_user_message(&content);
+				let _ = session.add_system_managed_user_message(&content);
 			}
 			// Emit structured lifecycle event for JSONL/WebSocket consumers
 			if let Some(sid) = crate::session::context::current_session_id() {

--- a/src/session/chat/session/core.rs
+++ b/src/session/chat/session/core.rs
@@ -1338,6 +1338,24 @@ mod tests {
 			.collect()
 	}
 
+	#[test]
+	fn real_user_turn_resets_steer_streak() {
+		let mut cs = make_session(vec![msg("system", false)]);
+		cs.consecutive_steers = 3;
+		cs.steer_attempt = 2;
+		cs.steer_last_signal = crate::supervisor::detect::DetectorSignal::Loop;
+
+		cs.add_user_message("new task after prior loop stopped")
+			.unwrap();
+
+		assert_eq!(cs.consecutive_steers, 0);
+		assert_eq!(cs.steer_attempt, 0);
+		assert_eq!(
+			cs.steer_last_signal,
+			crate::supervisor::detect::DetectorSignal::None
+		);
+	}
+
 	// ── Case 1: no cache markers anywhere ────────────────────────────────────────
 	// Compressed block gets cached=true (marker #1) and the last eligible user/tool
 	// message in the preserved zone gets marker #2 automatically.

--- a/src/session/chat/session/main_loop.rs
+++ b/src/session/chat/session/main_loop.rs
@@ -1748,7 +1748,11 @@ pub async fn run_interactive_session_with_input(
 			)
 			.await;
 
-			chat_session.add_user_message(&inbox_msg.content)?;
+			if inbox_msg.source.is_system_managed() {
+				chat_session.add_system_managed_user_message(&inbox_msg.content)?;
+			} else {
+				chat_session.add_user_message(&inbox_msg.content)?;
+			}
 			prepare_for_api_call(&mut chat_session, &current_config, operation_rx.clone()).await?;
 
 			let is_jsonl = current_config.runtime_output_mode.as_deref() == Some("jsonl");

--- a/src/session/chat/session/messages.rs
+++ b/src/session/chat/session/messages.rs
@@ -243,6 +243,10 @@ impl ChatSession {
 		}
 		self.session.messages.push(message);
 
+		self.consecutive_steers = 0;
+		self.steer_attempt = 0;
+		self.steer_last_signal = crate::supervisor::detect::DetectorSignal::None;
+
 		// Check if we should cache this user message (after push, so the message exists
 		// at a known index and the cache manager can enforce the 2-marker limit).
 		if self.cache_next_user_message {
@@ -264,6 +268,19 @@ impl ChatSession {
 			// Reset the flag after applying (or attempting to apply) cache
 			self.cache_next_user_message = false;
 		}
+
+		Ok(())
+	}
+
+	// Add a system-managed user-role message. Provider APIs still see role=user,
+	// but task/compression/learning logic must not treat it as a user request.
+	pub fn add_system_managed_user_message(&mut self, content: &str) -> Result<()> {
+		let message = crate::session::Session::build_message("user", content);
+		if let Some(session_file) = &self.session.session_file {
+			let message_json = serde_json::to_string(&message)?;
+			crate::session::append_to_session_file(session_file, &message_json)?;
+		}
+		self.session.messages.push(message);
 
 		Ok(())
 	}

--- a/src/session/chat/session/prompt_setup.rs
+++ b/src/session/chat/session/prompt_setup.rs
@@ -92,7 +92,7 @@ pub async fn setup_system_prompt_and_cache(
 						)?;
 					}
 					"user" => {
-						chat_session.add_user_message(&msg.content)?;
+						chat_session.add_system_managed_user_message(&msg.content)?;
 					}
 					_ => {} // Should not happen
 				}
@@ -153,7 +153,7 @@ pub async fn setup_system_prompt_and_cache(
 									"<instructions>\n{}\n</instructions>",
 									processed_instructions
 								);
-								chat_session.add_user_message(&wrapped)?;
+								chat_session.add_system_managed_user_message(&wrapped)?;
 
 								if supports_caching {
 									let cache_manager = CacheManager::new();

--- a/src/session/dedup.rs
+++ b/src/session/dedup.rs
@@ -140,7 +140,7 @@ pub fn placeholder(tool_name: &str, content: &str, was_truncated: bool) -> Strin
 	// directive instead.
 	if was_truncated {
 		return format!(
-			"[duplicate tool call — `{tool_name}`: same args, same TRUNCATED output as before — repeating returns no more. STOP; to see the cut-off part, {hint}.]",
+			"[duplicate tool call — `{tool_name}`: identical args returned the same truncated output already in your context — re-running yields no more. To reach the cut-off part, {hint}.]",
 			hint = crate::utils::truncation::truncation_hint(tool_name),
 		);
 	}
@@ -161,7 +161,7 @@ pub fn placeholder(tool_name: &str, content: &str, was_truncated: bool) -> Strin
 		format!("it begins: {first} — and ends: {last}")
 	};
 	format!(
-		"[duplicate tool call — `{tool_name}`: same args, same output as earlier ({fingerprint}), already in your context. Don't repeat it — reuse that result, or change the args/tool to get something new.]"
+		"[duplicate tool call — `{tool_name}`: identical args returned the same output you already have ({fingerprint}). Reuse that earlier result; only call again with different args or a different tool if you need something it does not contain.]"
 	)
 }
 
@@ -231,13 +231,13 @@ mod tests {
 	}
 
 	#[test]
-	fn placeholder_truncated_repeat_is_a_stop_directive() {
-		// A truncated repeat must NOT echo the body; it must tell the model to
-		// stop re-running and how to narrow instead.
+	fn placeholder_truncated_repeat_redirects_without_echoing_body() {
+		// A truncated repeat must NOT echo the body; it must tell the model the
+		// re-run yields no more and how to reach the cut-off part instead.
 		let s = placeholder("shell", "huge output that was truncated\n", true);
 		assert!(s.contains("shell"));
-		assert!(s.contains("TRUNCATED"));
-		assert!(s.contains("STOP")); // strong stop directive
+		assert!(s.contains("truncated"));
+		assert!(s.contains("yields no more")); // positive-forward deterrent
 		assert!(s.contains("grep")); // shell-specific narrowing hint
 		assert!(!s.contains("huge output")); // body is not echoed
 	}

--- a/src/session/inbox.rs
+++ b/src/session/inbox.rs
@@ -114,6 +114,18 @@ impl InboxSource {
 			InboxSource::GuardValidator { .. } => "🛡️",
 		}
 	}
+
+	pub fn is_system_managed(&self) -> bool {
+		matches!(
+			self,
+			InboxSource::BackgroundAgent { .. }
+				| InboxSource::TapRun { .. }
+				| InboxSource::Skill { .. }
+				| InboxSource::SkillValidator { .. }
+				| InboxSource::GuardrailHook { .. }
+				| InboxSource::GuardValidator { .. }
+		)
+	}
 }
 
 /// Render an injected inbox message to stdout so the user sees what the AI

--- a/src/session/layers/layer_trait.rs
+++ b/src/session/layers/layer_trait.rs
@@ -234,7 +234,7 @@ pub trait Layer {
 							session
 								.messages
 								.iter()
-								.rfind(|m| m.role == "user")
+								.rfind(|m| crate::session::is_real_user_task_message(m))
 								.map(|m| m.content.clone())
 								.unwrap_or_else(|| "No previous messages found".to_string())
 						})

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -126,6 +126,29 @@ impl Default for Message {
 	}
 }
 
+pub fn is_system_managed_user_content(content: &str) -> bool {
+	let trimmed = content.trim_start();
+	trimmed.starts_with("<instructions>")
+		|| trimmed.starts_with("<continuation>")
+		|| crate::mcp::runtime::skill::is_skill_message(content)
+		|| crate::supervisor::gate::is_supervisor_injection(content)
+}
+
+pub fn is_real_user_task_message(message: &Message) -> bool {
+	if message.role != "user" || message.content.trim().is_empty() {
+		return false;
+	}
+	!is_system_managed_user_content(&message.content)
+}
+
+pub fn latest_real_user_task_content(messages: &[Message]) -> Option<&str> {
+	messages
+		.iter()
+		.rev()
+		.find(|m| is_real_user_task_message(m))
+		.map(|m| m.content.as_str())
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct SessionInfo {
 	pub name: String,

--- a/src/session/share/upload.rs
+++ b/src/session/share/upload.rs
@@ -139,9 +139,8 @@ fn extract_title(raw: &[u8]) -> Option<String> {
 		if stripped.is_empty() {
 			continue;
 		}
-		// Skip bootstrap-looking entries (skill / identity / role-doc injections).
-		let first_char = stripped.chars().next()?;
-		if first_char == '<' {
+		// Skip system-managed user-role entries.
+		if crate::session::is_system_managed_user_content(stripped) {
 			continue;
 		}
 		if stripped.starts_with("# Octomind") || stripped.starts_with("## Lessons") {

--- a/src/supervisor/detect.rs
+++ b/src/supervisor/detect.rs
@@ -54,18 +54,18 @@ impl SelfReport {
 /// One-time system-side instruction that makes the agent self-annotate. Injected
 /// out-of-band; the resulting tags are stripped before display.
 pub const SELF_REPORT_INSTRUCTION: &str = "\
-<supervisor>
-End every response with a status tag on its own final line, in this exact form:
+<system-reminder>
+Finish every response with one status line — the last line, nothing after it:
 `<sup>STATE · brief reason</sup>`
-Replace STATE with exactly one of these words — never write the literal text \"STATE\":
-exploring, progressing, blocked, need_input, done. The reason is a few words.
-- `done` only when the user's task is fully complete.
-- `need_input` when you are asking the user a question and waiting on them.
-- `blocked` when you are stuck and cannot proceed.
-- `exploring` while still gathering context; `progressing` while actively making changes.
+Start the tag with one state word, then ` · `, then a few words of reason. Use exactly one of these words (write the word itself, not the placeholder STATE):
+- `exploring` — still gathering context, reading code
+- `progressing` — actively making changes
+- `blocked` — stuck, cannot proceed
+- `need_input` — asking the user a question and waiting on them
+- `done` — the user's task is fully complete
 Examples: `<sup>progressing · wiring store registration</sup>` or `<sup>done · migration verified</sup>`
-This tag is for the system and is hidden from the user. Always include exactly one.
-</supervisor>";
+This line is read by the system and hidden from the user. Emit exactly one, leading with the state word.
+</system-reminder>";
 
 /// One-time system-side instruction enabling evidence-bound claims. The agent
 /// backs load-bearing factual claims about the codebase with a verbatim quote it
@@ -73,11 +73,11 @@ This tag is for the system and is hidden from the user. Always include exactly o
 /// checks the quote really occurs in some tool output, catching fabricated
 /// citations for free (no model call).
 pub const EVIDENCE_INSTRUCTION: &str = "\
-<supervisor>
-When you assert a load-bearing fact about the code or repo (a path, signature, value, or concrete behavior), back it with text you actually saw in a tool result, quoted verbatim between guillemets, in this exact form:
+<system-reminder>
+Before you assert a load-bearing fact about the code or repo (a path, signature, value, or concrete behavior), copy the supporting text you actually saw in a tool result, character-for-character, between guillemets, in this exact form:
 [evidence: <locator> «exact text copied verbatim from the tool output»]
-Quote verbatim — do not paraphrase inside « ». Tag only load-bearing factual claims; do NOT tag plans, reasoning, or general knowledge. A « » quote that is not found in any tool result you received will be flagged and you will be asked to re-ground it against real output or retract the claim.
-</supervisor>";
+The text inside « » must be a literal copy that string-matches the tool output — rewording, summarizing, or trimming it breaks the match. Tag only load-bearing factual claims about the code, not plans, reasoning, or general knowledge. If you cannot find a line that supports a claim, say so and drop it — do not invent a quote. A « » quote not found in any tool result you received will be flagged to re-ground against real output or retract.
+</system-reminder>";
 
 /// Parse the *last* `<sup>…</sup>` token from a response. Returns the state and
 /// an optional short reason. Tolerant of the `·` or `|` reason separator.
@@ -583,49 +583,89 @@ pub fn signal_description(signal: DetectorSignal) -> &'static str {
 	}
 }
 
-/// The advisory steer note for a fired signal. Out-of-band; the `<supervisor>`
-/// framing keeps it distinct from user content.
+/// Shared persistent-failure frame: the model has been steered through the full
+/// 0→1→2 ladder on a *stuck* signal and still has not broken out, so small tweaks
+/// are clearly not working. Signal-agnostic and held on clamp. Only `Sequential`
+/// (advisory, false-positive-prone) never reaches it.
+const PERSISTENT_STEER: &str = "<system-reminder>\nYou have been steered several times here and have not broken out — small adjustments are not working. Stop iterating on the same approach: either take a fundamentally different path to the goal, or report `blocked` and name the single obstacle in your way.\n</system-reminder>";
+
+/// Conflict framing: a no-progress signal while the agent self-reports
+/// `progressing`. The counters and the self-assessment disagree — the canonical
+/// reason the supervisor escalates at all — so name the contradiction directly
+/// instead of the generic no-progress note. Same 0→1→2 escalation.
+const CONFLICT_VARIANTS: &[&str] = &[
+	"<system-reminder>\nYou reported you are making progress, but the last several actions added nothing new — your self-assessment and what the actions show disagree. Check which is right before continuing.\n</system-reminder>",
+	"<system-reminder>\nYou report progressing, yet no new information has appeared. Name in one line the concrete result your recent steps produced. If you cannot, the work has stalled — take a single different step that visibly moves the goal, not another like the ones that yielded nothing.\n</system-reminder>",
+	"<system-reminder>\nYour actions are not advancing the task despite a `progressing` report. Re-anchor: state the goal, what is actually done, and the one next step that moves it — then take it. If nothing does, report `blocked` with what is missing.\n</system-reminder>",
+];
+
+/// The advisory steer note for a fired signal. Out-of-band; the `<system-reminder>`
+/// framing keeps it distinct from user content. Wording is positive-forward (the
+/// concrete action to take, not a bare prohibition) and puts that action last, in
+/// the recency slot — negation and buried directives are the empirically weakest
+/// forms for instruction-following.
 ///
-/// `attempt` rotates the *framing* when the same signal re-fires without the
-/// model breaking out. Re-sending identical text loses salience (instruction
-/// habituation), so each retry reframes the same constraint from a different
-/// angle — one will land where another bounced:
-///   0 → diagnostic (what is happening and why it wastes context)
-///   1 → directive  (the concrete alternative action to take instead)
-///   2 → stop       (blunt: this is a loop, change or report `blocked`)
+/// `attempt` rotates the *framing* when the same signal re-fires without the model
+/// breaking out. Re-sending identical text loses salience (habituation), so each
+/// retry reframes the same constraint from a different angle:
+///   0 → diagnostic (what is happening; soft reconsider)
+///   1 → directive  (a grounded one-line self-check + the concrete alternative)
+///   2 → stop       (firm: a different approach now, or report `blocked`)
+///  3+ → persistent ([`PERSISTENT_STEER`]: fundamentally different path or `blocked`)
 /// Advance-then-clamp, not modulo: never soften once the model has proven it is
-/// stuck — hold the firmest frame.
-pub fn steer_note(signal: DetectorSignal, attempt: usize) -> &'static str {
+/// stuck — hold the firmest frame. `report` lets a no-progress signal switch to
+/// [`CONFLICT_VARIANTS`] when the agent insists it is `progressing`.
+pub fn steer_note(
+	signal: DetectorSignal,
+	report: Option<SelfReport>,
+	attempt: usize,
+) -> &'static str {
+	let stuck = matches!(
+		signal,
+		DetectorSignal::Loop
+			| DetectorSignal::NoProgress
+			| DetectorSignal::Truncation
+			| DetectorSignal::Dedup
+			| DetectorSignal::Distraction
+	);
+	// Ladder exhausted on a stuck signal without breakout → hold the firmest frame.
+	if stuck && attempt >= 3 {
+		return PERSISTENT_STEER;
+	}
+	// Counters say no-progress while the agent reports progressing: name the conflict.
+	if signal == DetectorSignal::NoProgress && report == Some(SelfReport::Progressing) {
+		return CONFLICT_VARIANTS[attempt.min(CONFLICT_VARIANTS.len() - 1)];
+	}
 	let variants: &[&str] = match signal {
 		DetectorSignal::Loop => &[
-			"<supervisor>\nThe last action produced a result you have already seen — it is not advancing the task. This usually means the current approach has stalled. Step back and reconsider what is actually blocking progress.\n</supervisor>",
-			"<supervisor>\nYou are still repeating the same action. First, in one sentence: why did the last attempt fail to make progress? Then change something concrete on the next call — a different tool, different arguments, or a different sub-goal. Do not re-issue the same call expecting a different result.\n</supervisor>",
-			"<supervisor>\nYou have repeated the same action without new results. Stop and try a different approach. If you cannot proceed, report `blocked`.\n</supervisor>",
+			"<system-reminder>\nThis result is identical to one already in your context — the last call added nothing, so the current approach has stalled. Reconsider what is actually blocking progress before the next call.\n</system-reminder>",
+			"<system-reminder>\nSame result again — you are repeating a call that already failed to advance the task. In one sentence, name why it failed. Then change one concrete thing on the next call — a different tool, different arguments, or a different sub-goal — that approaches the goal a new way.\n</system-reminder>",
+			"<system-reminder>\nThis is a loop: the same call keeps returning the same result. Make a different call that approaches the goal another way — a different tool, scope, or sub-goal — or report `blocked` with the one obstacle stopping you.\n</system-reminder>",
 		],
 		DetectorSignal::NoProgress => &[
-			"<supervisor>\nSeveral steps have passed without surfacing new information. The current line of inquiry may be exhausted — consider whether it is still the right one.\n</supervisor>",
-			"<supervisor>\nStill no new progress. Restate the goal in one line, list what is already known, then pick a single concrete next step that moves toward it — not another exploratory call.\n</supervisor>",
-			"<supervisor>\nSeveral steps have passed without new progress. Re-anchor on the user's actual request: restate the goal, what is done, and the next concrete step — or report `blocked`.\n</supervisor>",
+			"<system-reminder>\nThe last few steps surfaced nothing new — this line of inquiry looks exhausted. Consider whether it can still reach what you need.\n</system-reminder>",
+			"<system-reminder>\nStill nothing new. Name in one line what you still need but have not found, then take a single concrete step toward the goal using what you already know — a decision or an action, not another exploratory probe.\n</system-reminder>",
+			"<system-reminder>\nThis exploration has stalled. Re-anchor on the user's actual request: state the goal in one line, what is done, and the one next step that delivers it — then take it. If no such step exists, report `blocked` with what is missing.\n</system-reminder>",
 		],
 		DetectorSignal::Truncation => &[
-			"<supervisor>\nYour recent tool results were truncated — the output is capped. Re-running the same kind of broad call returns no more content, only more wasted context.\n</supervisor>",
-			"<supervisor>\nYour recent tool results were truncated — the output is capped, so re-running the same kind of broad call returns no more, just more wasted context. You are narrowing your args but the results keep getting truncated. First, in one sentence: what are you actually trying to find in this output?\n\nThen narrow smart, not small:\n  • If a more specific tool exists (signatures, structural search, semantic search, grep), use it instead of reading raw content.\n  • If you need several specific parts, request them all in parallel — never one tiny chunk at a time.\n  • If you need only one specific part, target it with the tool's parameters (line range, limit, offset, filter, query/pattern).\n\nMany tiny sequential reads of the same file waste more context than fewer, better-targeted calls. Narrow means fewer, better-targeted calls — not more calls.\n</supervisor>",
-			"<supervisor>\nSTOP re-issuing broad calls that keep truncating — you are burning context for nothing. Use a more specific tool (signatures, structural/semantic search, grep) or target the exact span you need (line range, limit, offset, filter). If you cannot, report `blocked`.\n</supervisor>",
+			"<system-reminder>\nYour recent tool results were truncated — the output is capped. Re-running the same broad call returns no new content, only more wasted context.\n</system-reminder>",
+			"<system-reminder>\nThe output is capped — broadening the call adds nothing. First, what are you trying to find in it? Then narrow smart, not small — fewer, better-targeted calls:\n  • Prefer a specific tool over raw reads: signatures, structural search, semantic search, or grep.\n  • Need several parts? Request them in one parallel batch, not one chunk per turn.\n  • Need one part? Target it with the tool's parameters (line range, limit, offset, filter, query/pattern).\n</system-reminder>",
+			"<system-reminder>\nThese broad calls keep truncating and will not return more. Switch now to a specific tool (signatures, structural/semantic search, grep) or target the exact span with parameters (line range, limit, offset, filter). If you cannot, report `blocked`.\n</system-reminder>",
 		],
 		DetectorSignal::Dedup => &[
-			"<supervisor>\nThe call(s) you just made returned output you already received earlier this session — the body was elided because it is a duplicate. You already have this information in context.\n</supervisor>",
-			"<supervisor>\nStop re-fetching what you already have. First, in one sentence: what are you still missing that these repeated calls aren't giving you? Then either act on the results already in context, or change the arguments/tool to obtain something genuinely new.\n</supervisor>",
-			"<supervisor>\nSTOP — you are repeating the same call(s) and getting the same output you already have. This is a loop; it adds nothing and wastes context. Do NOT repeat them. Act on the results already in context, or change the args/tool to get something new. If you truly cannot proceed, report `blocked`.\n</supervisor>",
+			"<system-reminder>\nThese call(s) returned output you already received this session — the body was elided as a duplicate, so you already have it in context.\n</system-reminder>",
+			"<system-reminder>\nThese calls keep returning output you already hold — re-fetching adds no new information. Ask yourself what you are still missing, then act on the result already in context, or change the tool or arguments to get something genuinely new.\n</system-reminder>",
+			"<system-reminder>\nThis is a loop: the same call(s), the same output you already hold, no new information. Act on what is already in context, or switch to a different tool or arguments that returns something new. If neither moves the task, report `blocked`.\n</system-reminder>",
 		],
 		DetectorSignal::Distraction => &[
-			"<supervisor>\nYour recent results have drifted away from the line of work you were pursuing — they are unrelated to the current goal and crowd out what matters.\n</supervisor>",
-			"<supervisor>\nRefocus on the current goal. First, in one sentence: how do your recent calls connect to the user's actual request? If they don't, make your next calls target exactly what the goal needs — the specific files, symbols, or behavior involved. If you have deliberately moved on to a new sub-task, ignore this.\n</supervisor>",
-			"<supervisor>\nYour recent work has drifted away from the line you were pursuing — you are pulling in content unrelated to what you have been doing, which crowds out what matters. Refocus on the current goal: make your next calls target exactly what it needs (the specific files, symbols, or behavior involved). If you have deliberately moved on to a new sub-task, ignore this.\n</supervisor>",
+			"<system-reminder>\nYour recent results have drifted off the work you were pursuing — they no longer serve the current goal.\n</system-reminder>",
+			"<system-reminder>\nPull back to the goal. In one line: what does the task actually need, and do your recent calls serve it? If not, make your next calls target exactly that — the specific files, symbols, or behavior the goal involves. If you deliberately moved on to a new sub-task, ignore this.\n</system-reminder>",
+			"<system-reminder>\nRe-anchor now: state the goal in one line and the single next step it needs, then make your next calls hit exactly that — and nothing unrelated. If you cannot tie the next step to the goal, report `blocked`. If you deliberately moved on to a new sub-task, ignore this.\n</system-reminder>",
 		],
 		DetectorSignal::Sequential => &[
-			"<supervisor>\nYou have made several single-tool-call turns in a row. If the next calls are independent (they don't need each other's results), issue them together in one parallel batch instead of one per turn — it is faster and wastes less context.\n</supervisor>",
-			"<supervisor>\nYou keep issuing one tool call per turn. Before the next turn: list the calls you know you need. Any that don't depend on a prior result — fire them in the SAME batch, not sequentially. Only chain calls whose arguments genuinely depend on an earlier result.\n</supervisor>",
-			"<supervisor>\nStill one call per turn. Stop serializing independent work: name your next 2+ calls and send every call that doesn't depend on another's output in a single parallel batch. If each call truly depends on the previous result, this is fine — otherwise batch them now.\n</supervisor>",
+			"<system-reminder>\nYou have made several single-call turns in a row. For maximum efficiency, when your next operations are independent (none needs another's result), invoke them all in one parallel batch rather than one per turn — e.g. reading 3 files is 3 calls in one batch. It is faster and uses less context.\n</system-reminder>",
+			"<system-reminder>\nYou keep issuing one tool call per turn. Name the calls you need next, then send every one that does not depend on a prior result together in a single parallel batch — three independent reads go out as three calls at once. Only chain calls whose arguments genuinely depend on an earlier result.\n</system-reminder>",
+			"<system-reminder>\nStill one call per turn — stop serializing independent work. Name your next 2+ calls and send every independent one in a single parallel batch this turn. If each call truly depends on the previous result, serial is correct — keep it.\n</system-reminder>",
 		],
 		DetectorSignal::None => return "",
 	};
@@ -1070,5 +1110,23 @@ mod tests {
 		d.note_task(42);
 		let off = vec![0.0, 0.0, 1.0];
 		assert!(!d.note_result(&off, 0.5));
+	}
+
+	#[test]
+	fn conflict_framing_when_progressing_but_no_progress() {
+		// No-progress signal while the agent insists it is progressing → conflict text.
+		let conflict = steer_note(DetectorSignal::NoProgress, Some(SelfReport::Progressing), 0);
+		assert!(conflict.contains("disagree"));
+		// Without the progressing claim it stays the generic no-progress note.
+		let generic = steer_note(DetectorSignal::NoProgress, None, 0);
+		assert!(!generic.contains("disagree"));
+	}
+
+	#[test]
+	fn persistent_frame_clamps_stuck_signals_past_the_ladder() {
+		// A stuck signal re-firing past the 0→1→2 ladder holds the persistent frame.
+		assert!(steer_note(DetectorSignal::Loop, None, 5).contains("not working"));
+		// Advisory Sequential never escalates to the persistent frame.
+		assert!(!steer_note(DetectorSignal::Sequential, None, 5).contains("not working"));
 	}
 }

--- a/src/supervisor/gate.rs
+++ b/src/supervisor/gate.rs
@@ -20,12 +20,20 @@
 use crate::config::Config;
 use tokio::sync::watch;
 
-const GATE_PROMPT: &str = r#"You are a strict completion verifier. The agent claims a task is COMPLETE.
-Check the agent's final result against the user's request. Identify concrete, checkable gaps
-that mean the task is NOT actually done: missing steps, unmet requirements, or claims stated
-without evidence.
+const GATE_PROMPT: &str = r#"You are a strict completion verifier. A different agent claims its task is COMPLETE.
+Judge the END STATE, not the agent's story: ignore its self-report and stated claim, and
+check only what the AGENT FINAL RESULT actually evidences against the USER REQUEST.
 
-If the task is genuinely complete, output exactly:
+Work through every part of the request, one at a time. For each, find the concrete proof it
+was done — a file path, line or code excerpt, command output, or named test in the result. A
+part counts as done only if such evidence is present; a confident or well-formatted assertion
+with no locatable artifact does NOT count. Reason first, then decide. Do not reward length,
+formatting, or tone — only verifiable substance.
+
+Flag a gap only when a requested part is provably missing, a stated requirement is unmet, or a
+claim has no supporting evidence. Each gap must name the specific unmet item.
+
+If every part is evidenced — or you cannot point to a concrete unmet item — output exactly:
 <verdict>PASS</verdict>
 
 Otherwise output one line per gap (and nothing else):
@@ -40,12 +48,12 @@ pub enum GateVerdict {
 	Gaps(Vec<String>),
 }
 
-/// True when a message is a supervisor-injected note (a `<supervisor>` advisory
+/// True when a message is a supervisor-injected note (a `<system-reminder>` advisory
 /// or a `<recall>` block), not a genuine user turn. Lets the gate find the real
 /// task instead of verifying against its own prior advisory.
 pub fn is_supervisor_injection(content: &str) -> bool {
 	let t = content.trim_start();
-	t.starts_with("<supervisor>") || t.starts_with("<recall>")
+	t.starts_with("<system-reminder>") || t.starts_with("<recall>")
 }
 
 /// Verify a self-reported completion. `task` is the user's request, `result` is
@@ -116,7 +124,7 @@ fn parse_verdict(resp: &str) -> GateVerdict {
 /// Build the out-of-band advisory injected back into the loop on gaps.
 pub fn format_advisory(gaps: &[String]) -> String {
 	let mut s = String::from(
-		"<supervisor>\nBefore accepting completion, a verification pass found gaps:\n",
+		"<system-reminder>\nYou reported this task complete, but a verification pass found gaps before it can be accepted as done:\n",
 	);
 	for g in gaps {
 		s.push_str("- ");
@@ -124,7 +132,7 @@ pub fn format_advisory(gaps: &[String]) -> String {
 		s.push('\n');
 	}
 	s.push_str(
-		"Address them, then re-report your status. If they are already handled, explain why.\n</supervisor>",
+		"The task is not done until each gap is closed. For each, do the work, then cite the concrete evidence that closes it — the file and line, the passing test, or the command output. If a gap is already satisfied, point to that exact evidence rather than describing it. If a gap is wrong or out of scope, say so and why. Then re-report your status.\n</system-reminder>",
 	);
 	s
 }

--- a/src/supervisor/learning/extract.rs
+++ b/src/supervisor/learning/extract.rs
@@ -11,44 +11,47 @@ use crate::config::Config;
 use anyhow::Result;
 
 const EXTRACTION_SYSTEM_PROMPT: &str = r#"# Step 1: Decision
-First, decide: does this conversation contain any USER corrections or USER-stated rules?
-Output your decision:
+Scan for a USER turn that either (a) corrects the AI and states the fix, or (b) declares a
+project convention, preference, or constraint. The test is mechanical: can you copy a verbatim
+user line that supports a rule?
+Output your decision on its own line:
 <decision>LEARN</decision> or <decision>NONE</decision>
 
 If NONE, stop here. Do not output anything else.
 
 # Step 2: Extract (only if LEARN)
-For each lesson, you MUST provide the exact user quote as evidence.
-If you cannot quote the user, you do not have a lesson — skip it.
+Work quote-first, one lesson at a time:
+1. Copy the supporting USER line VERBATIM — exact characters from the transcript, no paraphrase or summary. This goes in evidence="...".
+2. ONLY THEN write the reusable rule it supports.
+If you cannot copy a verbatim user line for a candidate rule, drop it — a lesson with no real user quote is not a lesson. Never invent or stretch a quote to fill evidence.
 
 # What qualifies as a lesson
-- User correction: user explicitly said something is wrong and stated the fix
-- User-stated rule: user declared a project convention, preference, or constraint
-- Repeated failure: user corrected the same type of mistake more than once
+- User correction: the user said something is wrong and stated the fix
+- User-stated rule: the user declared a project convention, preference, or constraint
+- Repeated failure: the user corrected the same kind of mistake more than once
 
-# What does NOT qualify
+# What does NOT qualify (these have no user quote)
 - Anything the AI discovered, debugged, or figured out without user input
-- One-time implementation details or debugging steps
+- A successful AI action that received no user feedback
+- One-off implementation details or debugging steps
 - Generic knowledge any developer would know
-- Anything derivable by reading the codebase
-- Successful AI actions that received no user feedback
+- Anything recoverable by reading the codebase
 
 # Scope (REQUIRED on every lesson)
-- scope="global": a durable preference about HOW THIS USER WORKS, true in EVERY
-  project and role (e.g. "always open a single PR", "never add silent fallbacks",
-  "the user runs build/test commands themselves"). Use ONLY when the rule is
-  clearly about the user's general way of working — NOT tied to this task, this
-  project, or this role.
+- scope="global": a durable fact about HOW THIS USER WORKS, true in EVERY project and role
+  (e.g. "always open a single PR", "never add silent fallbacks", "the user runs build/test
+  commands themselves"). Use ONLY when the quote is clearly about the user's general way of
+  working — NOT tied to this task, this project, or this role.
 - scope="scoped" (default): a rule about THIS project, role, or task.
-Be conservative: most lessons are "scoped". When unsure, use "scoped".
+Most lessons are scoped. When unsure, use "scoped".
 
 # Rules
-- Max 3 lessons. One strong lesson is better than three weak ones.
-- confidence=high: direct user correction ("no, do X instead")
-- confidence=medium: user-stated preference without direct correction
+- Max 3 lessons; copy a distinct verbatim quote for each. One strong lesson beats three weak ones.
+- confidence=high: the quote is a direct correction ("no, do X instead")
+- confidence=medium: the quote states a preference without a direct correction
 - State each lesson as a reusable rule, not a narrative
 
-# Existing Lessons (DO NOT duplicate; refine one only if the user changed their mind)
+# Existing Lessons (DO NOT duplicate; refine one only if a new user quote shows they changed their mind)
 {existing_lessons}
 
 # Output Format
@@ -64,8 +67,9 @@ Capture up to 2 pieces of DURABLE UNDERSTANDING about the subject that took real
 to discover and would save re-exploration next time: architecture, key decisions,
 structure, constraints, or non-obvious facts (e.g. "auth is delegated to octolib",
 "deploy runs on GitLab not GitHub", "the dataset's date column is epoch milliseconds").
-Do NOT capture transient state, exact line numbers, or anything one search recovers.
-These need no user quote.
+Capture a fact ONLY if you can point to where in this work it was established; if you cannot,
+omit it — capturing 0 is fine. Skip transient state, exact line numbers, and anything one
+search recovers. These need no user quote.
 <orientation tags="keyword1,keyword2" confidence="high|medium">
 A durable, reusable fact about how the subject works.
 </orientation>"#;

--- a/src/supervisor/learning/inject.rs
+++ b/src/supervisor/learning/inject.rs
@@ -10,20 +10,31 @@ use crate::config::Config;
 use anyhow::Result;
 
 const FILE_RETRIEVAL_PROMPT: &str = r#"# Task
-Given the user's request below, output 3-5 search keywords (one per line) to find relevant lessons from past sessions.
+Given the user's request below, output 3-5 search keywords to recall relevant lessons from past sessions.
 
-# Rules
-- Focus on: tool names, error names, domain terms, API names, action verbs.
-- One keyword per line, lowercase.
-- Output ONLY the keywords — no explanations, no numbering, no punctuation."#;
+# Output format
+Write each keyword on its own line, lowercase, a single word or short term. Output only the keywords — no numbering, no surrounding punctuation, no explanations (each line is used verbatim as a search term).
+
+Example output:
+rate limit
+retry backoff
+http client
+reqwest
+
+# What makes a good keyword
+Draw from the request's tool names, error names, domain terms, API names, and action verbs."#;
 
 const MCP_RETRIEVAL_PROMPT: &str = r#"# Task
-Given the user's request below, write a single concise semantic search query to find relevant lessons from past sessions.
+Given the user's request below, write one semantic search query to recall relevant lessons from past sessions.
 
-# Rules
-- Natural language, optimized for embedding similarity search.
-- Include key domain terms and intent.
-- Output ONLY the query — one line, no explanations."#;
+# Output format
+Return exactly one line of natural language — output that line only (every extra line becomes a separate spurious query).
+
+Example output:
+retry logic and backoff for rate-limited http requests in the api client
+
+# What makes a good query
+State the core intent in plain language and include the key domain terms, optimized for embedding similarity."#;
 
 /// Retrieve relevant lessons for the current message and format them for
 /// injection. Two tiers:
@@ -147,18 +158,18 @@ pub async fn retrieve_and_format(
 	// rules; orientation is working assumptions to verify, never truth.
 	let mut inner = String::new();
 	if !lesson_block.is_empty() {
-		inner.push_str("<lessons>\n");
+		inner.push_str("<lessons>\nRules learned in past sessions — follow them. [n] is confidence in [0,1]; weight your adherence by it.\n");
 		inner.push_str(&lesson_block);
 		inner.push_str("</lessons>\n");
 	}
 	if !orient_block.is_empty() {
 		inner.push_str(
-			"<orientation hint=\"working assumptions — verify before relying on them\">\n",
+			"<orientation hint=\"working assumptions — verify before relying on them\">\nUnverified guesses, not facts. Before acting on one, open the relevant code and confirm it; if the code doesn't back it, drop it.\n",
 		);
 		inner.push_str(&orient_block);
 		inner.push_str("</orientation>\n");
 	}
-	let out = format!("\n\n<recall>\n{inner}</recall>");
+	let out = format!("\n\n<recall>\nRecall from past sessions, relevant to the current task — apply it now.\n{inner}</recall>");
 	(out, new_contents)
 }
 

--- a/src/supervisor/recite.rs
+++ b/src/supervisor/recite.rs
@@ -29,18 +29,17 @@ use crate::session::anchor::Anchor;
 ///
 /// Recites `intent` verbatim — it is immutable (first-write-wins) so it never
 /// drifts — and the last-known `next_steps`, explicitly labelled stale because
-/// they only refresh at compaction. Wrapped in `<supervisor>` so
+/// they only refresh at compaction. Wrapped in `<system-reminder>` so
 /// [`crate::supervisor::gate::is_supervisor_injection`] excludes it from the
 /// verify-gate's real-task search.
 pub fn recite_note(anchor: &Anchor) -> Option<String> {
 	if anchor.intent.is_empty() && anchor.next_steps.is_empty() {
 		return None;
 	}
-	let mut s = String::from(
-		"<supervisor>\nStay anchored to the goal — keep it in view across this long session:\n",
-	);
+	let mut s =
+		String::from("<system-reminder>\nYou are deep in this session — re-anchor on your goal:\n");
 	if !anchor.intent.is_empty() {
-		s.push_str("<intent>");
+		s.push_str("Goal (fixed): <intent>");
 		s.push_str(anchor.intent.trim());
 		s.push_str("</intent>\n");
 	}
@@ -55,7 +54,7 @@ pub fn recite_note(anchor: &Anchor) -> Option<String> {
 			}
 		}
 	}
-	s.push_str("</supervisor>");
+	s.push_str("</system-reminder>");
 	Some(s)
 }
 

--- a/src/supervisor/stats.rs
+++ b/src/supervisor/stats.rs
@@ -48,6 +48,8 @@ struct Stats {
 	gate_pass: u64,
 	gate_fail: u64,
 	steers: u64,
+	pregate_blocks: u64,
+	claim_blocks: u64,
 	lessons_stored: u64,
 	orientation_stored: u64,
 	recalls_injected: u64,
@@ -96,6 +98,14 @@ pub fn gate_fail() {
 pub fn steer() {
 	with(|s| s.steers += 1);
 }
+/// The deterministic pre-gate refused a `done` (code changed, no check ran).
+pub fn pregate_block() {
+	with(|s| s.pregate_blocks += 1);
+}
+/// The evidence check refused a `done` (cited quotes absent from tool output).
+pub fn claim_block() {
+	with(|s| s.claim_blocks += 1);
+}
 /// `n` lessons were stored by distill.
 pub fn lessons(n: u64) {
 	with(|s| s.lessons_stored += n);
@@ -116,6 +126,8 @@ pub fn snapshot() -> Option<serde_json::Value> {
 	let idle = s.calls == 0
 		&& s.gate_runs == 0
 		&& s.steers == 0
+		&& s.pregate_blocks == 0
+		&& s.claim_blocks == 0
 		&& s.lessons_stored == 0
 		&& s.orientation_stored == 0
 		&& s.recalls_injected == 0;
@@ -134,6 +146,8 @@ pub fn snapshot() -> Option<serde_json::Value> {
 		"gate_pass": s.gate_pass,
 		"gate_fail": s.gate_fail,
 		"steers": s.steers,
+		"pregate_blocks": s.pregate_blocks,
+		"claim_blocks": s.claim_blocks,
 		"lessons_stored": s.lessons_stored,
 		"orientation_stored": s.orientation_stored,
 		"recalls_injected": s.recalls_injected,

--- a/src/utils/truncation.rs
+++ b/src/utils/truncation.rs
@@ -301,11 +301,11 @@ pub fn truncate_mcp_response_global(
 	// the write fails — both still carry the tag + tool-specific narrowing hint.
 	let notice = match crate::utils::spill::write_spill(tool_name, content) {
 		Some(path) => format!(
-			"\n\n──────────\n{TRUNCATION_NOTICE_TAG}: showing only the first ~{max_tokens} of ~{token_count} tokens (~{omitted} cut from the end). The FULL untruncated output was saved to:\n  {path}\nDo NOT re-run this call — identical arguments return this same truncated output. Instead, either:\n- Read a specific span from the spill file above (line range or symbol).\n- Use a search tool to locate the exact symbol or pattern without re-reading the whole output.\nTo narrow at the source instead, {hint}.",
+			"\n\n──────────\n{TRUNCATION_NOTICE_TAG}: showing only the first ~{max_tokens} of ~{token_count} tokens (~{omitted} cut from the end). Identical arguments return this same truncated output, so re-running wastes a turn. The full output was saved here:\n  {path}\nTo get the rest, read the span you need from that file (a line range or a single symbol), or run a search tool against it to jump to the exact pattern. To return less at the source next time, {hint}.",
 			path = path.display(),
 		),
 		None => format!(
-			"\n\n──────────\n{TRUNCATION_NOTICE_TAG}: showing only the first ~{max_tokens} of ~{token_count} tokens (~{omitted} cut from the end). Do NOT re-run this call — identical arguments return this same truncated output. Instead, use a search tool to locate the exact symbol or pattern without re-running. To narrow at the source instead, {hint}."
+			"\n\n──────────\n{TRUNCATION_NOTICE_TAG}: showing only the first ~{max_tokens} of ~{token_count} tokens (~{omitted} cut from the end). The cut tail is not in this result, and identical arguments return this same truncated output, so re-running wastes a turn. To get the rest, re-issue a narrower call that returns less — {hint}. If what you need is in the shown portion above, read or search it there instead of re-fetching."
 		),
 	};
 

--- a/src/websocket/server.rs
+++ b/src/websocket/server.rs
@@ -408,7 +408,12 @@ fn spawn_ws_inbox_monitor(
 						},
 					));
 
-					if let Err(e) = chat_session.add_user_message(&inbox_msg.content) {
+					let add_result = if inbox_msg.source.is_system_managed() {
+						chat_session.add_system_managed_user_message(&inbox_msg.content)
+					} else {
+						chat_session.add_user_message(&inbox_msg.content)
+					};
+					if let Err(e) = add_result {
 						log_error!("WS monitor: failed to add inbox message: {}", e);
 						sessions
 							.lock()
@@ -909,7 +914,11 @@ async fn handle_user_message(
 				}),
 			)
 			.await?;
-			chat_session.add_user_message(&inbox_msg.content)?;
+			if inbox_msg.source.is_system_managed() {
+				chat_session.add_system_managed_user_message(&inbox_msg.content)?;
+			} else {
+				chat_session.add_user_message(&inbox_msg.content)?;
+			}
 			let op_rx = cancellation.new_operation();
 			// Per-request spending boundary (see handle_user_message).
 			chat_session.start_request_spending_tracking();


### PR DESCRIPTION
- Introduce is_real_user_task_message to filter synthetic input
- Add add_system_managed_user_message to handle automated injections
- Prevent system-managed messages from triggering steer resets
- Update conversation compression to ignore system-managed content
- Refine capability activation to trigger only on real user tasks
- Mark tool result hints and steers as system-managed
- Implement deduplication for pre-gate verification nudges
- Track and report pregate and claim block statistics in supervisor
- Update websocket server and session processing to filter managed roles
- Centralize pre-gate markers and notes as constants