### PR TITLE
fix(session): defer plan compression until turn acceptance

### DIFF
--- a/src/session/chat/response.rs
+++ b/src/session/chat/response.rs
@@ -983,78 +983,12 @@ pub async fn process_response<S: OutputSink>(
 	// `<validation validator="…">…</validation>` into the inbox.
 	crate::session::hooks::run_turn_validators(&session_id, params.role, &current_content).await;
 
-	// 🗜️ DEFERRED PLAN COMPRESSION: Process plan(done) compression after assistant message
-	// When plan(done) triggers compression, we defer it to here so the follow-up API call
-	// (which generates the "plan completed" response) benefits from cache hits on the
-	// unmodified conversation. Compression runs now — after the response is displayed —
-	// so the session saves with compressed state for the next user turn.
-	if crate::mcp::core::plan::has_pending_project_compression() {
-		log_debug!("Processing deferred plan(done) compression after assistant response");
-
-		// Task compression (forced for last task)
-		match crate::mcp::core::plan::process_pending_compression(params.chat_session).await {
-			Ok(Some(metrics)) => {
-				params
-					.chat_session
-					.session
-					.info
-					.compression_stats
-					.add_compression(
-						crate::session::CompressionKind::Task,
-						metrics.messages_removed,
-						metrics.tokens_saved,
-					);
-				CostTracker::display_compression_result("Task", &metrics);
-			}
-			Ok(None) => {}
-			Err(e) => {
-				log_debug!("Deferred task compression failed: {}. Continuing.", e);
-			}
-		}
-
-		// Phase compression
-		match crate::mcp::core::plan::process_pending_phase_compression(params.chat_session).await {
-			Ok(Some(metrics)) => {
-				params
-					.chat_session
-					.session
-					.info
-					.compression_stats
-					.add_compression(
-						crate::session::CompressionKind::Phase,
-						metrics.messages_removed,
-						metrics.tokens_saved,
-					);
-				CostTracker::display_compression_result("Phase", &metrics);
-			}
-			Ok(None) => {}
-			Err(e) => {
-				log_debug!("Deferred phase compression failed: {}. Continuing.", e);
-			}
-		}
-
-		// Project compression
-		match crate::mcp::core::plan::process_pending_project_compression(params.chat_session).await
-		{
-			Ok(Some(metrics)) => {
-				params
-					.chat_session
-					.session
-					.info
-					.compression_stats
-					.add_compression(
-						crate::session::CompressionKind::Project,
-						metrics.messages_removed,
-						metrics.tokens_saved,
-					);
-				CostTracker::display_compression_result("Project", &metrics);
-			}
-			Ok(None) => {}
-			Err(e) => {
-				log_debug!("Deferred project compression failed: {}. Continuing.", e);
-			}
-		}
-	}
+	// 🗜️ DEFERRED PLAN COMPRESSION: queued by plan(done), NOT run here.
+	// It must only fire once the turn's completion is actually accepted — the
+	// verify-gate runs after process_response, and on gaps it re-runs the turn.
+	// Compressing here would wipe the detailed context the re-run needs. So the
+	// caller (execute_api_call_and_process_response) invokes
+	// `run_deferred_plan_compression` at a non-re-run exit instead.
 
 	// Emit cost message through sink (WebSocket/JSONL)
 	let total_tokens = params.chat_session.session.info.input_tokens
@@ -1083,4 +1017,59 @@ pub async fn process_response<S: OutputSink>(
 		}
 	}
 	Ok(())
