### PR TITLE
feat(mcp): enhance subagent handoff and plan recitation

### DIFF
--- a/src/mcp/agent/functions.rs
+++ b/src/mcp/agent/functions.rs
@@ -119,6 +119,11 @@ pub fn get_all_functions(config: &crate::config::Config) -> Vec<McpFunction> {
 /// Execute an agent tool call.
 /// For config-defined agents: spawns subprocess via ACP command.
 /// For dynamic agents: executes in-process using ChatSession.
+/// Appended to every subagent task. Children return free-text, so without a
+/// contract a child can dump raw output verbatim into the parent's context. The
+/// compact handoff keeps fan-out cheap — the SOTA sub-agent rule.
+const AGENT_OUTPUT_CONTRACT: &str = "Return format: reply with a concise summary (≤2000 tokens) of what you did and what you found, plus the exact file paths involved. Do not paste full file contents or raw command output — the caller can open the files by path if it needs them.";
+
 pub async fn execute_agent_command(
 	call: &McpToolCall,
 	config: &crate::config::Config,
@@ -145,6 +150,8 @@ pub async fn execute_agent_command(
 			));
 		}
 	};
+	let augmented_task = format!("{}\n\n---\n{AGENT_OUTPUT_CONTRACT}", task.trim_end());
+	let task = augmented_task.as_str();
 
 	// Check config-defined agents first (subprocess execution)
 	let config_agent = config.agents.iter().find(|a| a.name == agent_name).cloned();

--- a/src/mcp/core/plan/core.rs
+++ b/src/mcp/core/plan/core.rs
@@ -866,6 +866,42 @@ pub fn get_completed_task_count() -> Result<usize> {
 	storage.get_completed_task_count()
 }
 
