### PR TITLE
feat(workflow): capture stderr for process failures

### DIFF
--- a/src/session/chat/response.rs
+++ b/src/session/chat/response.rs
@@ -636,6 +636,15 @@ pub async fn process_response<S: OutputSink>(
 						let is_error = tr.map(|r| r.is_error()).unwrap_or(true);
 						let is_mutation =
 							crate::supervisor::detect::is_mutation_tool(&call.tool_name);
+						// Verify-gate evidence ledger: record what actually executed —
+						// completion claims are checked against this, not the narrative.
+						params.chat_session.evidence.record(
+							&call.tool_name,
+							&call.parameters,
+							is_mutation,
+							is_error,
+							result_content.len(),
+						);
 						// Tool-agnostic: detect truncation by the sentinel the global
 						// truncation choke point stamps, not by tool identity.
 						let is_truncated = result_content

--- a/src/session/chat/session/api_executor.rs
+++ b/src/session/chat/session/api_executor.rs
@@ -417,6 +417,7 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 			.unwrap_or_default();
 		let result = chat_session.last_response.clone();
 		let claim = chat_session.last_self_report_reason.clone();
+		let actions = chat_session.evidence.render();
 		crate::supervisor::stats::gate_run();
 		animation_manager.set_phase("Verifying completion …").await;
 		let verdict = crate::supervisor::gate::verify(
@@ -424,6 +425,7 @@ pub async fn execute_api_call_and_process_response<S: OutputSink>(
 			&task,
 			&result,
 			claim.as_deref(),
+			&actions,
 			operation_rx.clone(),
 		)
 		.await;

--- a/src/session/chat/session/core.rs
+++ b/src/session/chat/session/core.rs
@@ -231,6 +231,10 @@ pub struct ChatSession {
 	/// Supervisor: entries recalled during the current trajectory (content, role,
 	/// project). The verify-gate reinforces (pass) or decays (fail) them, then clears.
 	pub recalled_refs: Vec<(String, String, String)>,
+	/// Supervisor: runtime-recorded tool log for the current task — ground truth
+	/// the verify-gate checks completion claims against. Reset on each genuine
+	/// user turn; gate/steer re-runs (system-managed messages) keep accumulating.
+	pub evidence: crate::supervisor::gate::EvidenceLedger,
 }
 
 /// Parameters for creating a new ChatSession
@@ -361,6 +365,7 @@ impl ChatSession {
 			last_steered_calls: None,
 			last_self_report_reason: None,
 			recalled_refs: Vec::new(),
+			evidence: crate::supervisor::gate::EvidenceLedger::default(),
 		}
 	}
 
@@ -571,6 +576,7 @@ impl ChatSession {
 						last_steered_calls: None,
 						last_self_report_reason: None,
 						recalled_refs: Vec::new(),
+						evidence: crate::supervisor::gate::EvidenceLedger::default(),
 					};
 					// Keep session.info.role in sync with the active role
 					chat_session.session.info.role = params.role.to_string();
@@ -1322,6 +1328,7 @@ mod tests {
 			last_steered_calls: None,
 			last_self_report_reason: None,
 			recalled_refs: Vec::new(),
+			evidence: crate::supervisor::gate::EvidenceLedger::default(),
 		}
 	}
 

