### PR TITLE
fix(session): error on empty provider completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -750,6 +750,17 @@ name = "cfg_block"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -2052,11 +2063,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2066,8 +2075,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2720,11 +2732,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -3116,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3691,9 +3703,9 @@ checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -3723,15 +3735,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash 2.1.3",
  "rustls",
@@ -3745,16 +3758,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3806,6 +3819,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,6 +3868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,10 +3893,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rapidhash"
-version = "4.5.0"
+name = "rand_pcg"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -4629,7 +4668,7 @@ dependencies = [
  "owo-colors",
  "rand 0.8.6",
  "rand_core 0.6.4",
- "rand_pcg",
+ "rand_pcg 0.3.1",
  "scoped-tls",
  "smallvec",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "branches"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +611,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1484,6 +1496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1663,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1751,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1780,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -2063,9 +2116,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2762,6 +2817,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,6 +3093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3224,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3246,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -3158,6 +3275,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3282,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "octolib"
-version = "0.23.8"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1d9d1946d1df8b56326fa1a0215f2df49d09946fab84413527e1c7c510efe4"
+checksum = "c6f77ac538dccc51e777fa9a56c3f4960088958c6b1d925112c4e0f67cbff892"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3296,6 +3435,7 @@ dependencies = [
  "dirs",
  "hex",
  "hf-hub",
+ "jsonschema",
  "jsonwebtoken",
  "reqwest 0.12.28",
  "serde",
@@ -3440,6 +3580,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
@@ -4015,6 +4161,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -5693,6 +5856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5803,6 +5972,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5828,6 +6007,12 @@ dependencies = [
  "tempfile",
  "termcolor",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ overflow-checks = false # Disable overflow checks in release mode
 
 [dependencies]
 # octolib = { path = "../octolib", default-features = false, features = ["huggingface"] }
-octolib = { version = "0.23.7", default-features = false, features = ["huggingface"] }
+octolib = { version = "0.24.0", default-features = false, features = ["huggingface"] }
 tokenizers = { version = "0.22.2", default-features = false } # model's own tokenizer for exact token counts
 rmcp = { version = "1.7.0", default-features = false }
 

--- a/doc/integration/01-websocket-server.md
+++ b/doc/integration/01-websocket-server.md
@@ -33,10 +33,11 @@ Communication uses JSON messages over WebSocket.
 
 ### Client to Server
 
-**Session message** -- send user input:
+**Message** -- send user input:
 ```json
 {
   "type": "message",
+  "request_id": "req-001",
   "session_id": "my-session",
   "content": "Explain the auth module"
 }
@@ -46,20 +47,24 @@ Communication uses JSON messages over WebSocket.
 ```json
 {
   "type": "command",
+  "request_id": "req-002",
   "session_id": "my-session",
   "command": "mcp",
   "args": ["list"]
 }
 ```
 
+`request_id` is optional on every client frame. When present, the server echoes it in the immediate `ack` frame and in validation errors, so clients can correlate accepted/rejected inputs without relying only on ordering.
+
 `command` is the slash-command name **without** the leading `/` (see [Session Commands](../reference/02-session-commands.md) for the full list). `args` is optional. The command channel only accepts recognized commands: an unknown command returns `{"type":"error","message":"Unknown command: '...'..."}` — it is **not** treated as free-text AI input. Use a `message` frame for that.
 
-The `done` command (`/done`) is special: it compresses the conversation and replies with a `status` frame (`"Conversation compressed"` or `"Nothing to compress"`). If you supply `args`, they are joined and immediately processed as a follow-up user message after compression.
+The `done` command (`/done`) is special: it compresses the conversation and replies with a data-carrying `status` frame (`"Conversation compressed"` or `"Nothing to compress"`). If you supply `args`, they are joined and immediately processed as a follow-up user message after compression.
 
 **Session creation** (auto-named):
 ```json
 {
-  "type": "session"
+  "type": "session",
+  "request_id": "req-003"
 }
 ```
 
@@ -67,6 +72,7 @@ The `done` command (`/done`) is special: it compresses the conversation and repl
 ```json
 {
   "type": "session",
+  "request_id": "req-004",
   "session_id": "my-session"
 }
 ```
@@ -98,6 +104,20 @@ Each session is processed **serially**. While a session is busy handling a `mess
 Wait for the prior request to finish — i.e. for its terminating `cost` frame (see below) — before sending the next one. Different `session_id`s run independently.
 
 ### Server to Client
+
+For every valid JSON text input frame (`session`, `message`, or `command`), the server first sends an immediate acknowledgement before doing any longer work:
+
+```json
+{
+  "type": "ack",
+  "request_id": "req-001",
+  "message_type": "message",
+  "session_id": "my-session",
+  "status": "received"
+}
+```
+
+`request_id` and `session_id` are omitted when the input did not include them. Malformed JSON and validation failures do not produce `ack`; they produce an `error` frame instead. If a validation failure includes a `request_id`, the error echoes it.
 
 Responses to a single `message` arrive as a **stream** of frames: zero or more `thinking`, `tool_use`, `tool_result`, and `assistant` frames, terminated by a final `cost` frame that marks the end of the turn.
 
@@ -165,19 +185,22 @@ Responses to a single `message` arrive as a **stream** of frames: zero or more `
   "type": "status",
   "message": "Command 'mcp' executed successfully",
   "session_id": "my-session",
-  "data": { "...": "structured command output" }
+  "data": { "command_type": "mcp" }
 }
 ```
 
-Both `session_id` and `data` are optional. The connection-time welcome status omits `session_id`. The `data` field is present only for commands that return structured output (e.g. `mcp list`, `info`) — it carries that command's JSON result.
+Both `session_id` and `data` are optional. The connection-time welcome status omits `session_id`. Command completion statuses always include `data`, either with command metadata (for plain handled commands) or the command's structured JSON result (e.g. `mcp list`, `info`). This lets clients distinguish command completion from the connection/session status frames.
 
 **Error:**
 ```json
 {
   "type": "error",
-  "message": "Invalid session ID"
+  "message": "Invalid session ID",
+  "request_id": "req-001"
 }
 ```
+
+`request_id` appears only when the server can associate the error with a client-supplied ID.
 
 **MCP notification:**
 ```json
@@ -292,6 +315,7 @@ asyncio.run(main())
 ## Validation
 
 - `session_id` (when provided) and `content` must be non-empty strings
+- `request_id` is optional, but when provided must be non-empty and no more than 256 bytes
 - Message `content` is limited to 10MB
 - Commands must be non-empty strings (without leading `/`)
 - Command `args` is optional

--- a/doc/use-cases/04-web-dashboard-integration.md
+++ b/doc/use-cases/04-web-dashboard-integration.md
@@ -77,6 +77,10 @@ class OctomindClient {
           // canonical end-of-turn signal.
           this.handlers.onCost(msg.session_cost);
           break;
+        case 'ack':
+          // Optional immediate receipt signal. Use request_id if you need
+          // per-input correlation.
+          break;
         case 'error':
           this.handlers.onError(msg.message);
           break;
@@ -190,13 +194,14 @@ answer = asyncio.run(ask_octomind("What does the login function do?"))
 | Client -> Server | `session` | Create or resume a session (no AI call). With no `session_id` the server creates an auto-named session; with a `session_id` it resumes that session if it exists on disk, otherwise creates one with that name. |
 | Client -> Server | `message` | Send user input (field `content`, max 10 MB) |
 | Client -> Server | `command` | Execute a session command (field `command`, bare name without the leading `/`; optional `args` array) |
+| Server -> Client | `ack` | Immediate receipt acknowledgement for each valid JSON text input (`message_type`, optional `request_id`, optional `session_id`, `status = "received"`). Malformed/invalid input returns `error` instead. |
 | Server -> Client | `assistant` | AI response text (`content`) |
 | Server -> Client | `thinking` | Extended thinking (`content`, if the model supports it) |
 | Server -> Client | `tool_use` | Tool being called (`tool`, `tool_id`, `server`, `params`) |
 | Server -> Client | `tool_result` | Tool execution result (`tool`, `tool_id`, `server`, `content`, `success`) |
 | Server -> Client | `cost` | Token usage and cost; emitted once after each completed AI turn (use it as the end-of-turn signal) |
-| Server -> Client | `status` | Free-form status text in `message` (e.g. the connection welcome, `Session created: <id>` / `Session resumed: <id>`, command-executed notices, `Session ended`, `Conversation compressed`). Not a machine-readable completion marker -- use `cost` for that. May carry an optional `session_id` and structured `data`. |
-| Server -> Client | `error` | Error text in `message` |
+| Server -> Client | `status` | Free-form status text in `message` (e.g. the connection welcome, `Session created: <id>` / `Session resumed: <id>`, command-executed notices, `Session ended`, `Conversation compressed`). Command completion statuses carry `data`; AI turns still end with `cost`. May carry an optional `session_id`. |
+| Server -> Client | `error` | Error text in `message`, with optional `request_id` when the failed input provided one |
 | Server -> Client | `mcp_notification` | Notification forwarded from an MCP server (`server`, `method`, `params`) |
 | Server -> Client | `skill` | Skill lifecycle event (`action` = activate/use/forget, `name`, optional `trigger`) |
 | Server -> Client | `injected` | Non-user input being added to the conversation (`source_kind` = schedule/background_agent/tap_run/skill/skill_validator/inject/webhook/guardrail_hook/guardrail_validator, `source_label`, `content`); emitted just before the AI responds so the UI can show what triggered it |
@@ -224,6 +229,7 @@ Concurrency is across **different** `session_id`s. Requests to the **same** `ses
 - Sessions are stateful -- context persists across messages
 - Tool execution (file reading, shell commands) is streamed in real-time
 - A `cost` message is emitted once after each completed AI turn -- use it as the end-of-turn signal, not the free-form `status` text
+- Every valid JSON input gets an immediate `ack`; use optional client `request_id` values if the UI needs correlation
 - User `message` `content` is capped at 10 MB, and the WebSocket frame/message size limit is also 10 MB; larger input returns a validation error
 - The server has no built-in authentication, authorization, or TLS -- use a reverse proxy with TLS for production and never expose the server directly to the internet
 - Cost tracking is per-session via `cost` messages

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -73,6 +73,11 @@ pub struct ChatCompletionParams<'a> {
 	pub schema: Option<serde_json::Value>,
 	/// Optional reasoning effort override (falls back to `config.reasoning_effort`)
 	pub reasoning_effort: Option<crate::config::ReasoningEffortConfig>,
+	/// Attach MCP tools to the request (default true). Text-only internal
+	/// calls (compression, learning extraction) disable this: the model never
+	/// calls tools there, the definitions waste input tokens, and their
+	/// presence blocks schema enforcement on proxy providers.
+	pub tools: bool,
 }
 
 impl<'a> ChatCompletionParams<'a> {
@@ -99,6 +104,7 @@ impl<'a> ChatCompletionParams<'a> {
 			cancellation_token: None,
 			schema: None,
 			reasoning_effort: None,
+			tools: true,
 		}
 	}
 
@@ -123,6 +129,12 @@ impl<'a> ChatCompletionParams<'a> {
 	/// Override reasoning effort for this call (otherwise inherits from config).
 	pub fn with_reasoning_effort(mut self, effort: crate::config::ReasoningEffortConfig) -> Self {
 		self.reasoning_effort = Some(effort);
+		self
+	}
+
+	/// Don't attach MCP tools — for text-only calls (compression, learning).
+	pub fn without_tools(mut self) -> Self {
+		self.tools = false;
 		self
 	}
 
@@ -196,7 +208,7 @@ impl<'a> ChatCompletionParams<'a> {
 		}
 
 		// Fetch and add MCP tools if MCP is configured
-		if !self.config.mcp.servers.is_empty() {
+		if self.tools && !self.config.mcp.servers.is_empty() {
 			let mcp_functions = crate::mcp::get_available_functions(self.config).await;
 			if !mcp_functions.is_empty() {
 				// Convert MCP functions to octolib FunctionDefinitions

--- a/src/session/chat/conversation_compression/ai.rs
+++ b/src/session/chat/conversation_compression/ai.rs
@@ -125,7 +125,11 @@ async fn call_ai_for_decision(
 	)
 	.with_max_retries(decision_config.max_retries)
 	.with_full_context_tokens(true)
-	.with_cancellation_token(operation_rx);
+	.with_cancellation_token(operation_rx)
+	// Text-only summarization: no tools. Sending the MCP toolset here wastes
+	// input tokens and makes proxy providers (octohub) skip schema
+	// enforcement, breaking the JSON wire mode.
+	.without_tools();
 
 	if let Some(s) = schema.clone() {
 		params = params.with_schema(s);

--- a/src/session/completion.rs
+++ b/src/session/completion.rs
@@ -52,6 +52,10 @@ pub struct ChatCompletionWithValidationParams<'a> {
 	pub schema: Option<serde_json::Value>,
 	/// Optional reasoning effort override (falls back to `config.reasoning_effort`)
 	pub reasoning_effort: Option<crate::config::ReasoningEffortConfig>,
+	/// Attach MCP tools to the request (default true). Text-only internal
+	/// calls (compression, learning extraction) disable this — see
+	/// `crate::providers::ChatCompletionParams::tools`.
+	pub tools: bool,
 }
 
 impl<'a> ChatCompletionWithValidationParams<'a> {
@@ -78,6 +82,7 @@ impl<'a> ChatCompletionWithValidationParams<'a> {
 			cancellation_token: None,
 			schema: None,
 			reasoning_effort: None,
+			tools: true,
 		}
 	}
 
@@ -111,6 +116,12 @@ impl<'a> ChatCompletionWithValidationParams<'a> {
 	/// Override reasoning effort for this call (otherwise inherits from config).
 	pub fn with_reasoning_effort(mut self, effort: crate::config::ReasoningEffortConfig) -> Self {
 		self.reasoning_effort = Some(effort);
+		self
+	}
+
+	/// Don't attach MCP tools — for text-only calls (compression, learning).
+	pub fn without_tools(mut self) -> Self {
+		self.tools = false;
 		self
 	}
 }
@@ -171,8 +182,14 @@ pub async fn chat_completion_with_validation(
 
 	// Calculate EXACTLY what we're about to send to the API using enhanced token counting
 	let total_input_tokens = if params.full_context_tokens {
-		// Use enhanced token counting that includes system prompt + tools
-		let tools = crate::mcp::get_available_functions(params.config).await;
+		// Use enhanced token counting that includes system prompt + tools.
+		// Skip the tool fetch when tools are disabled — they won't be sent,
+		// so counting them would overestimate and reject valid requests.
+		let tools = if params.tools {
+			crate::mcp::get_available_functions(params.config).await
+		} else {
+			Vec::new()
+		};
 		estimate_full_context_tokens(
 			params.messages,
 			if tools.is_empty() { None } else { Some(&tools) },
@@ -199,7 +216,7 @@ pub async fn chat_completion_with_validation(
 	}
 
 	// Input size is acceptable, proceed with API call
-	let chat_params = ChatCompletionParams::new(
+	let mut chat_params = ChatCompletionParams::new(
 		params.messages,
 		&actual_model,
 		params.temperature,
@@ -209,6 +226,10 @@ pub async fn chat_completion_with_validation(
 		params.config,
 	)
 	.with_max_retries(params.max_retries);
+
+	if !params.tools {
+		chat_params = chat_params.without_tools();
+	}
 
 	let chat_params = if let Some(schema) = params.schema {
 		chat_params.with_schema(schema)

--- a/src/session/completion.rs
+++ b/src/session/completion.rs
@@ -130,6 +130,21 @@ pub struct ChatCompletionProviderParams<'a> {
 	pub schema: Option<serde_json::Value>,
 }
 
+/// A successful completion that carries nothing actionable — no text, no tool
+/// calls, and no structured output. This is a provider fault, not a real
+/// end-of-turn, so the caller surfaces it as an error. Extracted + unit-tested
+/// so the classification can't silently drift into treating a tool-only or
+/// structured-output response as empty (which would error out real turns).
+fn is_empty_completion(
+	content: &str,
+	tool_calls: Option<&Vec<crate::mcp::McpToolCall>>,
+	structured_output: Option<&serde_json::Value>,
+) -> bool {
+	content.trim().is_empty()
+		&& tool_calls.is_none_or(|c| c.is_empty())
+		&& structured_output.is_none()
+}
+
 /// High-level function to send a chat completion with input validation and context management.
 /// Checks input size and returns an error when limits are exceeded.
 pub async fn chat_completion_with_validation(
@@ -213,18 +228,35 @@ pub async fn chat_completion_with_validation(
 		chat_params
 	};
 
-	// Convert to octolib params and call provider
+	// Convert to octolib params and call provider.
 	let octolib_params = chat_params
 		.to_octolib_params()
 		.await
 		.map_err(|e| anyhow::anyhow!("Failed to convert message parameters: {}", e))?;
 
 	let octolib_response = provider.chat_completion(octolib_params).await?;
+	let response = crate::providers::convert_response_from_octolib(octolib_response);
 
-	// Convert response back to Octomind format
-	Ok(crate::providers::convert_response_from_octolib(
-		octolib_response,
-	))
+	// An empty completion — a successful HTTP response with no content, no tool
+	// calls, and no structured output — is a provider fault (e.g. some providers
+	// return finish_reason=stop with an empty body). Surface it as an error: if we
+	// returned it, the response loop would read it as a normal end-of-turn, render
+	// nothing, and silently strand the user at the prompt. Transport retries
+	// already live in the provider's own max_retries — we do not add another layer.
+	if is_empty_completion(
+		&response.content,
+		response.tool_calls.as_ref(),
+		response.structured_output.as_ref(),
+	) {
+		return Err(anyhow::anyhow!(
+			"Provider '{}' returned an empty response (finish_reason={:?}, no content or tool calls) for model '{}'",
+			provider.name(),
+			response.finish_reason,
+			actual_model
+		));
+	}
+
+	Ok(response)
 }
 
 /// High-level function to send a chat completion using the provider abstraction.
@@ -301,6 +333,50 @@ pub fn load_structured_output_schema(path: &str) -> Result<serde_json::Value> {
 		));
 	}
 	Ok(schema)
+}
+
+#[cfg(test)]
+mod empty_completion_tests {
+	use super::is_empty_completion;
+	use crate::mcp::McpToolCall;
+	use serde_json::json;
+
+	fn call() -> McpToolCall {
+		McpToolCall {
+			tool_name: "view".into(),
+			parameters: json!({}),
+			tool_id: "t1".into(),
+		}
+	}
+
+	#[test]
+	fn blank_content_no_tools_no_schema_is_empty() {
+		assert!(is_empty_completion("", None, None));
+		assert!(is_empty_completion("   \n\t ", None, None));
+	}
+
+	#[test]
+	fn empty_tool_vec_is_still_empty() {
+		// Some providers hand back `Some([])` rather than `None`.
+		assert!(is_empty_completion("", Some(&vec![]), None));
+	}
+
+	#[test]
+	fn text_response_is_not_empty() {
+		assert!(!is_empty_completion("hello", None, None));
+	}
+
+	#[test]
+	fn tool_only_response_is_not_empty() {
+		// Tool calls with no prose is a valid turn — must NOT be flagged as empty.
+		assert!(!is_empty_completion("", Some(&vec![call()]), None));
+	}
+
+	#[test]
+	fn structured_output_is_not_empty() {
+		// Structured-output replies carry empty content by design — not empty.
+		assert!(!is_empty_completion("", None, Some(&json!({"ok": true}))));
+	}
 }
 
 #[cfg(test)]

--- a/src/supervisor/learning/extract.rs
+++ b/src/supervisor/learning/extract.rs
@@ -597,7 +597,8 @@ async fn call_extraction_llm(
 	let params = crate::session::ChatCompletionWithValidationParams::new(
 		&messages, model, 0.3, 1.0, 0, 4096, config,
 	)
-	.with_max_retries(1);
+	.with_max_retries(1)
+	.without_tools();
 
 	let response = crate::session::chat_completion_with_validation(params).await?;
 	if let Some(usage) = &response.exchange.usage {
@@ -661,7 +662,8 @@ pub(crate) async fn call_learning_llm(
 	)
 	.with_max_retries(1)
 	.with_full_context_tokens(true)
-	.with_cancellation_token(operation_rx);
+	.with_cancellation_token(operation_rx)
+	.without_tools();
 
 	let response = crate::session::chat_completion_with_validation(params).await?;
 	if let Some(usage) = &response.exchange.usage {

--- a/src/websocket/protocol.rs
+++ b/src/websocket/protocol.rs
@@ -26,6 +26,10 @@ use serde_json::Value;
 /// - `session_id` present → resume if exists on disk, else create with that name
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionMessage {
+	/// Optional client-supplied correlation ID. Echoed by the server in the ack.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub request_id: Option<String>,
+
 	/// Session name / ID. Absent = auto-named, present = create-or-resume.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub session_id: Option<String>,
@@ -34,6 +38,10 @@ pub struct SessionMessage {
 /// Send user input to an existing session and receive an AI response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserMessage {
+	/// Optional client-supplied correlation ID. Echoed by the server in the ack.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub request_id: Option<String>,
+
 	/// Session name / ID — must refer to an established session.
 	pub session_id: String,
 
@@ -44,6 +52,10 @@ pub struct UserMessage {
 /// Execute a session command (equivalent to `/command [args…]` in the CLI).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandMessage {
+	/// Optional client-supplied correlation ID. Echoed by the server in the ack.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub request_id: Option<String>,
+
 	/// Session name / ID — must refer to an established session.
 	pub session_id: String,
 
@@ -70,6 +82,24 @@ pub enum ClientMessage {
 impl ClientMessage {
 	/// Semantic validation beyond what serde already enforces structurally.
 	pub fn validate(&self) -> Result<(), String> {
+		fn validate_request_id(request_id: &Option<String>) -> Result<(), String> {
+			if let Some(id) = request_id {
+				if id.trim().is_empty() {
+					return Err("request_id cannot be empty when provided".to_string());
+				}
+				if id.len() > 256 {
+					return Err("request_id exceeds maximum size (256 bytes)".to_string());
+				}
+			}
+			Ok(())
+		}
+
+		match self {
+			ClientMessage::Session(m) => validate_request_id(&m.request_id)?,
+			ClientMessage::Message(m) => validate_request_id(&m.request_id)?,
+			ClientMessage::Command(c) => validate_request_id(&c.request_id)?,
+		}
+
 		match self {
 			ClientMessage::Session(_) => Ok(()),
 
@@ -95,6 +125,30 @@ impl ClientMessage {
 				}
 				Ok(())
 			}
+		}
+	}
+
+	pub fn request_id(&self) -> Option<&str> {
+		match self {
+			ClientMessage::Session(m) => m.request_id.as_deref(),
+			ClientMessage::Message(m) => m.request_id.as_deref(),
+			ClientMessage::Command(c) => c.request_id.as_deref(),
+		}
+	}
+
+	pub fn message_type(&self) -> &'static str {
+		match self {
+			ClientMessage::Session(_) => "session",
+			ClientMessage::Message(_) => "message",
+			ClientMessage::Command(_) => "command",
+		}
+	}
+
+	pub fn session_id(&self) -> Option<&str> {
+		match self {
+			ClientMessage::Session(m) => m.session_id.as_deref(),
+			ClientMessage::Message(m) => Some(m.session_id.as_str()),
+			ClientMessage::Command(c) => Some(c.session_id.as_str()),
 		}
 	}
 }
@@ -161,6 +215,21 @@ pub struct StatusPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorPayload {
 	pub message: String,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AckPayload {
+	/// Echo of the client-supplied request_id, when present.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub request_id: Option<String>,
+	/// Client frame type being acknowledged: session, message, or command.
+	pub message_type: String,
+	/// Session ID from the input frame when it is known.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub session_id: Option<String>,
+	pub status: String,
 }
 
 /// Skill lifecycle event (activate via auto-activation, explicit use, or forget).
@@ -211,6 +280,8 @@ pub struct McpNotificationPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerMessage {
+	/// Immediate acknowledgement that a valid client input frame was received.
+	Ack(AckPayload),
 	/// AI assistant response text
 	Assistant(AssistantPayload),
 	/// AI thinking/reasoning content (separate from assistant response)
@@ -237,7 +308,26 @@ pub enum ServerMessage {
 
 impl ServerMessage {
 	pub fn error(message: String) -> Self {
-		ServerMessage::Error(ErrorPayload { message })
+		ServerMessage::Error(ErrorPayload {
+			message,
+			request_id: None,
+		})
+	}
+
+	pub fn error_for_request(message: String, request_id: Option<String>) -> Self {
+		ServerMessage::Error(ErrorPayload {
+			message,
+			request_id,
+		})
+	}
+
+	pub fn ack(client_msg: &ClientMessage) -> Self {
+		ServerMessage::Ack(AckPayload {
+			request_id: client_msg.request_id().map(ToOwned::to_owned),
+			message_type: client_msg.message_type().to_string(),
+			session_id: client_msg.session_id().map(ToOwned::to_owned),
+			status: "received".to_string(),
+		})
 	}
 
 	pub fn status(message: String, session_id: Option<String>) -> Self {
@@ -290,7 +380,10 @@ mod tests {
 		let msg: ClientMessage = serde_json::from_str(json).unwrap();
 		assert!(matches!(
 			msg,
-			ClientMessage::Session(SessionMessage { session_id: None })
+			ClientMessage::Session(SessionMessage {
+				session_id: None,
+				..
+			})
 		));
 		assert!(msg.validate().is_ok());
 	}
@@ -302,7 +395,8 @@ mod tests {
 		assert!(matches!(
 			msg,
 			ClientMessage::Session(SessionMessage {
-				session_id: Some(_)
+				session_id: Some(_),
+				..
 			})
 		));
 		assert!(msg.validate().is_ok());
@@ -311,6 +405,7 @@ mod tests {
 	#[test]
 	fn test_session_roundtrip() {
 		let msg = ClientMessage::Session(SessionMessage {
+			request_id: None,
 			session_id: Some("my-session".to_string()),
 		});
 		let json = serde_json::to_string(&msg).unwrap();
@@ -343,6 +438,7 @@ mod tests {
 	#[test]
 	fn test_message_empty_session_id_fails_validate() {
 		let msg = ClientMessage::Message(UserMessage {
+			request_id: None,
 			session_id: "  ".to_string(),
 			content: "Fix the bug".to_string(),
 		});
@@ -352,6 +448,7 @@ mod tests {
 	#[test]
 	fn test_message_empty_content_fails_validate() {
 		let msg = ClientMessage::Message(UserMessage {
+			request_id: None,
 			session_id: "sess_123".to_string(),
 			content: "  ".to_string(),
 		});
@@ -361,6 +458,7 @@ mod tests {
 	#[test]
 	fn test_message_content_too_large_fails_validate() {
 		let msg = ClientMessage::Message(UserMessage {
+			request_id: None,
 			session_id: "sess_123".to_string(),
 			content: "x".repeat(11 * 1024 * 1024),
 		});
@@ -370,6 +468,7 @@ mod tests {
 	#[test]
 	fn test_message_roundtrip() {
 		let msg = ClientMessage::Message(UserMessage {
+			request_id: None,
 			session_id: "sess_123".to_string(),
 			content: "Hello".to_string(),
 		});
@@ -416,6 +515,7 @@ mod tests {
 	#[test]
 	fn test_command_empty_session_id_fails_validate() {
 		let msg = ClientMessage::Command(CommandMessage {
+			request_id: None,
 			session_id: "  ".to_string(),
 			command: "info".to_string(),
 			args: vec![],
@@ -426,6 +526,7 @@ mod tests {
 	#[test]
 	fn test_command_empty_command_fails_validate() {
 		let msg = ClientMessage::Command(CommandMessage {
+			request_id: None,
 			session_id: "sess_123".to_string(),
 			command: "  ".to_string(),
 			args: vec![],
@@ -436,6 +537,7 @@ mod tests {
 	#[test]
 	fn test_command_roundtrip() {
 		let msg = ClientMessage::Command(CommandMessage {
+			request_id: None,
 			session_id: "sess_123".to_string(),
 			command: "model".to_string(),
 			args: vec!["openrouter:anthropic/claude-sonnet-4".to_string()],
@@ -451,6 +553,7 @@ mod tests {
 	#[test]
 	fn test_command_args_omitted_when_empty() {
 		let msg = ClientMessage::Command(CommandMessage {
+			request_id: None,
 			session_id: "sess_123".to_string(),
 			command: "info".to_string(),
 			args: vec![],
@@ -480,6 +583,48 @@ mod tests {
 		let json = serde_json::to_string(&msg).unwrap();
 		assert!(json.contains("\"type\":\"error\""));
 		assert!(json.contains("something went wrong"));
+	}
+
+	#[test]
+	fn test_request_id_validation_and_ack_serialization() {
+		let msg: ClientMessage = serde_json::from_str(
+			r#"{"type":"message","request_id":"req-1","session_id":"sess_123","content":"Hello"}"#,
+		)
+		.unwrap();
+		assert!(msg.validate().is_ok());
+		assert_eq!(msg.request_id(), Some("req-1"));
+		assert_eq!(msg.message_type(), "message");
+		assert_eq!(msg.session_id(), Some("sess_123"));
+
+		let ack = ServerMessage::ack(&msg);
+		let json = serde_json::to_string(&ack).unwrap();
+		assert!(json.contains("\"type\":\"ack\""));
+		assert!(json.contains("\"request_id\":\"req-1\""));
+		assert!(json.contains("\"message_type\":\"message\""));
+		assert!(json.contains("\"session_id\":\"sess_123\""));
+		assert!(json.contains("\"status\":\"received\""));
+	}
+
+	#[test]
+	fn test_empty_request_id_fails_validate() {
+		let msg = ClientMessage::Command(CommandMessage {
+			request_id: Some(" ".to_string()),
+			session_id: "sess_123".to_string(),
+			command: "info".to_string(),
+			args: vec![],
+		});
+		assert!(msg.validate().is_err());
+	}
+
+	#[test]
+	fn test_error_for_request_serialization() {
+		let msg = ServerMessage::error_for_request(
+			"content cannot be empty".to_string(),
+			Some("req-2".to_string()),
+		);
+		let json = serde_json::to_string(&msg).unwrap();
+		assert!(json.contains("\"type\":\"error\""));
+		assert!(json.contains("\"request_id\":\"req-2\""));
 	}
 
 	#[test]

--- a/src/websocket/protocol.rs
+++ b/src/websocket/protocol.rs
@@ -248,6 +248,19 @@ impl ServerMessage {
 		})
 	}
 
+	/// A command-completion status. Unlike `status()` (which is also used for the
+	/// connection handshake), this carries `data` — clients distinguish a finished
+	/// command from a data-less handshake ack purely by the presence of `data`. Without
+	/// it, an interactive `/done` (and any plain `Handled` command) is misread as the
+	/// handshake and the client hangs on "working" because the turn never finalizes.
+	pub fn command_status(message: String, session_id: Option<String>, data: Value) -> Self {
+		ServerMessage::Status(StatusPayload {
+			message,
+			session_id,
+			data: Some(data),
+		})
+	}
+
 	pub fn skill(
 		action: impl Into<String>,
 		name: impl Into<String>,

--- a/src/websocket/server.rs
+++ b/src/websocket/server.rs
@@ -190,10 +190,16 @@ async fn handle_connection(
 						// Validate message
 						if let Err(e) = client_msg.validate() {
 							log_error!("Message validation failed from {}: {}", peer_addr, e);
-							let error = ServerMessage::error(e);
+							let error = ServerMessage::error_for_request(
+								e,
+								client_msg.request_id().map(ToOwned::to_owned),
+							);
 							send_message(&mut ws_sender, &error).await?;
 							continue;
 						}
+
+						send_message(&mut ws_sender, &ServerMessage::ack(&client_msg)).await?;
+						let request_id = client_msg.request_id().map(ToOwned::to_owned);
 
 						// Process the message
 						if let Err(e) = process_client_message(
@@ -205,9 +211,18 @@ async fn handle_connection(
 						.await
 						{
 							log_error!("Message processing failed for {}: {}", peer_addr, e);
-							let error = ServerMessage::error(format!("Internal error: {}", e));
+							let error = ServerMessage::error_for_request(
+								format!("Internal error: {}", e),
+								request_id,
+							);
 							send_message(&mut ws_sender, &error).await?;
 						}
+					}
+					Ok(Message::Binary(_)) => {
+						let error = ServerMessage::error(
+							"Unsupported WebSocket message type: send JSON text frames".to_string(),
+						);
+						send_message(&mut ws_sender, &error).await?;
 					}
 					Ok(Message::Close(_)) => {
 						log_info!("Client {} closed connection", peer_addr);
@@ -221,9 +236,10 @@ async fn handle_connection(
 							break;
 						}
 					}
-					Ok(_) => {
-						// Ignore other message types (binary, pong, etc.)
+					Ok(Message::Pong(_)) => {
+						// Ignore pong replies; they are transport-level control frames.
 					}
+					Ok(_) => {}
 					Err(e) => {
 						log_error!("WebSocket protocol error from {}: {}", peer_addr, e);
 						break;
@@ -759,16 +775,32 @@ async fn handle_command_message(
 			Ok(DoneOutcome::NothingToCompress) => "Nothing to compress".to_string(),
 			Ok(DoneOutcome::Failed(e)) => {
 				let error = ServerMessage::error(format!("Compression failed: {}", e));
-				send_message(ws_sender, &error).await?;
-				chat_session.save()?;
+				let save_result = chat_session.save();
 				sessions.lock().await.insert(session_id, chat_session);
+				if let Err(save_err) = save_result {
+					send_message(
+						ws_sender,
+						&ServerMessage::error(format!("Failed to save session: {}", save_err)),
+					)
+					.await?;
+					return Ok(());
+				}
+				send_message(ws_sender, &error).await?;
 				return Ok(());
 			}
 			Err(e) => {
 				let error = ServerMessage::error(format!("Compression failed: {}", e));
-				send_message(ws_sender, &error).await?;
-				chat_session.save()?;
+				let save_result = chat_session.save();
 				sessions.lock().await.insert(session_id, chat_session);
+				if let Err(save_err) = save_result {
+					send_message(
+						ws_sender,
+						&ServerMessage::error(format!("Failed to save session: {}", save_err)),
+					)
+					.await?;
+					return Ok(());
+				}
+				send_message(ws_sender, &error).await?;
 				return Ok(());
 			}
 		};
@@ -780,17 +812,26 @@ async fn handle_command_message(
 			Some(session_id.clone()),
 			serde_json::json!({ "command_type": "done", "message": status_msg }),
 		);
-		send_message(ws_sender, &status).await?;
-		chat_session.save()?;
+		let save_result = chat_session.save();
 		sessions
 			.lock()
 			.await
 			.insert(session_id.clone(), chat_session);
+		if let Err(e) = save_result {
+			send_message(
+				ws_sender,
+				&ServerMessage::error(format!("Failed to save session: {}", e)),
+			)
+			.await?;
+			return Ok(());
+		}
+		send_message(ws_sender, &status).await?;
 
 		// If args were provided, process them as a user message immediately after compression.
 		if !args.is_empty() {
 			let instructions = args.join(" ");
 			let user_msg = crate::websocket::protocol::UserMessage {
+				request_id: None,
 				session_id: session_id.clone(),
 				content: instructions,
 			};
@@ -800,59 +841,98 @@ async fn handle_command_message(
 	}
 
 	use crate::session::chat::session::commands::CommandResult;
-	let command_result = chat_session
+	let command_result = match chat_session
 		.process_command(
 			&slash_command,
 			&mut config_for_role.clone(),
 			role,
 			operation_rx,
 		)
-		.await?;
+		.await
+	{
+		Ok(result) => result,
+		Err(e) => {
+			let error = ServerMessage::error(format!("Command failed: {}", e));
+			let save_result = chat_session.save();
+			sessions.lock().await.insert(session_id, chat_session);
+			if let Err(save_err) = save_result {
+				send_message(
+					ws_sender,
+					&ServerMessage::error(format!("Failed to save session: {}", save_err)),
+				)
+				.await?;
+				return Ok(());
+			}
+			send_message(ws_sender, &error).await?;
+			return Ok(());
+		}
+	};
 
-	match command_result {
+	let terminal = match command_result {
 		CommandResult::Handled => {
 			log_debug!("Command '{}' executed successfully", slash_command);
 			// Data-carrying status (see command_status) so the client finalizes the turn
 			// instead of misreading a data-less status as the handshake ack.
-			let status = ServerMessage::command_status(
+			ServerMessage::command_status(
 				format!("Command '{}' executed successfully", slash_command),
 				Some(session_id.clone()),
 				serde_json::json!({ "command_type": command_name }),
-			);
-			send_message(ws_sender, &status).await?;
+			)
 		}
 		CommandResult::HandledWithOutput(command_output) => {
 			log_debug!(
 				"Command '{}' executed with structured output",
 				slash_command
 			);
-			let response = ServerMessage::Status(StatusPayload {
+			ServerMessage::Status(StatusPayload {
 				message: format!("Command '{}' executed successfully", slash_command),
 				session_id: Some(session_id.clone()),
 				data: Some(command_output.to_json()),
-			});
-			send_message(ws_sender, &response).await?;
+			})
 		}
 		CommandResult::Exit => {
 			log_info!("Session ended by command '{}'", slash_command);
-			let status =
-				ServerMessage::status("Session ended".to_string(), Some(session_id.clone()));
-			send_message(ws_sender, &status).await?;
+			let status = ServerMessage::command_status(
+				"Session ended".to_string(),
+				Some(session_id.clone()),
+				serde_json::json!({ "command_type": command_name, "action": "exit" }),
+			);
 			// Don't store session back — it's ended
+			if let Err(e) = chat_session.save() {
+				sessions
+					.lock()
+					.await
+					.insert(session_id.clone(), chat_session);
+				send_message(
+					ws_sender,
+					&ServerMessage::error(format!("Failed to save session: {}", e)),
+				)
+				.await?;
+				return Ok(());
+			}
+			send_message(ws_sender, &status).await?;
 			return Ok(());
 		}
 		CommandResult::TreatAsUserInput => {
 			// Command not recognised — return error rather than silently treating as AI input
-			let error = ServerMessage::error(format!(
+			ServerMessage::error(format!(
 				"Unknown command: '{}'. Use type \"message\" to send user input.",
 				slash_command
-			));
-			send_message(ws_sender, &error).await?;
+			))
 		}
-	}
+	};
 
-	chat_session.save()?;
+	let save_result = chat_session.save();
 	sessions.lock().await.insert(session_id, chat_session);
+	if let Err(e) = save_result {
+		send_message(
+			ws_sender,
+			&ServerMessage::error(format!("Failed to save session: {}", e)),
+		)
+		.await?;
+		return Ok(());
+	}
+	send_message(ws_sender, &terminal).await?;
 	Ok(())
 }
 
@@ -921,14 +1001,40 @@ async fn handle_user_message(
 			)
 			.await?;
 			if inbox_msg.source.is_system_managed() {
-				chat_session.add_system_managed_user_message(&inbox_msg.content)?;
+				if let Err(e) = chat_session.add_system_managed_user_message(&inbox_msg.content) {
+					log_error!("WebSocket pre-user: failed to add inbox message: {}", e);
+					send_message(
+						ws_sender,
+						&ServerMessage::error(format!("Error processing injected message: {}", e)),
+					)
+					.await?;
+					continue;
+				}
 			} else {
-				chat_session.add_user_message(&inbox_msg.content)?;
+				if let Err(e) = chat_session.add_user_message(&inbox_msg.content) {
+					log_error!("WebSocket pre-user: failed to add inbox message: {}", e);
+					send_message(
+						ws_sender,
+						&ServerMessage::error(format!("Error processing injected message: {}", e)),
+					)
+					.await?;
+					continue;
+				}
 			}
 			let op_rx = cancellation.new_operation();
 			// Per-request spending boundary (see handle_user_message).
 			chat_session.start_request_spending_tracking();
-			prepare_for_api_call(&mut chat_session, &config_for_role, op_rx.clone()).await?;
+			if let Err(e) =
+				prepare_for_api_call(&mut chat_session, &config_for_role, op_rx.clone()).await
+			{
+				log_error!("WebSocket pre-user: failed to prepare API call: {}", e);
+				send_message(
+					ws_sender,
+					&ServerMessage::error(format!("Error processing injected message: {}", e)),
+				)
+				.await?;
+				continue;
+			}
 			let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 			let sink = WebSocketSink::new(tx);
 			let result = execute_api_call_and_process_response(
@@ -945,6 +1051,11 @@ async fn handle_user_message(
 			}
 			if let Err(e) = result {
 				log_debug!("Error processing pre-user inbox message (websocket): {}", e);
+				send_message(
+					ws_sender,
+					&ServerMessage::error(format!("Error processing injected message: {}", e)),
+				)
+				.await?;
 			}
 		}
 	}
@@ -956,7 +1067,17 @@ async fn handle_user_message(
 	// Run pipe pre-processing if a matching [[pipe]] is configured.
 	let first_message_processed = !chat_session.session.messages.is_empty();
 
-	let processed_input = run_pipe_if_enabled(&input, role, first_message_processed).await?;
+	let processed_input = match run_pipe_if_enabled(&input, role, first_message_processed).await {
+		Ok(input) => input,
+		Err(e) => {
+			sessions
+				.lock()
+				.await
+				.insert(session_id.clone(), chat_session);
+			send_message(ws_sender, &ServerMessage::error(format!("Error: {}", e))).await?;
+			return Ok(());
+		}
+	};
 
 	// Conversation compression: check if AI should compress older exchanges.
 	// Runs BEFORE user message is added to avoid breaking the new request.
@@ -986,7 +1107,14 @@ async fn handle_user_message(
 			&config_for_role.custom_constraints_file_name,
 			&current_dir,
 		);
-	chat_session.add_user_message(&final_input_with_constraints)?;
+	if let Err(e) = chat_session.add_user_message(&final_input_with_constraints) {
+		sessions
+			.lock()
+			.await
+			.insert(session_id.clone(), chat_session);
+		send_message(ws_sender, &ServerMessage::error(format!("Error: {}", e))).await?;
+		return Ok(());
+	}
 
 	// Reset the per-request spending checkpoint at the request boundary, like the
 	// interactive loop (main_loop.rs) — otherwise max_request_spending_threshold
@@ -994,7 +1122,16 @@ async fn handle_user_message(
 	chat_session.start_request_spending_tracking();
 
 	// Prepare for API call
-	prepare_for_api_call(&mut chat_session, &config_for_role, operation_rx.clone()).await?;
+	if let Err(e) =
+		prepare_for_api_call(&mut chat_session, &config_for_role, operation_rx.clone()).await
+	{
+		sessions
+			.lock()
+			.await
+			.insert(session_id.clone(), chat_session);
+		send_message(ws_sender, &ServerMessage::error(format!("Error: {}", e))).await?;
+		return Ok(());
+	}
 
 	// Create channel for WebSocket sink to stream messages
 	let (ws_tx, mut ws_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1038,36 +1175,24 @@ async fn handle_user_message(
 		send_message(ws_sender, &msg).await?;
 	}
 
-	match api_result {
-		Ok(_) => {
-			// Cost message (events already emitted via sink — no reconstruction needed)
-			let total_tokens = chat_session.session.info.input_tokens
-				+ chat_session.session.info.output_tokens
-				+ chat_session.session.info.cache_read_tokens
-				+ chat_session.session.info.cache_write_tokens
-				+ chat_session.session.info.reasoning_tokens;
-			let cost_msg = ServerMessage::Cost(CostPayload {
-				session_tokens: total_tokens,
-				session_cost: chat_session.session.info.total_cost,
-				input_tokens: chat_session.session.info.input_tokens,
-				output_tokens: chat_session.session.info.output_tokens,
-				cache_read_tokens: chat_session.session.info.cache_read_tokens,
-				cache_write_tokens: chat_session.session.info.cache_write_tokens,
-				reasoning_tokens: chat_session.session.info.reasoning_tokens,
-				session_id: session_id.clone(),
-			});
-			send_message(ws_sender, &cost_msg).await?;
-		}
-		Err(e) => {
-			log_error!("API call failed: {}", e);
-			let error = ServerMessage::error(format!("Error: {}", e));
-			send_message(ws_sender, &error).await?;
-		}
-	}
-
 	// Save session
 	log_debug!("Saving session: {}", session_id);
-	chat_session.save()?;
+	let save_result = chat_session.save();
+	let total_tokens = chat_session.session.info.input_tokens
+		+ chat_session.session.info.output_tokens
+		+ chat_session.session.info.cache_read_tokens
+		+ chat_session.session.info.cache_write_tokens
+		+ chat_session.session.info.reasoning_tokens;
+	let cost_msg = ServerMessage::Cost(CostPayload {
+		session_tokens: total_tokens,
+		session_cost: chat_session.session.info.total_cost,
+		input_tokens: chat_session.session.info.input_tokens,
+		output_tokens: chat_session.session.info.output_tokens,
+		cache_read_tokens: chat_session.session.info.cache_read_tokens,
+		cache_write_tokens: chat_session.session.info.cache_write_tokens,
+		reasoning_tokens: chat_session.session.info.reasoning_tokens,
+		session_id: session_id.clone(),
+	});
 
 	// Clear the notification sender now that this request is done
 	crate::mcp::process::clear_notification_sender(Some(session_id.clone()));
@@ -1081,6 +1206,27 @@ async fn handle_user_message(
 		notify.notify_one();
 	}
 	log_debug!("Session stored back in memory: {}", session_id);
+
+	if let Err(e) = save_result {
+		send_message(
+			ws_sender,
+			&ServerMessage::error(format!("Failed to save session: {}", e)),
+		)
+		.await?;
+		return Ok(());
+	}
+
+	match api_result {
+		Ok(_) => {
+			// Cost message (events already emitted via sink — no reconstruction needed)
+			send_message(ws_sender, &cost_msg).await?;
+		}
+		Err(e) => {
+			log_error!("API call failed: {}", e);
+			let error = ServerMessage::error(format!("Error: {}", e));
+			send_message(ws_sender, &error).await?;
+		}
+	}
 
 	Ok(())
 }

--- a/src/websocket/server.rs
+++ b/src/websocket/server.rs
@@ -772,8 +772,14 @@ async fn handle_command_message(
 				return Ok(());
 			}
 		};
-		// Send compression status.
-		let status = ServerMessage::status(status_msg, Some(session_id.clone()));
+		// Send compression status as a command result (data-carrying) so clients finalize
+		// the turn — a data-less status is indistinguishable from the connection handshake
+		// and would leave an interactive session hung on "working".
+		let status = ServerMessage::command_status(
+			status_msg.clone(),
+			Some(session_id.clone()),
+			serde_json::json!({ "command_type": "done", "message": status_msg }),
+		);
 		send_message(ws_sender, &status).await?;
 		chat_session.save()?;
 		sessions
@@ -806,9 +812,12 @@ async fn handle_command_message(
 	match command_result {
 		CommandResult::Handled => {
 			log_debug!("Command '{}' executed successfully", slash_command);
-			let status = ServerMessage::status(
+			// Data-carrying status (see command_status) so the client finalizes the turn
+			// instead of misreading a data-less status as the handshake ack.
+			let status = ServerMessage::command_status(
 				format!("Command '{}' executed successfully", slash_command),
 				Some(session_id.clone()),
+				serde_json::json!({ "command_type": command_name }),
 			);
 			send_message(ws_sender, &status).await?;
 		}


### PR DESCRIPTION
- Add is_empty_completion helper to detect provider faults
- Prevent silent failures when responses lack content, tools, or schema
- Add unit tests to ensure valid tool/structured responses are not flagged