### PR TITLE
feat(session): track external spend from agents

### DIFF
--- a/src/mcp/agent/functions.rs
+++ b/src/mcp/agent/functions.rs
@@ -798,6 +798,14 @@ pub async fn run_acp_command(
 	// with status `done` even when the API call inside the subprocess failed.
 	let mut prompt_error: Option<Value> = None;
 	let mut prompt_response_received = false;
+	// Last cost the child reported, so repeated cumulative notifications bank
+	// deltas. A tap run resumes the same child session (`--name <id>`), so its
+	// reported total already covers earlier turns — resume from what we banked.
+	let mut child_cost = tap_run_id
+		.and_then(crate::session::tap_runs::find_job)
+		.and_then(|j| j.live.usage)
+		.map(|u| u.cost)
+		.unwrap_or(0.0);
 
 	loop {
 		// Check for cancellation before each line read
@@ -841,6 +849,18 @@ pub async fn run_acp_command(
 				.and_then(|x| x.as_bool()),
 		) {
 			g.verified = v;
+		}
+
+		// The child reports its own running session cost in `_meta` (which already
+		// includes anything IT delegated), so bank only the increment. Applies to
+		// every child — `agent_*`, `tap run`, layer — otherwise their spend never
+		// reaches the parent's total.
+		if let Some(cost) = msg
+			.pointer("/params/_meta/octomind.usage/session_cost")
+			.and_then(|v| v.as_f64())
+		{
+			crate::session::external_spend::record(cost - child_cost);
+			child_cost = cost;
 		}
 
 		// Forward session/update notifications to the parent's notification
@@ -1270,6 +1290,31 @@ echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpd
 			assert_eq!(usage.output_tokens, 20);
 			assert_eq!(usage.cache_read_tokens, 7);
 			assert!((usage.cost - 0.5).abs() < 1e-9);
+
+			// Resuming the same tap run replays the child's cumulative total, so
+			// only the increment may be banked: 0.5 then 0.8 owes 0.8, not 1.3.
+			let script = format!(
+				"{HANDSHAKE}{}\n{}{WAIT_STDIN_EOF}",
+				r#"echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"session_info_update"},"_meta":{"octomind.usage":{"session_tokens":160,"session_cost":0.8,"input_tokens":120,"output_tokens":40,"cache_read_tokens":7,"cache_write_tokens":0,"reasoning_tokens":0}}}}'"#,
+				r#"echo '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}'"#
+			);
+			run_acp_command(
+				"sh",
+				&["-c", &script],
+				"task",
+				&std::env::temp_dir(),
+				watch::channel(false).1,
+				Some("tap-test-live-000001"),
+				false,
+			)
+			.await
+			.expect("resume succeeds");
+
+			let banked = crate::session::external_spend::take();
+			assert!(
+				(banked - 0.8).abs() < 1e-9,
+				"expected 0.8 banked for the parent, got {banked}"
+			);
 		})
 		.await;
 	}