+}
+
+/// Run the plan(done) deferred compression (task → phase → project), queued by
+/// plan(done) and held until the turn's completion is accepted. Called by
+/// `execute_api_call_and_process_response` at a non-re-run exit — after the
+/// verify-gate passes, or when no gate applies. The gate's gap path re-runs the
+/// turn (returning early), so a rejected completion never reaches this point and
+/// the detailed context stays intact for the re-run. No-op when nothing pending.
+pub async fn run_deferred_plan_compression(chat_session: &mut ChatSession) {
+	if !crate::mcp::core::plan::has_pending_project_compression() {
+		return;
+	}
+	log_debug!("Processing deferred plan(done) compression after completion accepted");
+
+	// Task compression (forced for last task)
+	match crate::mcp::core::plan::process_pending_compression(chat_session).await {
+		Ok(Some(metrics)) => {
+			chat_session.session.info.compression_stats.add_compression(
+				crate::session::CompressionKind::Task,
+				metrics.messages_removed,
+				metrics.tokens_saved,
+			);
+			CostTracker::display_compression_result("Task", &metrics);
+		}
+		Ok(None) => {}
+		Err(e) => log_debug!("Deferred task compression failed: {}. Continuing.", e),
+	}
+
+	// Phase compression
+	match crate::mcp::core::plan::process_pending_phase_compression(chat_session).await {
+		Ok(Some(metrics)) => {
+			chat_session.session.info.compression_stats.add_compression(
+				crate::session::CompressionKind::Phase,
+				metrics.messages_removed,
+				metrics.tokens_saved,
+			);
+			CostTracker::display_compression_result("Phase", &metrics);
+		}
+		Ok(None) => {}
+		Err(e) => log_debug!("Deferred phase compression failed: {}. Continuing.", e),
+	}
+
+	// Project compression
+	match crate::mcp::core::plan::process_pending_project_compression(chat_session).await {
+		Ok(Some(metrics)) => {
+			chat_session.session.info.compression_stats.add_compression(
+				crate::session::CompressionKind::Project,
+				metrics.messages_removed,
+				metrics.tokens_saved,
+			);
+			CostTracker::display_compression_result("Project", &metrics);
+		}
+		Ok(None) => {}
+		Err(e) => log_debug!("Deferred project compression failed: {}. Continuing.", e),
+	}
 }

--- a/src/session/chat/session/api_executor.rs
+++ b/src/session/chat/session/api_executor.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::response::{process_response, ResponseProcessingParams};
+use super::super::response::{
+	process_response, run_deferred_plan_compression, ResponseProcessingParams,
+};
 use super::super::CostTracker;
 use super::core::ChatSession;
 use super::error_utils::display_rate_limit_info;
@@ -470,6 +472,14 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 			}
 		}
 	}
+
+	// Deferred plan(done) compression: held until the turn's completion is
+	// accepted, so it runs ONCE here — a non-re-run exit reached only after the
+	// verify-gate passed (or when no gate applied / iterations were exhausted).
+	// The gate's gap path returns earlier to re-run the turn, so a rejected
+	// completion never compresses and the re-run keeps full context. No-op unless
+	// plan(done) queued a project compression.
+	run_deferred_plan_compression(chat_session).await;
 
 	Ok(())
 }

--- a/src/session/chat/session/utils.rs
+++ b/src/session/chat/session/utils.rs
@@ -112,7 +112,10 @@ pub async fn get_initial_messages(
 						// this as system-managed (is_real_user_task_message) and never
 						// mistakes the project instructions for a genuine user task. Mirrors
 						// the non-interactive path in prompt_setup.rs.
-						content: format!("<instructions>\n{}\n</instructions>", processed_instructions),
+						content: format!(
+							"<instructions>\n{}\n</instructions>",
+							processed_instructions
+						),
 						timestamp: std::time::SystemTime::now()
 							.duration_since(std::time::UNIX_EPOCH)
 							.unwrap_or_default()

--- a/src/session/chat/session/utils.rs
+++ b/src/session/chat/session/utils.rs
@@ -108,7 +108,11 @@ pub async fn get_initial_messages(
 
 					let instructions_msg = crate::session::Message {
 						role: "user".to_string(),
-						content: processed_instructions,
+						// Wrap in <instructions> so task/compression/learning logic treats
+						// this as system-managed (is_real_user_task_message) and never
+						// mistakes the project instructions for a genuine user task. Mirrors
+						// the non-interactive path in prompt_setup.rs.
+						content: format!("<instructions>\n{}\n</instructions>", processed_instructions),
 						timestamp: std::time::SystemTime::now()
 							.duration_since(std::time::UNIX_EPOCH)
 							.unwrap_or_default()


### PR DESCRIPTION
- Move plan compression from process_response to api_executor
- Prevent context loss during verify-gate re-runs
- Wrap initial instructions in tags to distinguish from user tasks