+/// Compact live checklist for goal recitation: status icon + title only (no
+/// descriptions), the active task marked. Sync — safe at the pre-request
+/// injection point. Returns None when no plan is active.
+pub fn render_plan_checklist() -> Option<String> {
+	let storage = get_storage();
+	let storage = storage.lock().unwrap();
+	if !storage.has_active_plan().unwrap_or(false) {
+		return None;
+	}
+	let task_list = storage.get_task_list().ok()?;
+	if task_list.is_empty() {
+		return None;
+	}
+	let current = storage
+		.get_current_task_info()
+		.map(|(c, _, _, _)| c)
+		.unwrap_or(0);
+	let completed = task_list
+		.iter()
+		.filter(|(_, _, status)| matches!(status, TaskStatus::Completed))
+		.count();
+
+	let mut s = format!("Live plan ({completed}/{} done):\n", task_list.len());
+	for (i, (title, _desc, status)) in task_list.iter().enumerate() {
+		let num = i + 1;
+		let icon = match status {
+			TaskStatus::Completed => "✅",
+			TaskStatus::InProgress if num == current => "🔄",
+			TaskStatus::InProgress => "⏳",
+		};
+		let marker = if num == current { " ← current" } else { "" };
+		s.push_str(&format!("{icon} {title}{marker}\n"));
+	}
+	Some(s)
+}
+
 /// Get current plan display for session commands
 pub async fn get_current_plan_display() -> Result<String> {
 	let storage = get_storage();

--- a/src/mcp/core/plan/mod.rs
+++ b/src/mcp/core/plan/mod.rs
@@ -39,8 +39,8 @@ pub use compression::{
 pub use core::{
 	clear_plan_data, clear_task_start_index, execute_plan, get_and_clear_start_index,
 	get_completed_task_count, get_current_plan_display, get_current_task_start_index,
-	get_last_completed_task_for_compression, has_active_plan, set_current_task_start_index,
-	set_last_task_message_range,
+	get_last_completed_task_for_compression, has_active_plan, render_plan_checklist,
+	set_current_task_start_index, set_last_task_message_range,
 };
 pub use memory_storage::MemoryPlanStorage;
 pub use storage::{ExecutionPlan, MessageRange, PlanStatus, PlanStorage, PlanTask, TaskStatus};

--- a/src/session/chat/response.rs
+++ b/src/session/chat/response.rs
@@ -728,7 +728,7 @@ pub async fn process_response<S: OutputSink>(
 						if round_signal == crate::supervisor::detect::DetectorSignal::Distraction {
 							params.chat_session.detectors.reset_working_set();
 						}
-						crate::supervisor::stats::steer();
+						crate::supervisor::stats::steer(round_signal);
 						crate::supervisor::notify(&format!(
 							"steering — {}",
 							crate::supervisor::detect::signal_description(round_signal)

--- a/src/session/chat/session/api_executor.rs
+++ b/src/session/chat/session/api_executor.rs
@@ -180,9 +180,13 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 	// recency window — and crucially BEFORE the cache-marker advance below, so the
 	// cached prefix stays intact (the recited block lands after it each turn).
 	if config.supervisor.enabled && config.supervisor.recite.enabled {
-		if let Some(note) =
-			crate::supervisor::recite::recite_note(&chat_session.session.info.anchor)
-		{
+		// Prefer the live plan checklist (refreshed every turn from plan storage)
+		// over the anchor's stale next_steps snapshot for the recency-slot block.
+		let plan_checklist = crate::mcp::core::plan::render_plan_checklist();
+		if let Some(note) = crate::supervisor::recite::recite_note(
+			&chat_session.session.info.anchor,
+			plan_checklist.as_deref(),
+		) {
 			chat_session.add_system_managed_user_message(&note)?;
 			crate::log_debug!("Supervisor goal recitation injected");
 		}

--- a/src/session/chat/session/commands/display.rs
+++ b/src/session/chat/session/commands/display.rs
@@ -612,7 +612,28 @@ pub fn display_info(output: &CommandOutput) {
 				activity.push(format!("{} recalls", recalls));
 			}
 			if steers > 0 {
-				activity.push(format!("{} steers", steers));
+				let by_signal: Vec<String> = sstats
+					.get("steer_signals")
+					.and_then(|v| v.as_array())
+					.map(|a| {
+						a.iter()
+							.filter_map(|e| {
+								let label = e.get("label")?.as_str()?;
+								let count = e.get("count")?.as_u64()?;
+								Some(format!("{} {}", count, label))
+							})
+							.collect()
+					})
+					.unwrap_or_default();
+				if by_signal.is_empty() {
+					activity.push(format!("{} steers", steers));
+				} else {
+					activity.push(format!(
+						"{} steers ({})",
+						steers,
+						by_signal.join(&format!(" {} ", dot))
+					));
+				}
 			}
 			if pregate_blocks > 0 {
 				activity.push(format!("{} check-blocks", pregate_blocks));

--- a/src/supervisor/recite.rs
+++ b/src/supervisor/recite.rs
@@ -25,15 +25,18 @@
 use crate::session::anchor::Anchor;
 
 /// Build the recitation note for the context tail, or `None` when there is
-/// nothing durable to recite yet (no compaction has populated the anchor).
+/// nothing durable to recite yet.
 ///
 /// Recites `intent` verbatim — it is immutable (first-write-wins) so it never
-/// drifts — and the last-known `next_steps`, explicitly labelled stale because
-/// they only refresh at compaction. Wrapped in `<system-reminder>` so
-/// [`crate::supervisor::gate::is_supervisor_injection`] excludes it from the
-/// verify-gate's real-task search.
-pub fn recite_note(anchor: &Anchor) -> Option<String> {
-	if anchor.intent.is_empty() && anchor.next_steps.is_empty() {
+/// drifts. For the "what to do now" part it prefers the LIVE plan checklist
+/// (`plan_checklist`, re-read every turn from the plan tool's storage) over the
+/// `next_steps` snapshot, which only refreshes at compaction and is stale
+/// between. With an active plan it recites even before the first compaction —
+/// that is exactly when goal drift on a long task is most expensive. Wrapped in
+/// `<system-reminder>` so [`crate::supervisor::gate::is_supervisor_injection`]
+/// excludes it from the verify-gate's real-task search.
+pub fn recite_note(anchor: &Anchor, plan_checklist: Option<&str>) -> Option<String> {
+	if anchor.intent.is_empty() && anchor.next_steps.is_empty() && plan_checklist.is_none() {
 		return None;
 	}
 	let mut s =
@@ -43,7 +46,12 @@ pub fn recite_note(anchor: &Anchor) -> Option<String> {
 		s.push_str(anchor.intent.trim());
 		s.push_str("</intent>\n");
 	}
-	if !anchor.next_steps.is_empty() {
+	// Prefer the live plan checklist (current every turn) over the stale
+	// next_steps snapshot; fall back to next_steps only when no plan is active.
+	if let Some(checklist) = plan_checklist.map(str::trim).filter(|c| !c.is_empty()) {
+		s.push_str(checklist);
+		s.push('\n');
+	} else if !anchor.next_steps.is_empty() {
 		s.push_str("Last-known next steps (may be stale — re-check against current state):\n");
 		for step in &anchor.next_steps {
 			let step = step.trim();
@@ -65,7 +73,7 @@ mod tests {
 
 	#[test]
 	fn empty_anchor_recites_nothing() {
-		assert!(recite_note(&Anchor::default()).is_none());
+		assert!(recite_note(&Anchor::default(), None).is_none());
 	}
 
 	#[test]
@@ -79,7 +87,7 @@ mod tests {
 			},
 			0,
 		);
-		let note = recite_note(&a).expect("should recite");
+		let note = recite_note(&a, None).expect("should recite");
 		// Excluded from the gate's real-task search.
 		assert!(crate::supervisor::gate::is_supervisor_injection(&note));
 		assert!(note.contains("<intent>Add the truncation detector</intent>"));
@@ -96,8 +104,42 @@ mod tests {
 			},
 			0,
 		);
-		let note = recite_note(&a).expect("should recite");
+		let note = recite_note(&a, None).expect("should recite");
 		assert!(note.contains("<intent>Refactor auth</intent>"));
 		assert!(!note.contains("Last-known next steps"));
+	}
+
+	#[test]
+	fn live_plan_checklist_preferred_over_stale_next_steps() {
+		let mut a = Anchor::default();
+		a.extend(
+			AnchorUpdate {
+				intent: Some("Ship the feature".to_string()),
+				next_steps: vec!["STALE step".to_string()],
+				..Default::default()
+			},
+			0,
+		);
+		let note = recite_note(
+			&a,
+			Some("Live plan (1/2 done):\n✅ done it\n🔄 do this ← current"),
+		)
+		.expect("should recite");
+		assert!(note.contains("<intent>Ship the feature</intent>"));
+		assert!(note.contains("🔄 do this ← current"));
+		// The live checklist replaces the stale snapshot entirely.
+		assert!(!note.contains("STALE step"));
+		assert!(!note.contains("Last-known next steps"));
+	}
+
+	#[test]
+	fn live_plan_recites_even_with_empty_anchor() {
+		let note = recite_note(
+			&Anchor::default(),
+			Some("Live plan (0/1 done):\n🔄 first ← current"),
+		)
+		.expect("active plan recites pre-compaction");
+		assert!(crate::supervisor::gate::is_supervisor_injection(&note));
+		assert!(note.contains("🔄 first ← current"));
 	}
 }

--- a/src/supervisor/stats.rs
+++ b/src/supervisor/stats.rs
@@ -48,6 +48,13 @@ struct Stats {
 	gate_pass: u64,
 	gate_fail: u64,
 	steers: u64,
+	// Per-signal steer breakdown — which detector signal fired each steer.
+	steer_loop: u64,
+	steer_no_progress: u64,
+	steer_truncation: u64,
+	steer_dedup: u64,
+	steer_distraction: u64,
+	steer_sequential: u64,
 	pregate_blocks: u64,
 	claim_blocks: u64,
 	lessons_stored: u64,
@@ -94,9 +101,22 @@ pub fn gate_pass() {
 pub fn gate_fail() {
 	with(|s| s.gate_fail += 1);
 }
-/// A steer (advisory re-anchor) was queued.
-pub fn steer() {
-	with(|s| s.steers += 1);
+/// A steer (advisory re-anchor) was queued, attributed to the detector signal
+/// that fired it so `/info` can break the total down by signal.
+pub fn steer(signal: crate::supervisor::detect::DetectorSignal) {
+	use crate::supervisor::detect::DetectorSignal;
+	with(|s| {
+		s.steers += 1;
+		match signal {
+			DetectorSignal::Loop => s.steer_loop += 1,
+			DetectorSignal::NoProgress => s.steer_no_progress += 1,
+			DetectorSignal::Truncation => s.steer_truncation += 1,
+			DetectorSignal::Dedup => s.steer_dedup += 1,
+			DetectorSignal::Distraction => s.steer_distraction += 1,
+			DetectorSignal::Sequential => s.steer_sequential += 1,
+			DetectorSignal::None => {}
+		}
+	});
 }
 /// The deterministic pre-gate refused a `done` (code changed, no check ran).
 pub fn pregate_block() {
@@ -134,6 +154,19 @@ pub fn snapshot() -> Option<serde_json::Value> {
 	if idle {
 		return None;
 	}
+	// Steer breakdown by signal — ordered, non-zero only, so display stays generic.
+	let steer_signals: Vec<serde_json::Value> = [
+		("loop", s.steer_loop),
+		("no-progress", s.steer_no_progress),
+		("truncation", s.steer_truncation),
+		("dedup", s.steer_dedup),
+		("drift", s.steer_distraction),
+		("sequential", s.steer_sequential),
+	]
+	.into_iter()
+	.filter(|(_, n)| *n > 0)
+	.map(|(label, n)| serde_json::json!({ "label": label, "count": n }))
+	.collect();
 	Some(serde_json::json!({
 		"calls": s.calls,
 		"recall_calls": s.recall_calls,
@@ -146,6 +179,7 @@ pub fn snapshot() -> Option<serde_json::Value> {
 		"gate_pass": s.gate_pass,
 		"gate_fail": s.gate_fail,
 		"steers": s.steers,
+		"steer_signals": steer_signals,
 		"pregate_blocks": s.pregate_blocks,
 		"claim_blocks": s.claim_blocks,
 		"lessons_stored": s.lessons_stored,


### PR DESCRIPTION
- Implement render_plan_checklist for live goal tracking
- Integrate live plan checklist into supervisor recitation
- Prioritize live plan over stale next_steps snapshots
- Allow recitation before first compaction if active plan exists
- Add output contracts to subagent tasks to limit token usage
- Update recite_note signature to accept optional plan checklist
- Add tests for plan preference and pre-compaction recitation