--- a/src/session/chat/session/messages.rs
+++ b/src/session/chat/session/messages.rs
@@ -248,8 +248,13 @@ impl ChatSession {
 		self.steer_last_signal = crate::supervisor::detect::DetectorSignal::None;
 		self.last_steered_calls = None;
 		// New genuine task: the verify-gate's evidence ledger starts fresh (gate and
-		// steer re-runs arrive as system-managed messages and keep accumulating).
+		// steer re-runs arrive as system-managed messages and keep accumulating), and
+		// the gate's per-turn re-entry budget resets — a previous turn's exhaustion
+		// must not latch the gate off for the rest of the session. `gate_failed` is
+		// deliberately NOT reset: it labels the trajectory for distill and is cleared
+		// only by a later PASS.
 		self.evidence.reset();
+		self.gate_iterations = 0;
 
 		// Check if we should cache this user message (after push, so the message exists
 		// at a known index and the cache manager can enforce the 2-marker limit).

--- a/src/session/chat/session/messages.rs
+++ b/src/session/chat/session/messages.rs
@@ -247,6 +247,9 @@ impl ChatSession {
 		self.steer_attempt = 0;
 		self.steer_last_signal = crate::supervisor::detect::DetectorSignal::None;
 		self.last_steered_calls = None;
+		// New genuine task: the verify-gate's evidence ledger starts fresh (gate and
+		// steer re-runs arrive as system-managed messages and keep accumulating).
+		self.evidence.reset();
 
 		// Check if we should cache this user message (after push, so the message exists
 		// at a known index and the cache manager can enforce the 2-marker limit).

--- a/src/supervisor/gate.rs
+++ b/src/supervisor/gate.rs
@@ -18,17 +18,29 @@
 //! trajectory so only verified work is learned.
 
 use crate::config::Config;
+use std::collections::VecDeque;
 use tokio::sync::watch;
 
 const GATE_PROMPT: &str = r#"You are a strict completion verifier. A different agent claims its task is COMPLETE.
 Judge the END STATE, not the agent's story: ignore its self-report and stated claim, and
 check only what the AGENT FINAL RESULT actually evidences against the USER REQUEST.
 
+You may also receive RECORDED ACTIONS — the runtime's own log of every tool call the agent
+actually executed for this task ([mut] = state-changing, [read] = inspection; each line shows
+the arguments and an ok/ERROR outcome). The agent cannot edit this log; when present it
+outranks the narrative:
+- A claim of performed work (created, edited, ran, posted, sent, fixed…) is evidenced only by
+  a matching successful recorded action — narrative with no matching action is a gap.
+- A claim of verification ("tests pass", "checked X") needs a matching successful recorded
+  action; an ERROR outcome on the decisive check is a gap.
+- When RECORDED ACTIONS is absent or empty, the task may be pure reasoning — judge the result
+  text on its own terms.
+
 Work through every part of the request, one at a time. For each, find the concrete proof it
-was done — a file path, line or code excerpt, command output, or named test in the result. A
-part counts as done only if such evidence is present; a confident or well-formatted assertion
-with no locatable artifact does NOT count. Reason first, then decide. Do not reward length,
-formatting, or tone — only verifiable substance.
+was done — a recorded action, file path, line or code excerpt, command output, or named test
+in the result. A part counts as done only if such evidence is present; a confident or
+well-formatted assertion with no locatable artifact does NOT count. Reason first, then decide.
+Do not reward length, formatting, or tone — only verifiable substance.
 
 Flag a gap only when a requested part is provably missing, a stated requirement is unmet, or a
 claim has no supporting evidence. Each gap must name the specific unmet item.
@@ -56,15 +68,130 @@ pub fn is_supervisor_injection(content: &str) -> bool {
 	t.starts_with("<pay-attention>") || t.starts_with("<recall>")
 }
 
+/// Cap on ledger lines — beyond it the oldest are dropped (and counted in the
+/// render) so a very long turn still hands the verifier a bounded block.
+const LEDGER_CAP: usize = 128;
+/// Args locate the object of an action (path, command, url) — not replay it.
+const LEDGER_ARGS_MAX: usize = 120;
+
+/// One executed tool call (or a run of identical consecutive successful calls).
+#[derive(Debug)]
+struct LedgerEntry {
+	tool: String,
+	args: String,
+	mutation: bool,
+	error: bool,
+	bytes: usize,
+	repeats: usize,
+}
+
+/// Runtime-recorded tool log for the current task — the ground truth the
+/// verify-gate checks completion claims against. Entries are written by the
+/// tool loop from actual executions, so the agent's narrative cannot alter
+/// them. Reset on each genuine user turn; gate/steer re-runs (system-managed
+/// messages) keep accumulating into the same task slice.
+#[derive(Debug, Default)]
+pub struct EvidenceLedger {
+	entries: VecDeque<LedgerEntry>,
+	dropped: usize,
+}
+
+impl EvidenceLedger {
+	/// Start a fresh task slice (genuine user turn).
+	pub fn reset(&mut self) {
+		self.entries.clear();
+		self.dropped = 0;
+	}
+
+	/// Record one executed tool call. Only an identical consecutive repeat of a
+	/// successful call collapses into ×N — different args always keep their own
+	/// line (a decisive check like a test command must never disappear into a
+	/// generic collapsed row), and errors never collapse: each failure is signal.
+	pub fn record(
+		&mut self,
+		tool: &str,
+		parameters: &serde_json::Value,
+		mutation: bool,
+		error: bool,
+		bytes: usize,
+	) {
+		let mut args = parameters.to_string();
+		if args.chars().count() > LEDGER_ARGS_MAX {
+			args = args.chars().take(LEDGER_ARGS_MAX).collect();
+			args.push('…');
+		}
+		if !error {
+			if let Some(last) = self.entries.back_mut() {
+				if !last.error && last.tool == tool && last.args == args {
+					last.repeats += 1;
+					return;
+				}
+			}
+		}
+		self.entries.push_back(LedgerEntry {
+			tool: tool.to_string(),
+			args,
+			mutation,
+			error,
+			bytes,
+			repeats: 1,
+		});
+		if self.entries.len() > LEDGER_CAP {
+			self.entries.pop_front();
+			self.dropped += 1;
+		}
+	}
+
+	/// Render the block handed to the verify-gate; empty when nothing ran.
+	pub fn render(&self) -> String {
+		if self.entries.is_empty() {
+			return String::new();
+		}
+		let mut out = String::new();
+		if self.dropped > 0 {
+			out.push_str(&format!("(+{} earlier actions dropped)\n", self.dropped));
+		}
+		for e in &self.entries {
+			let kind = if e.mutation { "[mut]" } else { "[read]" };
+			let outcome = if e.error { "ERROR" } else { "ok" };
+			out.push_str(&format!(
+				"{} {} {} → {} ({})",
+				kind,
+				e.tool,
+				e.args,
+				outcome,
+				fmt_size(e.bytes)
+			));
+			if e.repeats > 1 {
+				out.push_str(&format!(" ×{}", e.repeats));
+			}
+			out.push('\n');
+		}
+		out
+	}
+}
+
+/// Compact byte-size hint for a tool result (`412b`, `2.3k`).
+fn fmt_size(bytes: usize) -> String {
+	if bytes >= 1024 {
+		format!("{:.1}k", bytes as f64 / 1024.0)
+	} else {
+		format!("{bytes}b")
+	}
+}
+
 /// Verify a self-reported completion. `task` is the user's request, `result` is
 /// the agent's final answer, `claim` is the agent's own stated reason from its
-/// `done` self-report (checked against the result). Fails open (PASS) on empty
-/// input or LLM error — a verifier outage must never block the agent.
+/// `done` self-report (checked against the result), `actions` is the rendered
+/// [`EvidenceLedger`] (empty when no tools ran — pure-reasoning tasks). Fails
+/// open (PASS) on empty input or LLM error — a verifier outage must never block
+/// the agent.
 pub async fn verify(
 	config: &Config,
 	task: &str,
 	result: &str,
 	claim: Option<&str>,
+	actions: &str,
 	operation_rx: watch::Receiver<bool>,
 ) -> GateVerdict {
 	if task.trim().is_empty() || result.trim().is_empty() {
@@ -74,7 +201,14 @@ pub async fn verify(
 		Some(c) if !c.trim().is_empty() => format!("\n\nAGENT'S STATED CLAIM: {c}"),
 		_ => String::new(),
 	};
-	let user = format!("USER REQUEST:\n{task}\n\nAGENT FINAL RESULT:\n{result}{claim_line}");
+	let actions_block = if actions.trim().is_empty() {
+		String::new()
+	} else {
+		format!("\n\nRECORDED ACTIONS:\n{actions}")
+	};
+	let user = format!(
+		"USER REQUEST:\n{task}\n\nAGENT FINAL RESULT:\n{result}{claim_line}{actions_block}"
+	);
 	// Verify with a deliberately separate (ideally different-family) model — a
 	// same-family verifier shares the generator's blind spots and rubber-stamps
 	// them. Strict config guarantees this is set; no fallback to the generator.
@@ -158,5 +292,82 @@ mod tests {
 	#[test]
 	fn no_markers_is_pass() {
 		assert_eq!(parse_verdict("looks good to me"), GateVerdict::Pass);
+	}
+
+	#[test]
+	fn ledger_renders_mutations_reads_and_errors() {
+		let mut l = EvidenceLedger::default();
+		l.record(
+			"edit",
+			&serde_json::json!({"path":"src/a.rs"}),
+			true,
+			false,
+			100,
+		);
+		l.record(
+			"shell",
+			&serde_json::json!({"command":"cargo test"}),
+			false,
+			true,
+			2048,
+		);
+		let r = l.render();
+		assert!(r.contains(r#"[mut] edit {"path":"src/a.rs"} → ok (100b)"#));
+		assert!(r.contains(r#"[read] shell {"command":"cargo test"} → ERROR (2.0k)"#));
+	}
+
+	#[test]
+	fn ledger_collapses_only_identical_successful_repeats() {
+		let mut l = EvidenceLedger::default();
+		let p = serde_json::json!({"path":"a"});
+		l.record("view", &p, false, false, 10);
+		l.record("view", &p, false, false, 10);
+		l.record("view", &serde_json::json!({"path":"b"}), false, false, 10);
+		let r = l.render();
+		assert!(r.contains("×2"));
+		assert_eq!(r.lines().count(), 2);
+	}
+
+	#[test]
+	fn ledger_never_collapses_errors() {
+		let mut l = EvidenceLedger::default();
+		let p = serde_json::json!({"command":"x"});
+		l.record("shell", &p, false, true, 10);
+		l.record("shell", &p, false, true, 10);
+		assert_eq!(l.render().lines().count(), 2);
+	}
+
+	#[test]
+	fn ledger_caps_and_counts_dropped() {
+		let mut l = EvidenceLedger::default();
+		for i in 0..130 {
+			l.record("view", &serde_json::json!({ "i": i }), false, false, 1);
+		}
+		let r = l.render();
+		assert!(r.starts_with("(+2 earlier actions dropped)"));
+		assert_eq!(r.lines().count(), 129); // 128 entries + dropped header
+	}
+
+	#[test]
+	fn ledger_truncates_long_args() {
+		let mut l = EvidenceLedger::default();
+		let big = "x".repeat(500);
+		l.record(
+			"write",
+			&serde_json::json!({ "content": big }),
+			true,
+			false,
+			1,
+		);
+		assert!(l.render().contains('…'));
+	}
+
+	#[test]
+	fn empty_ledger_renders_empty() {
+		let mut l = EvidenceLedger::default();
+		assert_eq!(l.render(), "");
+		l.record("view", &serde_json::json!({}), false, false, 1);
+		l.reset();
+		assert_eq!(l.render(), "");
 	}
 }

--- a/src/workflow/proc.rs
+++ b/src/workflow/proc.rs
@@ -58,10 +58,27 @@ pub struct StepStats {
 pub enum RunOutcome {
 	Ok(StepStats),
 	Empty(StepStats),
-	NonZero { stats: StepStats, code: Option<i32> },
+	/// `stderr_tail` is a truncated tail of the subprocess's stderr, captured
+	/// for diagnostics — the child may die before emitting a structured
+	/// `ServerMessage::Error` on stdout (startup failure, panic, upstream
+	/// gateway error, etc.), in which case this is the only clue available.
+	NonZero {
+		stats: StepStats,
+		code: Option<i32>,
+		stderr_tail: String,
+	},
 	Timeout(Duration),
-	SpawnError(anyhow::Error),
+	/// `stderr_tail` is empty when the failure happened before the child was
+	/// spawned (e.g. `current_exe()` lookup failed).
+	SpawnError {
+		source: anyhow::Error,
+		stderr_tail: String,
+	},
 }
+
+/// Max chars of stderr kept for diagnostics — enough to show a panic
+/// message or an upstream HTTP error without dumping a full log.
+const STDERR_TAIL_CHARS: usize = 800;
 
 /// Bundled arguments for [`run_step`].
 pub struct RunStepArgs {
@@ -102,7 +119,12 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 	let started = Instant::now();
 	let exe = match std::env::current_exe() {
 		Ok(p) => p,
-		Err(e) => return RunOutcome::SpawnError(e.into()),
+		Err(e) => {
+			return RunOutcome::SpawnError {
+				source: e.into(),
+				stderr_tail: String::new(),
+			}
+		}
 	};
 
 	let mut cmd = Command::new(&exe);
@@ -112,7 +134,7 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 		.arg("jsonl")
 		.stdin(Stdio::piped())
 		.stdout(Stdio::piped())
-		.stderr(Stdio::null());
+		.stderr(Stdio::piped());
 	if let Some(name) = session_name.as_deref() {
 		cmd.arg("--name").arg(name);
 	}
@@ -126,7 +148,12 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 
 	let mut child = match cmd.spawn() {
 		Ok(c) => c,
-		Err(e) => return RunOutcome::SpawnError(anyhow!("spawn failed: {e}")),
+		Err(e) => {
+			return RunOutcome::SpawnError {
+				source: anyhow!("spawn failed: {e}"),
+				stderr_tail: String::new(),
+			}
+		}
 	};
 
 	// Write the prompt to stdin and close it.
@@ -140,6 +167,22 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 
 	let stdout = child.stdout.take().expect("stdout piped");
 	let reader = BufReader::new(stdout);
+
+	// Read stderr concurrently with stdout so neither pipe's OS buffer can
+	// fill up and block the child — only used for diagnostics on failure,
+	// the stdout JSONL stream remains the sole data contract.
+	let stderr = child.stderr.take().expect("stderr piped");
+	let stderr_task = tokio::spawn(async move {
+		let mut buf = String::new();
+		let mut lines = BufReader::new(stderr).lines();
+		while let Ok(Some(line)) = lines.next_line().await {
+			if !buf.is_empty() {
+				buf.push('\n');
+			}
+			buf.push_str(&line);
+		}
+		buf
+	});
 
 	let collect = async {
 		let mut stats = StepStats::default();
@@ -203,10 +246,16 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 				if let Some(sp) = &spinner {
 					sp.finish_and_clear();
 				}
+				stderr_task.abort();
 				return RunOutcome::Timeout(started.elapsed());
 			}
 		}
 	};
+
+	// By the time `collect` resolves, the child has exited (or `wait`
+	// failed), so its stderr pipe has already hit EOF — this returns
+	// promptly rather than blocking on more output.
+	let stderr_text = stderr_task.await.unwrap_or_default();
 
 	if let Some(sp) = &spinner {
 		sp.finish_and_clear();
@@ -218,6 +267,7 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 				RunOutcome::NonZero {
 					stats,
 					code: status.code(),
+					stderr_tail: truncate_tail(&stderr_text, STDERR_TAIL_CHARS),
 				}
 			} else if stats.output.trim().is_empty() {
 				RunOutcome::Empty(stats)
@@ -225,7 +275,10 @@ pub async fn run_step(args: RunStepArgs) -> RunOutcome {
 				RunOutcome::Ok(stats)
 			}
 		}
-		Err(e) => RunOutcome::SpawnError(e),
+		Err(e) => RunOutcome::SpawnError {
+			source: e,
+			stderr_tail: truncate_tail(&stderr_text, STDERR_TAIL_CHARS),
+		},
 	}
 }
 
@@ -436,6 +489,19 @@ fn truncate(s: &str, n: usize) -> String {
 	} else {
 		let head: String = one_line.chars().take(n.saturating_sub(1)).collect();
 		format!("{head}…")
+	}
+}
+
+/// Keep the last `max_chars` of `s` (panics/fatal errors usually land at
+/// the end of stderr), prefixed with `…` if anything was cut.
+fn truncate_tail(s: &str, max_chars: usize) -> String {
+	let s = s.trim();
+	let count = s.chars().count();
+	if count <= max_chars {
+		s.to_string()
+	} else {
+		let kept: String = s.chars().skip(count - max_chars).collect();
+		format!("…{kept}")
 	}
 }
 

--- a/src/workflow/run.rs
+++ b/src/workflow/run.rs
@@ -356,11 +356,16 @@ impl Executor {
 						"produced no assistant output (attempt {attempt}/{max_attempts})"
 					));
 				}
-				RunOutcome::NonZero { stats, code } => {
+				RunOutcome::NonZero {
+					stats,
+					code,
+					stderr_tail,
+				} => {
 					let stats = self.fold_stats(&s.name, s.session, &stats);
 					self.totals.add(&stats);
-					last_err = Some(format!(
-						"failed exit code {code:?} (attempt {attempt}/{max_attempts})"
+					last_err = Some(with_stderr(
+						format!("failed exit code {code:?} (attempt {attempt}/{max_attempts})"),
+						&stderr_tail,
 					));
 				}
 				RunOutcome::Timeout(elapsed) => {
@@ -369,8 +374,11 @@ impl Executor {
 						elapsed.as_secs()
 					));
 				}
-				RunOutcome::SpawnError(e) => {
-					last_err = Some(format!("spawn error: {e}"));
+				RunOutcome::SpawnError {
+					source: e,
+					stderr_tail,
+				} => {
+					last_err = Some(with_stderr(format!("spawn error: {e}"), &stderr_tail));
 				}
 			}
 
@@ -508,9 +516,14 @@ impl Executor {
 							last_err =
 								Some(format!("empty output (attempt {attempt}/{max_attempts})"));
 						}
-						RunOutcome::NonZero { code, .. } => {
-							last_err = Some(format!(
-								"non-zero exit {code:?} (attempt {attempt}/{max_attempts})"
+						RunOutcome::NonZero {
+							code, stderr_tail, ..
+						} => {
+							last_err = Some(with_stderr(
+								format!(
+									"non-zero exit {code:?} (attempt {attempt}/{max_attempts})"
+								),
+								&stderr_tail,
 							));
 						}
 						RunOutcome::Timeout(e) => {
@@ -519,8 +532,11 @@ impl Executor {
 								e.as_secs()
 							));
 						}
-						RunOutcome::SpawnError(e) => {
-							last_err = Some(format!("spawn error: {e}"));
+						RunOutcome::SpawnError {
+							source: e,
+							stderr_tail,
+						} => {
+							last_err = Some(with_stderr(format!("spawn error: {e}"), &stderr_tail));
 						}
 					}
 				}
@@ -963,6 +979,19 @@ fn box_line(text: &str) {
 /// don't belong inside any box (loop exits, conditional decisions).
 fn info_line(text: &str) {
 	eprintln!("{} {}", "·".bright_black(), text);
+}
+
+/// Append a captured stderr tail to a failure message, if any was
+/// captured — the subprocess may die before emitting a structured
+/// `ServerMessage::Error` on its stdout stream, in which case this is
+/// the only diagnostic available (see `proc::RunOutcome::NonZero` /
+/// `SpawnError`).
+fn with_stderr(msg: String, stderr_tail: &str) -> String {
+	if stderr_tail.trim().is_empty() {
+		msg
+	} else {
+		format!("{msg}\n  stderr: {stderr_tail}")
+	}
 }
 
 /// Emit a step's assistant response so the user can see what each step


### PR DESCRIPTION
- Add stderr_tail to NonZero and SpawnError outcomes
- Implement concurrent stderr reading during step execution
- Truncate stderr to last 800 characters for diagnostics
- Include captured stderr in executor error messages

BREAKING CHANGE: RunOutcome::NonZero and RunOutcome::SpawnError signatures changed to structs