--- a/src/session/chat/cost_tracker.rs
+++ b/src/session/chat/cost_tracker.rs
@@ -29,6 +29,12 @@ impl CostTracker {
 		exchange: &ProviderExchange,
 		_config: &Config,
 	) -> Result<()> {
+		// Subagents, layers and the supervisor spend without a `&mut Session` in
+		// hand; bank it into the total here so spending thresholds and every
+		// cost readout see the session's real bill.
+		chat_session.session.fold_external_spend();
+		chat_session.estimated_cost = chat_session.session.info.total_cost;
+
 		if let Some(usage) = &exchange.usage {
 			// Simple token extraction with clean provider interface
 			let cache_read_tokens = usage.cache_read_tokens;

--- a/src/session/chat/response.rs
+++ b/src/session/chat/response.rs
@@ -1122,7 +1122,10 @@ pub async fn process_response<S: OutputSink>(
 	// caller (execute_api_call_and_process_response) invokes
 	// `run_deferred_plan_compression` at a non-re-run exit instead.
 
-	// Emit cost message through sink (WebSocket/JSONL)
+	// Emit cost message through sink (WebSocket/JSONL). Fold first so the
+	// reported total covers everything this turn spent, including subagents and
+	// the supervisor — a parent reading our `octomind.usage` gets the full bill.
+	params.chat_session.session.fold_external_spend();
 	let total_tokens = params.chat_session.session.info.input_tokens
 		+ params.chat_session.session.info.output_tokens
 		+ params.chat_session.session.info.cache_read_tokens

--- a/src/session/chat/session/commands/info.rs
+++ b/src/session/chat/session/commands/info.rs
@@ -19,7 +19,10 @@ use super::{CommandOutput, CommandResult};
 use crate::config::Config;
 use anyhow::Result;
 
-pub fn handle_info(session: &ChatSession, config: &Config) -> Result<CommandResult> {
+pub fn handle_info(session: &mut ChatSession, config: &Config) -> Result<CommandResult> {
+	// Pick up subagent/supervisor spend banked since the last API call so the
+	// session line is the real total, not just the main agent's share.
+	session.session.fold_external_spend();
 	let info = &session.session.info;
 
 	let tokens_used = info.input_tokens + info.output_tokens;

--- a/src/session/external_spend.rs
+++ b/src/session/external_spend.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 Muvon Un Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Spend by models that run outside the main agent loop — subagents (`agent_*`,
+//! `tap run`), layers, and the supervisor's own cheap-model calls.
+//!
+//! None of them hold a `&mut Session` at the moment they spend, so the cost
+//! lands in this process-global accumulator and is drained into
+//! `SessionInfo::total_cost` by [`crate::session::Session::fold_external_spend`]
+//! at the next point that does. Draining (rather than reading a running total)
+//! is what makes every dollar land exactly once, including across the
+//! monotonic-max merge that `persistence` applies on resume.
+//!
+//! One process == one interactive session, so a global is effectively
+//! session-scoped (same assumption as `supervisor::stats`).
+
+use std::sync::{Mutex, OnceLock};
+
+fn pending() -> &'static Mutex<f64> {
+	static P: OnceLock<Mutex<f64>> = OnceLock::new();
+	P.get_or_init(|| Mutex::new(0.0))
+}
+
+/// Bank spend by a model that runs outside the main loop.
+pub fn record(cost: f64) {
+	if cost <= 0.0 {
+		return;
+	}
+	if let Ok(mut p) = pending().lock() {
+		*p += cost;
+	}
+}
+
+/// Take everything banked so far, leaving the accumulator empty.
+pub fn take() -> f64 {
+	pending()
+		.lock()
+		.map(|mut p| std::mem::take(&mut *p))
+		.unwrap_or(0.0)
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -22,6 +22,7 @@ pub mod chat; // Chat session logic
 mod chat_helper; // Chat command completion
 pub mod context; // Session-scoped context for multi-session concurrency
 pub mod dedup; // Tool result deduplication
+pub mod external_spend; // Spend by models outside the main loop (subagents, layers, supervisor)
 pub mod helper_functions; // Helper functions for layers and other components
 pub mod history; // Role-based history management
 pub mod image; // Image processing and attachment utilities
@@ -476,6 +477,14 @@ impl Session {
 		self.info.total_api_time_ms += api_time_ms;
 		self.info.total_tool_time_ms += tool_time_ms;
 		self.info.total_layer_time_ms += total_time_ms;
+	}
+
+	/// Fold spend by models that ran outside the main loop (subagents, layers,
+	/// supervisor) into the session total, so `total_cost` is the session's real
+	/// bill rather than just the main agent's share. Their per-source token
+	/// breakdowns stay in their own accumulators for `/info` to show.
+	pub fn fold_external_spend(&mut self) {
+		self.info.total_cost += external_spend::take();
 	}
 
 	// Save the session to a file - append-only approach

--- a/src/supervisor/stats.rs
+++ b/src/supervisor/stats.rs
@@ -15,10 +15,11 @@
 //! Supervisor activity + usage tally, surfaced in `/info`.
 //!
 //! The supervisor's own model calls (verify-gate, distill, recall-prep) run on a
-//! separate cheap model and are otherwise invisible to the session totals. This
-//! process-global accumulator captures their token/cost spend plus what the
-//! supervisor *did* (gate runs, steers, lessons/orientation stored, recalls) so
-//! `/info` can show it. One process == one interactive session, so a global is
+//! separate cheap model. This process-global accumulator captures their
+//! token/cost spend plus what the supervisor *did* (gate runs, steers,
+//! lessons/orientation stored, recalls) so `/info` can show it as its own
+//! breakdown; the cost also feeds `session::external_spend` so it lands in the
+//! session total. One process == one interactive session, so a global is
 //! effectively session-scoped (same approach as the agents stats).
 
 use std::sync::{Mutex, OnceLock};
@@ -113,6 +114,7 @@ pub fn record_call(
 		s.api_time_ms += api_time_ms;
 		s.cost += cost;
 	});
+	crate::session::external_spend::record(cost);
 }
 
 /// A verify-gate verification ran (regardless of verdict).


### PR DESCRIPTION
- Implement global accumulator for costs from subagents and supervisors
- Add fold_external_spend to merge banked costs into session totals
- Record incremental cost updates during ACP command execution
- Update cost tracker and info command to include external spend
- Add test cases for resuming tap runs with cumulative cost reporting