### PR TITLE
feat(learning): implement explicit lesson supersession

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -91,13 +91,21 @@ pub async fn execute(args: &RunArgs, config: &Config) -> Result<()> {
 		None => None,
 	};
 
+	// Resuming without a tag comes back as the session's own role, not the config
+	// default — otherwise continuing a conversation silently swaps the agent, its
+	// model and its tools. An explicit tag always wins: that IS the switch.
+	let tag = match &args.tag {
+		Some(tag) => Some(tag.clone()),
+		None => resumed_session_name(args).and_then(|name| octomind::session::resume_role(&name)),
+	};
+
 	// Resolve config and role (tap/dep resolution only — MCP init happens after session ID is set)
 	let (run_config, role) =
-		octomind::agent::resolver::resolve_config_and_role(args.tag.as_deref(), config, None)
-			.await?;
+		octomind::agent::resolver::resolve_config_and_role(tag.as_deref(), config, None).await?;
 
 	let session_args = octomind::session::chat::session::GenericSessionArgs {
 		role: role.clone(),
+		role_explicit: args.tag.is_some(),
 		mode: args.format.clone().unwrap_or_else(|| "plain".to_string()),
 		name: args.name.clone(),
 		resume: args.resume.clone(),
@@ -119,6 +127,24 @@ pub async fn execute(args: &RunArgs, config: &Config) -> Result<()> {
 		)
 		.await
 	}
+}
+
+/// Which existing session this invocation will resume, if any.
+///
+/// `--name` is included because it resumes when the session already exists; a
+/// name with no file behind it is a brand-new session and must not recover a
+/// role from anywhere.
+fn resumed_session_name(args: &RunArgs) -> Option<String> {
+	if let Some(session) = &args.resume {
+		return Some(session.clone());
+	}
+	if args.resume_recent {
+		let current_dir = octomind::mcp::get_thread_working_directory();
+		return octomind::session::find_most_recent_session_for_project(&current_dir)
+			.ok()
+			.flatten();
+	}
+	args.name.clone()
 }
 
 /// Read input from stdin (piped or interactive prompt is not our job here).

--- a/src/mcp/core/plan/compression.rs
+++ b/src/mcp/core/plan/compression.rs
@@ -583,19 +583,30 @@ pub async fn compress_completed_task(
 
 	// Build the AnchorUpdate for this compaction. Heuristic for now: the
 	// task summary becomes one `changes_made` entry, file_refs come from
-	// tool-call extraction, and `intent` is set on the first compaction
-	// from the task description (first-write-wins). Future work can
-	// replace this with an LLM-generated update for richer
-	// decisions/errors_seen content — the call shape stays the same.
+	// tool-call extraction. Future work can replace this with an
+	// LLM-generated update for richer decisions/errors_seen content — the
+	// call shape stays the same.
+	//
+	// `intent` re-reads the CURRENT user request every time. It used to be
+	// first-write-wins, which froze the goal at whatever the session opened
+	// with; `recite_note` then re-injected that stale ask as "Goal (fixed)"
+	// every few turns and steered the model off the live task. Falling back to
+	// the task description only when no real user turn survives in context.
 	let now_unix = std::time::SystemTime::now()
 		.duration_since(std::time::UNIX_EPOCH)
 		.unwrap_or_default()
 		.as_secs();
-	let anchor_intent = if session.session.info.anchor.intent.is_empty() {
-		Some(task.description.clone())
-	} else {
-		None
-	};
+	let anchor_intent = crate::session::latest_real_user_task_content(&session.session.messages)
+		.map(str::to_string)
+		.or_else(|| {
+			session
+				.session
+				.info
+				.anchor
+				.intent
+				.is_empty()
+				.then(|| task.description.clone())
+		});
 	let anchor_update = crate::session::anchor::AnchorUpdate {
 		intent: anchor_intent,
 		changes_made: vec![format!("{}: {}", task.title, summary)],

--- a/src/session/anchor.rs
+++ b/src/session/anchor.rs
@@ -113,11 +113,15 @@ impl Anchor {
 
 	/// Merge an update into this anchor. Append-only fields (`changes_made`,
 	/// `decisions`, `file_refs`, `errors_seen`) are deduplicated on insert.
-	/// `intent` replaces when the update supplies one — suppliers decide when
-	/// that is right (most guard with `is_empty()` so the first write sticks;
-	/// conversation compaction supplies the summarizer's ORIGINAL REQUEST,
-	/// which carries forward verbatim and moves only on an explicit user
-	/// pivot, so a stale goal can heal). `next_steps` always replaces.
+	/// `intent` replaces whenever the update supplies one. Suppliers deliberately
+	/// do NOT guard with `is_empty()`: a first-write-wins intent froze the goal at
+	/// whatever the session opened with, and `recite::recite_note` re-injects it
+	/// mid-turn as "Goal (fixed)" — so the supervisor kept steering the model back
+	/// to work the user had already moved past. Both suppliers now re-resolve the
+	/// CURRENT request every time (conversation compaction from its fidelity goal,
+	/// task compaction from the latest real user turn) and skip the update when
+	/// that resolves empty, so the previous value survives rather than being
+	/// cleared. `next_steps` always replaces.
 	pub fn extend(&mut self, update: AnchorUpdate, now_unix: u64) {
 		if let Some(intent) = update.intent {
 			let trimmed = intent.trim();

--- a/src/session/chat/conversation_compression/apply.rs
+++ b/src/session/chat/conversation_compression/apply.rs
@@ -26,19 +26,17 @@ use crate::session::chat::session::ChatSession;
 use crate::session::estimate_tokens;
 use anyhow::Result;
 
-/// Open tag for the synthetic post-compression continuation wrapper.
-/// Detected verbatim by `is_continuation_message` so the next compression
-/// cycle's user-msg filter excludes these from `all_user_msgs`.
-const CONTINUATION_TAG_OPEN: &str = "<continuation>";
+// Continuation-wrapper vocabulary lives in `crate::session` so the builder here
+// and every reader of the live task (recall, resolve, verify-gate, recitation)
+// agree on one spelling.
+use crate::session::{CONTINUATION_FALLBACK_INTENT, CONTINUATION_TAG_OPEN};
 
-/// Open/close tags for the `<task>` intent embedded in a continuation wrapper.
-const CONTINUATION_TASK_OPEN: &str = "<task>";
-const CONTINUATION_TASK_CLOSE: &str = "</task>";
-
-/// Placeholder used when a continuation wrapper carries no real user intent
-/// (points the model at the summary instead). Shared by the builder and the
-/// extractor so the two never drift.
-const CONTINUATION_FALLBACK_INTENT: &str = "see summary above for the active task";
+/// `Message::name` carried by every compression summary inserted into the
+/// conversation — this module's conversation summaries and the task summaries
+/// from `mcp/core/plan/compression.rs` alike. Structural, so detection never
+/// depends on the rendered body text (which gets prefixed with the
+/// earlier-requests and plan sections).
+pub(super) const COMPRESSION_MESSAGE_NAME: &str = "plan_compression";
 
 /// True if `content` is a synthetic continuation wrapper inserted by a
 /// prior compression cycle (not a real user ask). Mirrors the
@@ -58,16 +56,7 @@ pub(super) fn is_continuation_message(content: &str) -> bool {
 /// Returns None when `content` isn't a continuation wrapper, has no `<task>`,
 /// or carries only the synthetic fallback placeholder (no real intent).
 pub(super) fn extract_continuation_task(content: &str) -> Option<String> {
-	if !is_continuation_message(content) {
-		return None;
-	}
-	let start = content.find(CONTINUATION_TASK_OPEN)? + CONTINUATION_TASK_OPEN.len();
-	let end = content[start..].find(CONTINUATION_TASK_CLOSE)? + start;
-	let task = content[start..end].trim();
-	if task.is_empty() || task == CONTINUATION_FALLBACK_INTENT {
-		return None;
-	}
-	Some(task.to_string())
+	crate::session::continuation_task(content).map(str::to_string)
 }
 
 /// Build the SOTA continuation wrapper for the trailing user turn after a
@@ -149,6 +138,21 @@ pub(super) async fn apply_compression(
 			.collect()
 	};
 
+	// Re-point the session anchor at the goal we just resolved. `recite_note`
+	// injects `anchor.intent` mid-turn as "Goal (fixed)", so leaving it on an
+	// older task makes the supervisor itself steer the model back to work the
+	// user has moved on from — the same stale-task failure compaction just
+	// fixed, arriving through a different door.
+	if !fidelity_goal.trim().is_empty() {
+		session.session.info.anchor.extend(
+			crate::session::anchor::AnchorUpdate {
+				intent: Some(fidelity_goal.clone()),
+				..Default::default()
+			},
+			crate::utils::time::now_secs(),
+		);
+	}
+
 	// Fold critical knowledge from the typed summary into the session.
 	// Done up-front so the session reflects the new knowledge before we
 	// insert the rendered markdown that omits the (already-folded) entries.
@@ -202,8 +206,11 @@ pub(super) async fn apply_compression(
 		archive_path.as_deref(),
 	);
 
-	// Prepend USER TASKS section (last 4 user requests, excluding the appended one).
-	// These are raw user messages — not AI-rephrased — so intent is never lost.
+	// Prepend the earlier-requests section (last 4 user requests, excluding the
+	// appended one). These are raw user messages — not AI-rephrased — so intent
+	// is never lost. The heading says "earlier" explicitly: an ambiguous "USER
+	// TASKS" list reads as a to-do list, and a post-compaction model will pick
+	// the first entry and redo finished work.
 	let compressed_entry = if user_tasks_msgs.is_empty() {
 		base_entry
 	} else {
@@ -213,7 +220,10 @@ pub(super) async fn apply_compression(
 			.map(|(i, msg)| format!("{}. {}", i + 1, msg))
 			.collect::<Vec<_>>()
 			.join("\n");
-		format!("## USER TASKS\n{}\n\n{}", user_tasks, base_entry)
+		format!(
+			"## EARLIER USER REQUESTS (history — already superseded, NOT the active task)\n{}\n\n{}",
+			user_tasks, base_entry
+		)
 	};
 
 	// Append the current active plan (if any) to the summary so the model doesn't have
@@ -337,7 +347,7 @@ pub(super) async fn apply_compression(
 		content: compressed_entry.clone(),
 		timestamp: now,
 		cached: false,
-		name: Some("plan_compression".to_string()),
+		name: Some(COMPRESSION_MESSAGE_NAME.to_string()),
 		id: inherited_response_id,
 		..Default::default()
 	};

--- a/src/session/chat/conversation_compression/apply.rs
+++ b/src/session/chat/conversation_compression/apply.rs
@@ -296,7 +296,9 @@ pub(super) async fn apply_compression(
 	// Evict existing content markers first to enforce the 2-marker limit.
 	let supports_caching = crate::session::model_supports_caching(&session.session.info.model);
 	// Evict stale content markers — but preserve the anchor's marker.
-	// The anchor (instructions) keeps its cache marker from session start.
+	// The anchor is the last preamble message (system prompt, welcome, or the
+	// `<instructions>` file, whichever ends the preamble), so marking it caches
+	// that whole stable block behind one breakpoint.
 	// Set 1h TTL on anchor when long cache is enabled — stable prefix, rarely changes.
 	if supports_caching {
 		for (i, msg) in session.session.messages.iter_mut().enumerate() {

--- a/src/session/chat/conversation_compression/prompt.rs
+++ b/src/session/chat/conversation_compression/prompt.rs
@@ -132,9 +132,12 @@ fn build_compression_prompt(
 5. User negative feedback (\"don't do X\", \"stop doing Y\") is the HIGHEST preservation priority — never lose a correction.
 </priorities>
 
+<active_task_rule>
+original_request is the ACTIVE task, not the session's opening ask. Quote it verbatim from the MOST RECENT real user turn in the transcript — always, whether or not the new request looks related to earlier work, and whether or not the user said they were abandoning anything. A later request supersedes an earlier one by being later. Only when the transcript contains no real user turn at all may you carry forward a prior summary's original_request unchanged.
+</active_task_rule>
+
 <scaffold_rules>
 If the transcript contains a prior <conversation_summary id=\"…\">…</conversation_summary> block, treat its content as established facts that must carry forward:
-- original_request: quote verbatim from the MOST RECENT real user turn in the transcript. If the user explicitly pivoted to a new task, quote the pivot request. Only carry forward the prior summary's original_request when no new user turn exists in the transcript.
 - analysis_findings, errors_and_corrections, critical_knowledge: carry forward all prior entries, append new ones.
 - progress: extend (do not replace) the prior progress narrative.
 - current_task, next_steps: replace based on the most recent transcript.

--- a/src/session/chat/conversation_compression/range.rs
+++ b/src/session/chat/conversation_compression/range.rs
@@ -53,7 +53,13 @@ fn states_task(m: &crate::session::Message) -> bool {
 	crate::session::is_real_user_task_message(m)
 		|| (m.role == "user" && super::apply::is_continuation_message(&m.content))
 		|| (m.role == "assistant"
-			&& m.name.as_deref() == Some(super::apply::COMPRESSION_MESSAGE_NAME))
+			// Two markers, either sufficient. `name` is what this module and
+			// `plan/compression.rs` set; the tag is what the body always
+			// carries. A summary missing one (older session file, a different
+			// insertion path) would otherwise become invisible here and
+			// accumulate in the prefix forever, stale task and all.
+			&& (m.name.as_deref() == Some(super::apply::COMPRESSION_MESSAGE_NAME)
+				|| m.content.contains(super::knowledge::SUMMARY_TAG_OPEN_PREFIX)))
 }
 
 /// Find the compression range deterministically from message structure.
@@ -73,8 +79,13 @@ pub(super) fn find_compression_range(
 		return Ok((0, 0));
 	};
 
-	// No preamble in front of it (no system prompt) — there is nothing we could
-	// keep as an anchor, and index 0 must survive for the drain to be expressible.
+	// Unreachable in practice, and deliberately not a silent compression-disable:
+	// every session entry point (interactive, non-interactive, websocket, ACP)
+	// routes through `setup_system_prompt_and_cache`, which seeds the system
+	// message before anything else, and a resumed session restores it from the
+	// session file. So index 0 is always system-role and never task-stating.
+	// The check exists because `first_task - 1` needs a message to anchor on —
+	// the drain is `start_idx+1..=end_idx`, so "drain from 0" is unexpressible.
 	if first_task == 0 {
 		return Ok((0, 0));
 	}

--- a/src/session/chat/conversation_compression/range.rs
+++ b/src/session/chat/conversation_compression/range.rs
@@ -18,21 +18,43 @@
 //
 // Anchor selection is purely structural and re-derived on every call — no
 // `first_prompt_idx` cache, no resume-time bootstrap detection, no Some/None
-// branching. Two-rule deterministic ladder:
+// branching. One deterministic rule:
 //
-//   1. If a `<instructions>` user message exists, anchor = its LATEST index.
-//   2. Else, anchor = first user message index.
+//   anchor = the last message of the immutable preamble, i.e. the index just
+//   before the FIRST message that states a task.
 //
-// No tool-skip dance: under this rule the anchor is always a user-role
-// message, never an assistant-with-tool_calls, so its tool results can't
-// orphan in the drain range.
+// "States a task" means a real user turn, a prior compression summary, or a
+// prior continuation wrapper — every message shape that can tell the model
+// what it is supposed to be doing. Draining from the first of them is what
+// makes compaction safe: the session's opening ask, older summaries, and the
+// previous cycle's continuation wrapper all fold into the NEW summary instead
+// of surviving beside it as competing instructions. Keeping the opening ask
+// verbatim (the old fallback rule) made the model abandon the live task and
+// re-execute the first thing it was ever asked.
+//
+// The preamble that survives is exactly the non-task scaffolding: system
+// prompt, welcome message, and the `<instructions>` file — none of which
+// claims to be the current request.
+//
+// No tool-skip dance: the message at the anchor is always the one preceding a
+// task-stating message, so it can never be an assistant still awaiting tool
+// results (a tool result must immediately follow its assistant message).
 
 use crate::session::chat::session::ChatSession;
 use anyhow::Result;
 
-/// User-role messages wrap the instructions file in this tag at injection
-/// time (see `prompt_setup.rs`). Detect by literal prefix on trimmed content.
-const INSTRUCTIONS_TAG_OPEN: &str = "<instructions>";
+/// True when a message can state or restate "what the user wants": a real user
+/// turn, a prior compression summary, or a prior continuation wrapper.
+///
+/// This is the compression boundary. Every such message must end up INSIDE the
+/// drained range so that after compaction exactly one statement of the active
+/// task survives — the fresh continuation wrapper.
+fn states_task(m: &crate::session::Message) -> bool {
+	crate::session::is_real_user_task_message(m)
+		|| (m.role == "user" && super::apply::is_continuation_message(&m.content))
+		|| (m.role == "assistant"
+			&& m.name.as_deref() == Some(super::apply::COMPRESSION_MESSAGE_NAME))
+}
 
 /// Find the compression range deterministically from message structure.
 ///
@@ -40,31 +62,23 @@ const INSTRUCTIONS_TAG_OPEN: &str = "<instructions>";
 /// - `anchor_idx` is KEPT (compression drains `anchor_idx+1..=end_idx`)
 /// - `end_idx = messages.len() - 1`
 ///
-/// Returns `(0, 0)` when there is nothing meaningful to compress (no anchor,
-/// too few conversational messages, or anchor already at the tail).
+/// Returns `(0, 0)` when there is nothing meaningful to compress (no task-
+/// stating message, no preamble to anchor on, too few conversational messages,
+/// or the anchor is already at the tail).
 pub(super) fn find_compression_range(
 	messages: &[crate::session::Message],
 	force: bool,
 ) -> Result<(usize, usize)> {
-	// Anchor: latest <instructions> user message, else first user message.
-	let anchor = messages
-		.iter()
-		.enumerate()
-		.rev()
-		.find(|(_, m)| {
-			m.role == "user" && m.content.trim_start().starts_with(INSTRUCTIONS_TAG_OPEN)
-		})
-		.map(|(i, _)| i)
-		.or_else(|| {
-			messages
-				.iter()
-				.position(crate::session::is_real_user_task_message)
-		});
-
-	let start_idx = match anchor {
-		Some(i) => i,
-		None => return Ok((0, 0)),
+	let Some(first_task) = messages.iter().position(states_task) else {
+		return Ok((0, 0));
 	};
+
+	// No preamble in front of it (no system prompt) — there is nothing we could
+	// keep as an anchor, and index 0 must survive for the drain to be expressible.
+	if first_task == 0 {
+		return Ok((0, 0));
+	}
+	let start_idx = first_task - 1;
 
 	let end_idx = messages.len() - 1;
 

--- a/src/session/chat/conversation_compression/schema.rs
+++ b/src/session/chat/conversation_compression/schema.rs
@@ -192,7 +192,7 @@ pub fn build_compression_schema(force: bool) -> serde_json::Value {
 			},
 			"original_request": {
 				"type": "string",
-				"description": "The user's original task statement. Quote verbatim from the very first user turn in the transcript; OR, if a prior **ORIGINAL REQUEST** exists in a previous summary inside the transcript, carry it forward unchanged. EXCEPTION: if the user has since explicitly abandoned that task for an unrelated one, quote the pivot request verbatim instead — the abandoned task must not linger as the goal. Never paraphrase."
+				"description": "The ACTIVE task: quote verbatim from the MOST RECENT real user turn in the transcript. This field is what the next model turn treats as its instruction, so a stale value makes it abandon the live task and redo old work. Only when the transcript contains no real user turn at all, carry forward the prior summary's request unchanged. Never paraphrase, and never prefer an earlier turn over a later one."
 			},
 			"session_context": {
 				"type": "string",
@@ -488,7 +488,7 @@ pub const XML_OUTPUT_SPEC: &str = r#"<output_format>
 Emit ONE single XML document with the following tags, in this order. Every required tag MUST be present. Use the exact tag names below. Do not add additional tags or attributes.
 
 <should_compress>true|false</should_compress>             (required, exactly true or false)
-<original_request>verbatim first user request</original_request>   (required, may be empty when should_compress is false)
+<original_request>verbatim MOST RECENT user request</original_request>   (required, may be empty when should_compress is false)
 <session_context>one sentence</session_context>           (required, may be empty when should_compress is false)
 <current_task>1-2 sentences</current_task>                (required, may be empty when should_compress is false)
 <progress>2-4 sentences</progress>                        (required, may be empty when should_compress is false)

--- a/src/session/chat/conversation_compression/tests.rs
+++ b/src/session/chat/conversation_compression/tests.rs
@@ -83,8 +83,11 @@ fn preserves_active_skill_in_drain_range() {
 		msg("system"),    // 0
 		msg("assistant"), // 1 welcome
 		{
+			// Wrapped exactly as prompt_setup.rs injects it — an unwrapped
+			// "instructions" string is just a real user turn, and the anchor
+			// (correctly) treats it as one.
 			let mut m = msg("user"); // 2 instructions
-			m.content = "instructions".into();
+			m.content = "<instructions>\nproject rules\n</instructions>".into();
 			m
 		},
 		{
@@ -731,12 +734,15 @@ fn bug_proof_token_mismatch_causes_zero_savings() {
 	use crate::session::estimate_message_tokens;
 
 	let mut messages = Vec::new();
-	messages.push(msg("system")); // 0
 
-	// Message at start_idx has LARGE token count
-	let mut large_msg = msg("user"); // 1
+	// Message at start_idx has LARGE token count. start_idx is the last
+	// preamble message — the system prompt — since the first user turn now
+	// belongs to the drain range.
+	let mut large_msg = msg("system"); // 0
 	large_msg.content = "x".repeat(4000); // ~1000 tokens
 	messages.push(large_msg);
+
+	messages.push(msg("user")); // 1
 
 	// Messages after start_idx have SMALL token counts
 	let mut small1 = msg("assistant"); // 2
@@ -1797,13 +1803,13 @@ fn compress_all_with_tool_cycles() {
 		after.insert(start_idx + 2 + i, user_msg.clone());
 	}
 
-	// Result: [system, user(anchor), summary(asst), user(5), user(7)]
-	assert_eq!(after.len(), 5);
-	assert_eq!(after[0].role, "system");
-	assert_eq!(after[1].role, "user"); // anchor
-	assert_eq!(after[2].role, "assistant"); // summary
-	assert_eq!(after[3].role, "user"); // extracted user from idx 5
-	assert_eq!(after[4].role, "user"); // extracted user from idx 7
+	// Result: [system(anchor), summary(asst), user(5), user(7)] — the first user
+	// turn is drained now, so it is no longer part of the surviving prefix.
+	assert_eq!(after.len(), 4);
+	assert_eq!(after[0].role, "system"); // anchor
+	assert_eq!(after[1].role, "assistant"); // summary
+	assert_eq!(after[2].role, "user"); // extracted user from idx 5
+	assert_eq!(after[3].role, "user"); // extracted user from idx 7
 }
 
 #[test]

--- a/src/session/chat/conversation_compression/tests.rs
+++ b/src/session/chat/conversation_compression/tests.rs
@@ -287,7 +287,10 @@ fn extends_range_to_include_tool_results() {
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Compress-all: end_idx = last message
-	assert_eq!(start_idx, 1);
+	assert_eq!(
+		start_idx, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 	assert_eq!(end_idx, 9, "compress-all: end_idx = last message");
 }
 
@@ -317,7 +320,10 @@ fn extends_when_ending_on_assistant_with_tools() {
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Compress-all: end_idx = last message
-	assert_eq!(start_idx, 1);
+	assert_eq!(
+		start_idx, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 	assert_eq!(end_idx, 9, "compress-all: end_idx = last message");
 }
 
@@ -359,7 +365,10 @@ fn handles_multiple_assistants_with_tools() {
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
 	// Compress-all: end_idx = last message, no preserved zone
-	assert_eq!(start_idx, 1);
+	assert_eq!(
+		start_idx, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 	assert_eq!(end_idx, 10, "compress-all: end_idx = last message");
 }
 
@@ -393,7 +402,7 @@ fn start_boundary_must_not_orphan_initial_tool_sequence() {
 	// (kept across compression cycles).
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(start_idx, 3, "anchor = first user message at idx 3");
+	assert_eq!(start_idx, 2, "anchor = message before the first user turn");
 	assert!(
 		end_idx >= 4,
 		"compression range must include messages after anchor"
@@ -437,7 +446,7 @@ fn leading_tool_exchange_stays_in_prefix_no_orphans() {
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(start_idx, 5, "anchor = first user message at idx 5");
+	assert_eq!(start_idx, 4, "anchor = message before the first user turn");
 	assert!(end_idx > start_idx);
 
 	// Drain range [6..=10] contains no tool messages (all asst/user), so no
@@ -479,7 +488,10 @@ fn anchor_when_first_user_precedes_tool_calls_assistant() {
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(start_idx, 1, "anchor = first user message at idx 1");
+	assert_eq!(
+		start_idx, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 	assert!(end_idx > start_idx, "must have valid range");
 	assert!(end_idx >= 3, "drain must include tool result at idx 3");
 }
@@ -509,7 +521,7 @@ fn welcome_preserved_when_no_instructions_file() {
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(start_idx, 2, "anchor = first user message at idx 2");
+	assert_eq!(start_idx, 1, "anchor = welcome; first user turn is drained");
 	assert!(end_idx > start_idx, "must have valid range");
 	assert!(
 		start_idx + 1 > 1,
@@ -539,7 +551,11 @@ fn anchor_is_instructions_message_when_present() {
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(start_idx, 2, "anchor must be the <instructions> message");
+	assert_eq!(start_idx, 3, "anchor = message before the first user turn");
+	assert!(
+		start_idx >= 2,
+		"<instructions> at idx 2 must survive outside the drain range"
+	);
 	assert_eq!(end_idx, 9, "compress-all: end_idx = last message");
 }
 
@@ -599,10 +615,14 @@ fn anchor_with_instructions_then_assistant_tool_calls() {
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
 
-	assert_eq!(start_idx, 2, "anchor on <instructions> message");
+	assert_eq!(start_idx, 5, "anchor = message before the first user turn");
+	assert!(
+		start_idx >= 2,
+		"<instructions> at idx 2 must survive outside the drain range"
+	);
 	assert_eq!(end_idx, 11, "compress-all: end_idx = last message");
-	// Drain range [3..=11] includes the assistant+tool_calls AND its tool result —
-	// both go together, no orphaning possible.
+	// The assistant+tool_calls at 3 and its tool result at 4 both sit in the
+	// surviving prefix — they go together, so no orphaning is possible.
 }
 
 #[test]
@@ -738,7 +758,7 @@ fn bug_proof_token_mismatch_causes_zero_savings() {
 	messages.push(msg("assistant")); // 8
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 1); // Large message
+	assert_eq!(start_idx, 0); // system prompt
 	assert_eq!(end_idx, 8); // compress-all: last message
 
 	// What calculate_range_tokens ACTUALLY counts (CURRENT BUG)
@@ -1239,7 +1259,10 @@ fn anchor_stable_across_repeated_compressions() {
 
 	// First compression
 	let (start1, end1) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start1, 1, "anchor = first user message");
+	assert_eq!(
+		start1, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 	assert!(end1 >= 4);
 
 	// Simulate post-compression state: anchor at 1, summary at 2, preserved tail
@@ -1255,7 +1278,7 @@ fn anchor_stable_across_repeated_compressions() {
 
 	// Second compression — anchor is STILL idx 1 (re-derived, not cached)
 	let (start2, end2) = find_compression_range(&after, false).unwrap();
-	assert_eq!(start2, 1, "anchor re-derives to same index");
+	assert_eq!(start2, 0, "anchor re-derives to same index");
 	assert!(end2 >= 4);
 }
 
@@ -1278,7 +1301,7 @@ fn old_compressed_summary_is_recompressed_on_next_cycle() {
 	} // 3-10
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 1, "start at permanent anchor");
+	assert_eq!(start_idx, 0, "start at permanent anchor");
 
 	// Drain range is start_idx+1..=end_idx = 2..=end_idx
 	// Index 2 (old summary) IS in the drain range — it gets re-compressed
@@ -1355,7 +1378,7 @@ fn bootstrap_with_many_messages_compresses_all() {
 	} // 4-13
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 2, "anchor must be instructions file at idx 2");
+	assert_eq!(start_idx, 1, "anchor = message before the first user turn");
 	assert_eq!(end_idx, 13, "compress-all: end_idx = last message");
 }
 
@@ -1382,9 +1405,9 @@ fn triple_compression_always_one_summary() {
 		messages.push(msg(if i % 2 == 0 { "user" } else { "assistant" }));
 	} // 3-10
 
-	// 3rd compression — still starts at anchor (1)
+	// 3rd compression — still starts at anchor (0)
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 1);
+	assert_eq!(start_idx, 0);
 
 	// Old summary at 2 is in drain range
 	assert!((start_idx + 1..=end_idx).contains(&2));
@@ -1480,12 +1503,14 @@ fn messages_to_compress_excludes_anchor_message() {
 	// The anchor at start_idx is KEPT by remove_messages_in_range.
 
 	let mut messages = Vec::new();
-	messages.push(msg("system")); // 0
 
-	let mut anchor = msg("user"); // 1
+	// The anchor is the last preamble message — the system prompt here, since
+	// the first user turn now belongs to the drain range.
+	let mut anchor = msg("system"); // 0
 	anchor.content = "ANCHOR_CONTENT_MUST_NOT_BE_SUMMARIZED".to_string();
 	messages.push(anchor);
 
+	messages.push(msg("user")); // 1
 	messages.push(msg("assistant")); // 2
 	messages.push(msg("user")); // 3
 	messages.push(msg("assistant")); // 4
@@ -1495,7 +1520,7 @@ fn messages_to_compress_excludes_anchor_message() {
 	messages.push(msg("assistant")); // 8
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 1);
+	assert_eq!(start_idx, 0);
 
 	let correct = &messages[start_idx + 1..=end_idx];
 	let wrong = &messages[start_idx..=end_idx];
@@ -1616,7 +1641,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 	} // 2-11
 
 	let (s1, e1) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(s1, 1, "Cycle 1: start must be anchor (1)");
+	assert_eq!(s1, 0, "Cycle 1: start must be anchor (0)");
 	assert!(e1 > s1, "Cycle 1: end must be after anchor");
 	assert!(
 		e1 < messages.len(),
@@ -1636,7 +1661,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 	}
 
 	let (s2, e2) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(s2, 1, "Cycle 2: start must still be anchor (1)");
+	assert_eq!(s2, 0, "Cycle 2: start must still be anchor (0)");
 	assert!(e2 > s2);
 
 	let drained2: Vec<Message> = messages.drain(s2 + 1..=e2).collect();
@@ -1651,7 +1676,7 @@ fn test_multiple_compression_cycles_anchor_never_moves() {
 	}
 
 	let (s3, e3) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(s3, 1, "Cycle 3: start must still be anchor (1)");
+	assert_eq!(s3, 0, "Cycle 3: start must still be anchor (0)");
 	assert!(e3 > s3);
 
 	// After 3 cycles the anchor is always at index 1 — never drifts.
@@ -1672,7 +1697,10 @@ fn compress_all_includes_last_message() {
 	messages.push(msg("user")); // 22
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 1);
+	assert_eq!(
+		start_idx, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 	assert_eq!(end_idx, 22, "compress-all: end_idx must be last message");
 }
 
@@ -1699,7 +1727,7 @@ fn compress_all_with_tool_loop_after_user_prompt() {
 	];
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 2, "anchor at instructions");
+	assert_eq!(start_idx, 1, "anchor = message before the first user turn");
 	assert_eq!(end_idx, 14, "compress-all: end_idx = last message");
 }
 
@@ -1741,7 +1769,10 @@ fn compress_all_with_tool_cycles() {
 	];
 
 	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
-	assert_eq!(start_idx, 1);
+	assert_eq!(
+		start_idx, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 	assert_eq!(end_idx, 8, "compress-all: end_idx = last message");
 
 	// Simulate compress-all + user extraction: drain, insert summary, re-inject users
@@ -1816,7 +1847,10 @@ fn tool_loop_only_one_user_message_still_compresses() {
 	);
 
 	// Tool-loop: single user message, no instructions → anchor = first user (idx 1).
-	assert_eq!(start_idx, 1, "anchor = first user message at idx 1");
+	assert_eq!(
+		start_idx, 0,
+		"anchor = preamble end; first user turn is drained"
+	);
 
 	// compress-all: end_idx = last message
 	assert_eq!(
@@ -1920,8 +1954,8 @@ fn regression_session_260521_no_stuck_first_turn_prefix() {
 
 	// New rule: anchor = first user message. NOT idx 7.
 	assert_eq!(
-		start_idx, 2,
-		"anchor MUST be the first user message, not parked past the bootstrap turn"
+		start_idx, 1,
+		"anchor MUST sit just before the first user turn, not parked past the bootstrap turn"
 	);
 	assert_eq!(end_idx, messages.len() - 1, "drain extends to last message");
 
@@ -2288,4 +2322,157 @@ fn level_cursor_single_level_is_always_zero() {
 	for n in 0..5 {
 		assert_eq!(select_compression_level_index(1, n), 0);
 	}
+}
+
+// ============================================================================
+// STALE-TASK REGRESSION TESTS: after a compaction the model must see exactly
+// ONE statement of what it is supposed to be doing. Every message shape that
+// can claim to be "the request" — the opening user turn, a prior summary, a
+// prior continuation wrapper — has to end up inside the drain range.
+// ============================================================================
+
+fn continuation_msg(task: &str) -> Message {
+	Message {
+		role: "user".to_string(),
+		content: format!(
+			"<continuation>\nresume\n<task>\n{}\n</task>\n</continuation>",
+			task
+		),
+		..Default::default()
+	}
+}
+
+fn summary_msg(body: &str) -> Message {
+	Message {
+		role: "assistant".to_string(),
+		content: format!(
+			"<conversation_summary id=\"c1\">\n{}</conversation_summary>",
+			body
+		),
+		name: Some(super::apply::COMPRESSION_MESSAGE_NAME.to_string()),
+		..Default::default()
+	}
+}
+
+#[test]
+fn opening_user_request_is_drained_not_kept_as_anchor() {
+	// The bug: the session's FIRST ask survived compaction verbatim as a real
+	// user turn, so the model dropped the live task and re-executed it.
+	let mut first = msg("user");
+	first.content = "read all memories to understand how we were benchmarking".into();
+	let mut latest = msg("user");
+	latest.content = "prepare the benchmark script".into();
+
+	let messages = vec![
+		msg("system"),    // 0
+		msg("assistant"), // 1 welcome
+		first,            // 2 opening ask — MUST be drained
+		msg("assistant"), // 3
+		msg("user"),      // 4
+		msg("assistant"), // 5
+		latest,           // 6 the live task
+		msg("assistant"), // 7
+	];
+
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
+
+	assert_eq!(start_idx, 1, "anchor = welcome, the last preamble message");
+	assert!(
+		(start_idx + 1..=end_idx).contains(&2),
+		"the opening ask must be inside the drain range"
+	);
+	for m in messages.iter().take(start_idx + 1) {
+		assert!(
+			!crate::session::is_real_user_task_message(m),
+			"no real user turn may survive in the preserved prefix"
+		);
+	}
+}
+
+#[test]
+fn prior_summary_and_continuation_never_survive_recompaction() {
+	// Without an <instructions> message the old anchor rule parked on the first
+	// real user turn, so every earlier cycle's summary AND its continuation
+	// wrapper (carrying a stale <task>) accumulated in the prefix forever.
+	let messages = vec![
+		msg("system"),                    // 0
+		msg("assistant"),                 // 1 welcome
+		summary_msg("cycle 1 progress"),  // 2 old summary
+		continuation_msg("the OLD task"), // 3 old continuation — stale <task>
+		msg("user"),                      // 4 new ask
+		msg("assistant"),                 // 5
+		msg("user"),                      // 6
+		msg("assistant"),                 // 7
+		msg("user"),                      // 8
+		msg("assistant"),                 // 9
+	];
+
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
+
+	assert_eq!(start_idx, 1, "anchor = welcome, before the old summary");
+	for stale in 2..=4 {
+		assert!(
+			(start_idx + 1..=end_idx).contains(&stale),
+			"idx {stale} (old summary / continuation / new ask) must be drained"
+		);
+	}
+}
+
+#[test]
+fn instructions_survive_but_never_anchor_a_stale_task() {
+	// With <instructions> present the preamble is longer, but the invariant is
+	// identical: instructions survive, every task statement is drained.
+	let mut instructions = msg("user");
+	instructions.content = "<instructions>\nproject rules\n</instructions>".into();
+
+	let messages = vec![
+		msg("system"),                    // 0
+		msg("assistant"),                 // 1 welcome
+		instructions,                     // 2 instructions — must survive
+		msg("user"),                      // 3 opening ask
+		summary_msg("cycle 1"),           // 4
+		continuation_msg("the OLD task"), // 5
+		msg("user"),                      // 6
+		msg("assistant"),                 // 7
+		msg("user"),                      // 8
+		msg("assistant"),                 // 9
+	];
+
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
+
+	assert_eq!(start_idx, 2, "anchor = the <instructions> message");
+	assert!(
+		messages[start_idx].content.starts_with("<instructions>"),
+		"instructions must survive outside the drain range"
+	);
+	for stale in 3..=6 {
+		assert!(
+			(start_idx + 1..=end_idx).contains(&stale),
+			"idx {stale} must be drained"
+		);
+	}
+}
+
+#[test]
+fn anchor_is_stable_when_only_synthetic_messages_precede_the_task() {
+	// A session whose drain range opens on a continuation wrapper (barren
+	// re-compaction — no fresh user turn) still anchors on the preamble.
+	let messages = vec![
+		msg("system"),                   // 0
+		summary_msg("prior work"),       // 1
+		continuation_msg("active task"), // 2
+		msg("assistant"),                // 3
+		msg("assistant"),                // 4
+		msg("assistant"),                // 5
+		msg("assistant"),                // 6
+		msg("assistant"),                // 7
+	];
+
+	let (start_idx, end_idx) = find_compression_range(&messages, false).unwrap();
+
+	assert_eq!(start_idx, 0, "anchor = system prompt");
+	assert!(
+		(start_idx + 1..=end_idx).contains(&2),
+		"the continuation wrapper carrying the task must be re-summarised"
+	);
 }

--- a/src/session/chat/conversation_compression/tests.rs
+++ b/src/session/chat/conversation_compression/tests.rs
@@ -187,7 +187,10 @@ fn preserves_active_skill_in_drain_range() {
 	// Expected post-compression layout:
 	// [system, welcome, instructions(anchor), skill, SUMMARY, user_req3]
 	assert_eq!(messages.len(), 6);
-	assert_eq!(messages[2].content, "instructions");
+	assert_eq!(
+		messages[2].content,
+		"<instructions>\nproject rules\n</instructions>"
+	);
 	assert!(
 		crate::mcp::runtime::skill::is_skill_message(&messages[3].content),
 		"skill comes right after anchor"

--- a/src/session/chat/session/api_executor.rs
+++ b/src/session/chat/session/api_executor.rs
@@ -37,10 +37,7 @@ const CONTINUE_NOTE: &str = "<pay-attention>\n<!-- octomind:pre_gate_unfinished_
 const PREGATE_NOTE: &str = "<pay-attention>\n<!-- octomind:pre_gate_unverified_mutation -->\nYou may only report done after a verification has actually passed. You reported done with state changes still unverified, so that claim isn't trustworthy yet. Run the check appropriate to this work (for example, inspect the resulting state, exercise the changed behavior, or use a domain-specific validator), watch the result, and report the actual outcome: pass, fail, or — if no meaningful check exists — what you inspected and why that is sufficient. Base the report on the observed result, not on what you expect.\n</pay-attention>";
 
 fn latest_real_user_turn_start(messages: &[crate::session::Message]) -> usize {
-	messages
-		.iter()
-		.rposition(crate::session::is_real_user_task_message)
-		.unwrap_or(messages.len())
+	crate::session::latest_task_turn_index(messages).unwrap_or(messages.len())
 }
 
 fn current_turn_tool_outputs(

--- a/src/session/chat/session/core.rs
+++ b/src/session/chat/session/core.rs
@@ -52,6 +52,9 @@ pub struct SessionInitParams<'a> {
 	pub config: &'a Config,
 	/// Role for the session
 	pub role: &'a str,
+	/// The role was named explicitly by the caller (see
+	/// [`crate::session::chat::session::GenericSessionArgs::role_explicit`]).
+	pub role_explicit: bool,
 	/// Optional JSON schema for structured output
 	pub schema: Option<serde_json::Value>,
 }
@@ -70,8 +73,15 @@ impl<'a> SessionInitParams<'a> {
 			output_mode: None,
 			config,
 			role,
+			role_explicit: false,
 			schema: None,
 		}
+	}
+
+	/// Mark the role as explicitly named by the caller rather than inherited.
+	pub fn with_role_explicit(mut self, role_explicit: bool) -> Self {
+		self.role_explicit = role_explicit;
+		self
 	}
 
 	/// Set session name
@@ -612,8 +622,13 @@ impl ChatSession {
 						chat_session.cache_next_user_message = true;
 					}
 
-					// Apply restored role if available
-					if let Some(restored_role) = runtime_state.role {
+					// Apply restored role if available. An explicitly named role is a
+					// deliberate switch and outranks whatever `/role` the session
+					// last logged — otherwise `run reviewer --resume x` would snap
+					// straight back to the old role.
+					if let Some(restored_role) =
+						runtime_state.role.filter(|_| !params.role_explicit)
+					{
 						// Validate that the restored role still exists in config
 						if params.config.roles.iter().any(|r| r.name == restored_role) {
 							chat_session.role = restored_role;

--- a/src/session/chat/session/params.rs
+++ b/src/session/chat/session/params.rs
@@ -26,6 +26,11 @@ pub struct GenericSessionArgs {
 	pub max_tokens: Option<u32>,
 	pub temperature: Option<f32>,
 	pub role: String,
+	/// The caller named the role explicitly (a CLI tag), rather than inheriting
+	/// it from a resumed session or the config default. An explicit role is a
+	/// deliberate switch, so it must not be overridden by a `/role` command
+	/// replayed out of the resumed session's log.
+	pub role_explicit: bool,
 	pub max_retries: Option<u32>,
 	/// Output mode: "plain", "jsonl", or "websocket". Anything else is
 	/// normalised to "plain" by `setup_and_initialize_session`.

--- a/src/session/chat/session/setup.rs
+++ b/src/session/chat/session/setup.rs
@@ -191,7 +191,8 @@ pub async fn setup_and_initialize_session(
 	}
 
 	// Create or load session
-	let mut session_params = SessionInitParams::new(&config_for_role, &role);
+	let mut session_params =
+		SessionInitParams::new(&config_for_role, &role).with_role_explicit(args.role_explicit);
 
 	if let Some(name) = name {
 		session_params = session_params.with_name(name);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -546,7 +546,7 @@ pub mod persistence;
 pub use persistence::{
 	append_to_session_file, clean_interrupted_tool_calls, extract_runtime_state_from_log,
 	find_most_recent_session_for_project, get_sessions_dir, list_available_sessions, load_session,
-	SessionRuntimeState,
+	resume_role, SessionRuntimeState,
 };
 pub mod prompt;
 pub use prompt::{add_compression_hints_to_prompt, create_system_prompt};

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -129,7 +129,7 @@ impl Default for Message {
 pub fn is_system_managed_user_content(content: &str) -> bool {
 	let trimmed = content.trim_start();
 	trimmed.starts_with("<instructions>")
-		|| trimmed.starts_with("<continuation>")
+		|| trimmed.starts_with(CONTINUATION_TAG_OPEN)
 		|| trimmed.starts_with("<system-note>")
 		|| crate::mcp::runtime::skill::is_skill_message(content)
 		|| crate::supervisor::gate::is_supervisor_injection(content)
@@ -156,12 +156,62 @@ pub fn is_real_user_task_message(message: &Message) -> bool {
 	!is_system_managed_user_content(&message.content)
 }
 
-pub fn latest_real_user_task_content(messages: &[Message]) -> Option<&str> {
+/// Open tag of the synthetic wrapper compaction inserts to carry the live
+/// request forward once the raw user turns have been drained.
+pub const CONTINUATION_TAG_OPEN: &str = "<continuation>";
+/// Open/close tags of the `<task>` intent embedded in a continuation wrapper.
+pub const CONTINUATION_TASK_OPEN: &str = "<task>";
+pub const CONTINUATION_TASK_CLOSE: &str = "</task>";
+/// Placeholder a continuation wrapper carries when there was no real user
+/// intent to forward. Shared by the builder and every reader so they can't drift.
+pub const CONTINUATION_FALLBACK_INTENT: &str = "see summary above for the active task";
+
+/// The `<task>` a continuation wrapper carries, borrowed from `content`.
+///
+/// `None` when `content` is not a wrapper, carries no `<task>`, or holds only
+/// the synthetic placeholder — i.e. whenever there is no real intent to read.
+pub fn continuation_task(content: &str) -> Option<&str> {
+	let trimmed = content.trim_start();
+	if !trimmed.starts_with(CONTINUATION_TAG_OPEN) {
+		return None;
+	}
+	let start = trimmed.find(CONTINUATION_TASK_OPEN)? + CONTINUATION_TASK_OPEN.len();
+	let end = trimmed[start..].find(CONTINUATION_TASK_CLOSE)? + start;
+	let task = trimmed[start..end].trim();
+	if task.is_empty() || task == CONTINUATION_FALLBACK_INTENT {
+		return None;
+	}
+	Some(task)
+}
+
+/// Index of the message that opens the current turn: the most recent genuine
+/// user turn, or — once a compaction has drained them all — the continuation
+/// wrapper carrying the live request forward.
+///
+/// Without the fallback every consumer (lesson recall, task resolution, the
+/// verify-gate's turn window, constraint recitation) goes blind for the rest of
+/// the turn immediately after a compaction.
+pub fn latest_task_turn_index(messages: &[Message]) -> Option<usize> {
 	messages
 		.iter()
-		.rev()
-		.find(|m| is_real_user_task_message(m))
-		.map(|m| m.content.as_str())
+		.rposition(is_real_user_task_message)
+		.or_else(|| {
+			messages
+				.iter()
+				.rposition(|m| m.role == "user" && continuation_task(&m.content).is_some())
+		})
+}
+
+/// The live user request — the text at [`latest_task_turn_index`], unwrapped
+/// when it is a continuation wrapper. The two always resolve to the same
+/// message, so an index and its content can never disagree.
+pub fn latest_real_user_task_content(messages: &[Message]) -> Option<&str> {
+	let message = messages.get(latest_task_turn_index(messages)?)?;
+	if is_real_user_task_message(message) {
+		Some(message.content.as_str())
+	} else {
+		continuation_task(&message.content)
+	}
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -534,6 +584,51 @@ mod tests {
 			id: None,
 		}
 	}
+	#[test]
+	fn latest_task_falls_back_to_continuation_after_compaction() {
+		let wrapper = "<continuation>\nResume from where the previous turn left off.\n<task>\nprepare the benchmark script\n</task>\n</continuation>";
+
+		// While a genuine user turn survives, it wins outright.
+		let live = vec![
+			create_test_message("system", "sys", None, None),
+			create_test_message("user", wrapper, None, None),
+			create_test_message("user", "prepare the benchmark script", None, None),
+		];
+		assert_eq!(
+			latest_real_user_task_content(&live),
+			Some("prepare the benchmark script")
+		);
+
+		// After compaction drains every raw user turn, the wrapper carries the
+		// live request — without this the whole supervisor stack goes blind.
+		let compacted = vec![
+			create_test_message("system", "sys", None, None),
+			create_test_message("assistant", "<conversation_summary/>", None, None),
+			create_test_message("user", wrapper, None, None),
+		];
+		assert_eq!(
+			latest_real_user_task_content(&compacted),
+			Some("prepare the benchmark script")
+		);
+
+		// The synthetic placeholder is not intent — it must not resolve.
+		let barren = vec![create_test_message(
+			"user",
+			&format!(
+				"<continuation>\n<task>\n{}\n</task>\n</continuation>",
+				CONTINUATION_FALLBACK_INTENT
+			),
+			None,
+			None,
+		)];
+		assert_eq!(latest_real_user_task_content(&barren), None);
+
+		// Non-wrappers and malformed wrappers never yield a task.
+		assert_eq!(continuation_task("just a user message"), None);
+		assert_eq!(continuation_task("<continuation>\nno task tag"), None);
+		assert_eq!(continuation_task("<continuation>\n<task>\n</task>"), None);
+	}
+
 	#[test]
 	fn ensure_system_managed_wraps_unmarked_content_only() {
 		// Marked content passes through untouched.

--- a/src/session/persistence.rs
+++ b/src/session/persistence.rs
@@ -865,6 +865,51 @@ pub fn extract_runtime_state_from_log(session_file: &PathBuf) -> Result<SessionR
 	Ok(state)
 }
 
+/// The role a session should come back as when resumed without an explicit one.
+///
+/// Resuming is not starting: the session already knows what it was, so falling
+/// back to the config default silently switches the agent (and its model, tools
+/// and system prompt) out from under a conversation already in progress.
+///
+/// Prefers the last `/role` switch recorded in the log over the role the session
+/// was created with — that switch is the more recent expression of intent.
+/// `None` when the session file is missing, unreadable, or records no role, in
+/// which case the caller keeps its own default.
+pub fn resume_role(session_name: &str) -> Option<String> {
+	let session_file = get_sessions_dir()
+		.ok()?
+		.join(format!("{}.jsonl.zst", session_name));
+	if !session_file.exists() {
+		return None;
+	}
+	if let Some(role) = extract_runtime_state_from_log(&session_file)
+		.ok()
+		.and_then(|state| state.role)
+	{
+		return Some(role);
+	}
+	// Fall back to the creation role in the SUMMARY header. Only the first few
+	// lines are read — the whole log is not needed for this.
+	let reader = BufReader::new(ZstdDecoder::new(File::open(&session_file).ok()?).ok()?);
+	for line in reader.lines().take(10) {
+		let Ok(line) = line else { break };
+		let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+			continue;
+		};
+		if value.get("type").and_then(|t| t.as_str()) != Some("SUMMARY") {
+			continue;
+		}
+		let role = value
+			.get("session_info")
+			.and_then(|i| i.get("role"))
+			.and_then(|r| r.as_str())?;
+		if !role.is_empty() {
+			return Some(role.to_string());
+		}
+	}
+	None
+}
+
 /// Apply a command to runtime state (for state extraction)
 fn apply_command_to_runtime_state(state: &mut SessionRuntimeState, command_line: &str) {
 	let parts: Vec<&str> = command_line.split_whitespace().collect();

--- a/src/supervisor/learning/extract.rs
+++ b/src/supervisor/learning/extract.rs
@@ -51,13 +51,17 @@ Most lessons are scoped. When unsure, use "scoped".
 - confidence=medium: the quote states a preference without a direct correction
 - State each lesson as a reusable rule, not a narrative
 
-# Existing Lessons (DO NOT duplicate; refine one only if a new user quote shows they changed their mind)
+# Existing Lessons (each carries an id you can reference)
 {existing_lessons}
 
 # Output Format
-<lesson scope="global|scoped" confidence="high|medium" tags="keyword1,keyword2" evidence="exact user quote here">
+<lesson scope="global|scoped" confidence="high|medium" tags="keyword1,keyword2" evidence="exact user quote here" supersedes="L#">
 Lesson text — what to do or avoid, stated as a rule.
-</lesson>"#;
+</lesson>
+
+Set supersedes="L#" ONLY when this lesson REPLACES that exact existing lesson because a new
+user quote refines it or reverses it — the old one is then deleted. Omit the attribute for
+anything new. Never restate an existing lesson that has not changed: drop it instead."#;
 
 /// Appended to the extraction prompt when orientation capture is enabled.
 const ORIENTATION_SECTION: &str = r#"
@@ -110,7 +114,10 @@ pub async fn run_extraction(
 		existing_scoped.len(),
 		existing_global.len()
 	);
-	let existing_text = format_existing(&existing_scoped, &existing_global);
+	// Bounded, id-labelled slice of the store — this is what the model may
+	// reference with `supersedes`, so prompt size is independent of corpus size.
+	let reconcile = reconcile_candidates(&existing_scoped, &existing_global);
+	let existing_text = format_existing(&reconcile);
 
 	let transcript = build_transcript(messages);
 	if transcript.is_empty() {
@@ -171,12 +178,13 @@ pub async fn run_extraction(
 		return Ok(stored);
 	}
 
-	let lessons_ev = parse_lessons_with_evidence(&response, role, project, session_name);
+	let candidates =
+		parse_lessons_with_evidence(&response, role, project, session_name, reconcile.len());
 	crate::log_debug!(
 		"Learning extraction: LLM returned {} lessons with evidence",
-		lessons_ev.len()
+		candidates.len()
 	);
-	if lessons_ev.is_empty() {
+	if candidates.is_empty() {
 		return Ok(stored);
 	}
 
@@ -192,47 +200,47 @@ pub async fn run_extraction(
 		.filter(|m| crate::session::is_real_user_task_message(m))
 		.map(|m| m.content.as_str())
 		.collect();
-	let lessons_ev: Vec<(Lesson, String)> = lessons_ev
+	let candidates: Vec<Candidate> = candidates
 		.into_iter()
-		.filter(|(lesson, evidence)| {
-			let found = user_turns.iter().any(|u| u.contains(evidence.as_str()));
+		.filter(|c| {
+			let found = user_turns.iter().any(|u| u.contains(c.evidence.as_str()));
 			if !found {
 				crate::log_debug!(
 					"Learning rejected (evidence not verbatim in any user turn): {}",
-					lesson.content
+					c.lesson.content
 				);
 			}
 			found
 		})
 		.collect();
-	if lessons_ev.is_empty() {
+	if candidates.is_empty() {
 		return Ok(stored);
 	}
 
 	// 2. One batched LLM pass: does the evidence actually support each lesson's
-	//    rule? Fail-open — a verifier outage must never block learning.
-	let keep = verify_lessons(config, &lessons_ev, &transcript).await;
-	let lessons: Vec<Lesson> = lessons_ev
+	//    rule? Fail-closed — an unverifiable rule must not become durable state.
+	let keep = verify_lessons(config, &candidates, &transcript).await;
+	let candidates: Vec<Candidate> = candidates
 		.into_iter()
 		.zip(keep.iter())
-		.filter_map(|((lesson, _), &k)| {
+		.filter_map(|(c, &k)| {
 			if !k {
 				crate::log_debug!(
 					"Learning rejected (evidence does not support rule): {}",
-					lesson.content
+					c.lesson.content
 				);
 			}
-			k.then_some(lesson)
+			k.then_some(c)
 		})
 		.collect();
-	if lessons.is_empty() {
+	if candidates.is_empty() {
 		return Ok(stored);
 	}
 
-	// Store each. Match within the same scope. Identical content is skipped;
-	// a refinement (high word overlap) supersedes the stale lesson — delete the
-	// old, write the new — so a correction to a previous correction wins instead
-	// of being silently dropped.
+	// Store each. Identical content is skipped. A refinement or reversal deletes
+	// the lesson the model explicitly named via `supersedes`, so a correction to
+	// a previous correction wins instead of being silently dropped — and no
+	// unrelated lesson is ever deleted on a similarity guess.
 	// Dedup lessons against existing lessons only (exclude orientation entries
 	// that share the same store).
 	let existing_lessons_scoped: Vec<Lesson> = existing_scoped
@@ -240,7 +248,8 @@ pub async fn run_extraction(
 		.filter(|l| l.memory_type != "orientation")
 		.cloned()
 		.collect();
-	for lesson in &lessons {
+	for candidate in &candidates {
+		let lesson = &candidate.lesson;
 		let existing = if lesson.scope == "global" {
 			&existing_global
 		} else {
@@ -255,7 +264,13 @@ pub async fn run_extraction(
 			continue;
 		}
 
-		if let Some(old) = best_overlap(&lesson.content, existing) {
+		// A scoped rule may not delete a user-wide one: crossing scopes here
+		// would let one project erase a preference that holds everywhere.
+		if let Some(old) = candidate
+			.supersedes
+			.and_then(|i| reconcile.get(i))
+			.filter(|old| old.scope == lesson.scope)
+		{
 			if let Err(e) = backend
 				.delete(&old.file_id(), &old.role, &old.project, config)
 				.await
@@ -283,6 +298,32 @@ pub async fn run_extraction(
 	Ok(stored)
 }
 
+/// Per-message transcript budget for USER turns. Every lesson needs a verbatim
+/// user quote, so this is where the signal is — spend the characters here.
+const USER_MSG_CHARS: usize = 2000;
+/// Per-message budget for assistant/tool turns: context only, never evidence.
+const OTHER_MSG_CHARS: usize = 500;
+
+/// Keep both ends of an over-budget message. Corrections and final constraints
+/// land at the END of long messages, which head-only truncation always dropped.
+/// UTF-8 safe: both cuts land on character boundaries.
+fn head_tail(content: &str, budget: usize) -> String {
+	if content.len() <= budget {
+		return content.to_string();
+	}
+	let half = budget / 2;
+	let head_end = crate::utils::truncation::floor_char_boundary(content, half);
+	let mut tail_start = content.len() - half;
+	while !content.is_char_boundary(tail_start) {
+		tail_start += 1;
+	}
+	format!(
+		"{}...[middle truncated]...{}",
+		&content[..head_end],
+		&content[tail_start..]
+	)
+}
+
 /// Build a compact transcript from session messages.
 fn build_transcript(messages: &[crate::session::Message]) -> String {
 	let mut transcript = String::new();
@@ -290,29 +331,42 @@ fn build_transcript(messages: &[crate::session::Message]) -> String {
 		if msg.role == "system" {
 			continue;
 		}
-		let role_label = match msg.role.as_str() {
-			"user" => "USER",
-			"assistant" => "ASSISTANT",
-			"tool" => "TOOL",
+		let (role_label, budget) = match msg.role.as_str() {
+			"user" => ("USER", USER_MSG_CHARS),
+			"assistant" => ("ASSISTANT", OTHER_MSG_CHARS),
+			"tool" => ("TOOL", OTHER_MSG_CHARS),
 			_ => continue,
 		};
 
-		// Truncate long messages to keep transcript manageable
-		let content = if msg.content.len() > 500 {
-			format!("{}...[truncated]", {
-				let mut end = 500;
-				while !msg.content.is_char_boundary(end) {
-					end -= 1;
-				}
-				&msg.content[..end]
-			})
-		} else {
-			msg.content.clone()
-		};
-
-		transcript.push_str(&format!("[{}]: {}\n\n", role_label, content));
+		transcript.push_str(&format!(
+			"[{}]: {}\n\n",
+			role_label,
+			head_tail(&msg.content, budget)
+		));
 	}
 	transcript
+}
+
+/// A parsed `<lesson>` before it earns storage: the rule, the verbatim quote the
+/// verification gate checks it against, and the existing lesson it claims to
+/// replace (index into the candidates shown in the prompt).
+struct Candidate {
+	lesson: Lesson,
+	evidence: String,
+	supersedes: Option<usize>,
+}
+
+/// Parse `supersedes="L3"` into a 0-based index, accepting only ids that were
+/// actually offered. Anything else — unknown id, garbage, out of range — means
+/// "no supersede", never an accidental delete.
+fn parse_supersedes(attrs: &str, candidate_count: usize) -> Option<usize> {
+	let raw = extract_attr(attrs, "supersedes")?;
+	let n: usize = raw.trim().trim_start_matches(['L', 'l']).parse().ok()?;
+	if n >= 1 && n <= candidate_count {
+		Some(n - 1)
+	} else {
+		None
+	}
 }
 
 /// Parse `<lesson>` tags, keeping each lesson's verbatim evidence quote
@@ -322,7 +376,8 @@ fn parse_lessons_with_evidence(
 	role: &str,
 	project: &str,
 	source: &str,
-) -> Vec<(Lesson, String)> {
+	candidate_count: usize,
+) -> Vec<Candidate> {
 	let mut lessons = Vec::new();
 	let now = chrono::Utc::now().to_rfc3339();
 
@@ -385,8 +440,8 @@ fn parse_lessons_with_evidence(
 					.unwrap_or_else(|| format!("{}...", truncated))
 			};
 
-			lessons.push((
-				Lesson {
+			lessons.push(Candidate {
+				lesson: Lesson {
 					content: content.to_string(),
 					title,
 					memory_type: "learning".into(),
@@ -400,7 +455,8 @@ fn parse_lessons_with_evidence(
 					created: now.clone(),
 				},
 				evidence,
-			));
+				supersedes: parse_supersedes(attrs, candidate_count),
+			});
 		}
 
 		remaining = &after_open[end_tag + 9..]; // skip past </lesson>
@@ -428,20 +484,17 @@ const VERIFY_TRANSCRIPT_CHARS: usize = 12_000;
 
 /// One batched verifier pass: which of the candidate lessons does the
 /// transcript evidence actually support? Returns a keep-mask aligned with
-/// `lessons`. Fail-open: any error keeps everything — a verifier outage must
-/// never block learning.
-async fn verify_lessons(
-	config: &Config,
-	lessons: &[(Lesson, String)],
-	transcript: &str,
-) -> Vec<bool> {
+/// `lessons`. Fail-CLOSED: a verifier outage or unusable output rejects
+/// everything. A lost lesson costs one extraction; an unverified lesson is
+/// durable state that steers every later session.
+async fn verify_lessons(config: &Config, lessons: &[Candidate], transcript: &str) -> Vec<bool> {
 	let mut listed = String::new();
-	for (i, (lesson, evidence)) in lessons.iter().enumerate() {
+	for (i, c) in lessons.iter().enumerate() {
 		listed.push_str(&format!(
 			"LESSON {}: {}\n  EVIDENCE: \"{}\"\n",
 			i + 1,
-			lesson.content,
-			evidence
+			c.lesson.content,
+			c.evidence
 		));
 	}
 	let view: String = transcript.chars().take(VERIFY_TRANSCRIPT_CHARS).collect();
@@ -460,38 +513,44 @@ async fn verify_lessons(
 	{
 		Ok(r) => r,
 		Err(e) => {
-			crate::log_debug!("Lesson verification failed, keeping all: {}", e);
-			return vec![true; lessons.len()];
+			crate::log_debug!(
+				"Lesson verification unavailable, rejecting all {} candidates: {}",
+				lessons.len(),
+				e
+			);
+			return vec![false; lessons.len()];
 		}
 	};
 
-	let unsupported = parse_unsupported(&resp, lessons.len());
+	let Some(unsupported) = parse_unsupported(&resp, lessons.len()) else {
+		crate::log_debug!(
+			"Lesson verification returned unusable output, rejecting all {} candidates",
+			lessons.len()
+		);
+		return vec![false; lessons.len()];
+	};
 	(0..lessons.len())
 		.map(|i| !unsupported.contains(&(i + 1)))
 		.collect()
 }
 
 /// Extract the unsupported index list from the verifier's JSON, dropping
-/// out-of-range indices (the verifier's output is untrusted).
-fn parse_unsupported(resp: &str, count: usize) -> Vec<usize> {
-	let Some(start) = resp.find('{') else {
-		return Vec::new();
-	};
-	let Some(end) = resp.rfind('}') else {
-		return Vec::new();
-	};
-	let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&resp[start..=end]) else {
-		return Vec::new();
-	};
-	let Some(items) = parsed.get("unsupported").and_then(|v| v.as_array()) else {
-		return Vec::new();
-	};
-	items
-		.iter()
-		.filter_map(|v| v.as_u64())
-		.map(|n| n as usize)
-		.filter(|&n| n >= 1 && n <= count)
-		.collect()
+/// out-of-range indices (the verifier's output is untrusted). `None` means the
+/// response was unusable — no JSON object, or no `unsupported` array — which is
+/// a verification failure, NOT an empty unsupported list.
+fn parse_unsupported(resp: &str, count: usize) -> Option<Vec<usize>> {
+	let start = resp.find('{')?;
+	let end = resp.rfind('}')?;
+	let parsed = serde_json::from_str::<serde_json::Value>(&resp[start..=end]).ok()?;
+	let items = parsed.get("unsupported")?.as_array()?;
+	Some(
+		items
+			.iter()
+			.filter_map(|v| v.as_u64())
+			.map(|n| n as usize)
+			.filter(|&n| n >= 1 && n <= count)
+			.collect(),
+	)
 }
 
 /// Parse `<orientation>` tags — durable subject understanding. No evidence
@@ -560,8 +619,12 @@ fn word_overlap(new_content: &str, existing_content: &str) -> f64 {
 	overlap as f64 / new_words.len() as f64
 }
 
-/// Find the existing lesson most similar to `new_content` above the 0.6
-/// overlap threshold — the candidate to supersede. None if nothing is close.
+/// Find the existing entry most similar to `new_content` above the 0.6 overlap
+/// threshold — the candidate to supersede. None if nothing is close.
+///
+/// Orientation only. Lessons reconcile through the model's explicit
+/// `supersedes` id: word overlap cannot tell a refinement from a contradiction
+/// from a coincidence, and it must not decide a deletion on its own.
 fn best_overlap<'a>(new_content: &str, existing: &'a [Lesson]) -> Option<&'a Lesson> {
 	existing
 		.iter()
@@ -571,31 +634,65 @@ fn best_overlap<'a>(new_content: &str, existing: &'a [Lesson]) -> Option<&'a Les
 		.map(|(_, l)| l)
 }
 
-/// Format existing lessons (global + scoped) for the extraction prompt's
-/// dedup context, so the model neither duplicates nor wrongly re-scopes them.
-fn format_existing(scoped: &[Lesson], global: &[Lesson]) -> String {
-	let fmt = |ls: &[Lesson]| {
-		ls.iter()
-			.map(|l| format!("- [{}] {}", l.confidence, l.content))
-			.collect::<Vec<_>>()
-			.join("\n")
+/// Existing lessons offered to the extractor for dedup and supersede. Prompt
+/// size must not grow with the store; 20 is a workable retrieval-candidate
+/// count and the only knob evaluation needs.
+const RECONCILE_CANDIDATES: usize = 20;
+/// Slots held for global lessons so a busy project cannot crowd out the
+/// user-wide rules that matter most.
+const RECONCILE_GLOBAL_MIN: usize = 5;
+
+/// Pick the existing lessons to show the extractor: highest importance first,
+/// both scopes represented, capped. Orientation entries share the store but are
+/// not lessons, so they never appear here. Deterministic — ties break on
+/// creation time then content, since directory read order is not stable.
+fn reconcile_candidates(scoped: &[Lesson], global: &[Lesson]) -> Vec<Lesson> {
+	let ranked = |ls: &[Lesson]| {
+		let mut v: Vec<Lesson> = ls
+			.iter()
+			.filter(|l| l.memory_type != "orientation")
+			.cloned()
+			.collect();
+		v.sort_by(|a, b| {
+			b.importance
+				.partial_cmp(&a.importance)
+				.unwrap_or(std::cmp::Ordering::Equal)
+				.then_with(|| b.created.cmp(&a.created))
+				.then_with(|| a.content.cmp(&b.content))
+		});
+		v
 	};
-	let mut out = String::new();
-	if !global.is_empty() {
-		out.push_str("## Global (user-wide)\n");
-		out.push_str(&fmt(global));
-		out.push('\n');
+	let global = ranked(global);
+	let scoped = ranked(scoped);
+	let reserved = global.len().min(RECONCILE_GLOBAL_MIN);
+	let mut out: Vec<Lesson> = scoped
+		.into_iter()
+		.take(RECONCILE_CANDIDATES - reserved)
+		.collect();
+	out.extend(global.into_iter().take(RECONCILE_CANDIDATES - out.len()));
+	out
+}
+
+/// Format the reconcile candidates for the extraction prompt. Each line carries
+/// the `L#` id the model references with `supersedes`, plus the scope so it
+/// neither duplicates nor wrongly re-scopes an existing rule.
+fn format_existing(candidates: &[Lesson]) -> String {
+	if candidates.is_empty() {
+		return "(none)".to_string();
 	}
-	if !scoped.is_empty() {
-		out.push_str("## This project/role\n");
-		out.push_str(&fmt(scoped));
-		out.push('\n');
-	}
-	if out.is_empty() {
-		"(none)".to_string()
-	} else {
-		out
-	}
+	candidates
+		.iter()
+		.enumerate()
+		.map(|(i, l)| {
+			let scope = if l.scope == "global" {
+				"global"
+			} else {
+				"this project/role"
+			};
+			format!("[L{}] ({}, {}) {}", i + 1, scope, l.confidence, l.content)
+		})
+		.collect::<Vec<_>>()
+		.join("\n")
 }
 
 /// Extract an XML attribute value: `key="value"`.
@@ -940,10 +1037,20 @@ mod tests {
 
 	/// Test helper: parse lessons, discarding the evidence quotes.
 	fn parse_lesson_tags(response: &str, role: &str, project: &str, source: &str) -> Vec<Lesson> {
-		parse_lessons_with_evidence(response, role, project, source)
+		parse_lessons_with_evidence(response, role, project, source, 0)
 			.into_iter()
-			.map(|(lesson, _)| lesson)
+			.map(|c| c.lesson)
 			.collect()
+	}
+
+	fn lesson(content: &str, scope: &str, importance: f64) -> Lesson {
+		Lesson {
+			content: content.into(),
+			scope: scope.into(),
+			importance,
+			created: "2026-01-01T00:00:00Z".into(),
+			..Default::default()
+		}
 	}
 
 	#[test]
@@ -1127,11 +1234,21 @@ This project uses X
 
 	#[test]
 	fn test_parse_unsupported_filters_out_of_range() {
-		assert_eq!(parse_unsupported(r#"{"unsupported":[2,7,0]}"#, 3), vec![2]);
-		assert!(parse_unsupported(r#"{"unsupported":[]}"#, 3).is_empty());
-		assert!(parse_unsupported("not json", 3).is_empty());
-		assert!(parse_unsupported(r#"{"unsupported":"nope"}"#, 3).is_empty());
-		assert!(parse_unsupported("{}", 3).is_empty());
+		assert_eq!(
+			parse_unsupported(r#"{"unsupported":[2,7,0]}"#, 3),
+			Some(vec![2])
+		);
+		assert_eq!(parse_unsupported(r#"{"unsupported":[]}"#, 3), Some(vec![]));
+	}
+
+	#[test]
+	fn test_parse_unsupported_unusable_output_is_none() {
+		// None means "verification failed" — the caller must reject everything,
+		// not read it as an empty unsupported list.
+		assert_eq!(parse_unsupported("not json", 3), None);
+		assert_eq!(parse_unsupported(r#"{"unsupported":"nope"}"#, 3), None);
+		assert_eq!(parse_unsupported("{}", 3), None);
+		assert_eq!(parse_unsupported(r#"{"unsupported":[1,"#, 3), None);
 	}
 
 	#[test]
@@ -1139,9 +1256,106 @@ This project uses X
 		let response = r#"<lesson confidence="high" tags="auth" evidence="use bearer tokens">
 Bearer token auth is required
 </lesson>"#;
-		let parsed = parse_lessons_with_evidence(response, "dev", "proj", "src");
+		let parsed = parse_lessons_with_evidence(response, "dev", "proj", "src", 0);
 		assert_eq!(parsed.len(), 1);
-		assert_eq!(parsed[0].1, "use bearer tokens");
-		assert_eq!(parsed[0].0.content, "Bearer token auth is required");
+		assert_eq!(parsed[0].evidence, "use bearer tokens");
+		assert_eq!(parsed[0].lesson.content, "Bearer token auth is required");
+		assert_eq!(parsed[0].supersedes, None);
+	}
+
+	#[test]
+	fn test_parse_supersedes_only_accepts_offered_ids() {
+		assert_eq!(parse_supersedes(r#" supersedes="L3""#, 5), Some(2));
+		assert_eq!(parse_supersedes(r#" supersedes="3""#, 5), Some(2));
+		// Never offered, never parseable, or out of range → no delete.
+		assert_eq!(parse_supersedes(r#" supersedes="L9""#, 5), None);
+		assert_eq!(parse_supersedes(r#" supersedes="L0""#, 5), None);
+		assert_eq!(parse_supersedes(r#" supersedes="nope""#, 5), None);
+		assert_eq!(parse_supersedes(r#" supersedes="""#, 5), None);
+		assert_eq!(parse_supersedes(r#" confidence="high""#, 5), None);
+		assert_eq!(parse_supersedes(r#" supersedes="L1""#, 0), None);
+	}
+
+	#[test]
+	fn test_head_tail_preserves_end_of_long_message() {
+		let long = format!("{}CORRECTION AT THE END", "a".repeat(3000));
+		let out = head_tail(&long, 500);
+		assert!(out.ends_with("CORRECTION AT THE END"));
+		assert!(out.starts_with("aaa"));
+		assert!(out.contains("...[middle truncated]..."));
+		// Short input passes through untouched.
+		assert_eq!(head_tail("short", 500), "short");
+	}
+
+	#[test]
+	fn test_head_tail_utf8_safe() {
+		// Multibyte throughout: both cuts must land on char boundaries or this
+		// panics on slice.
+		let long = "日本語テキスト".repeat(200);
+		let out = head_tail(&long, 501);
+		assert!(out.contains("...[middle truncated]..."));
+		assert!(out.len() < long.len());
+	}
+
+	#[test]
+	fn test_build_transcript_keeps_tail_of_long_user_turn() {
+		let msg = |role: &str, content: String| crate::session::Message {
+			role: role.into(),
+			content,
+			timestamp: 0,
+			cached: false,
+			cache_ttl: None,
+			tool_call_id: None,
+			name: None,
+			tool_calls: None,
+			images: None,
+			videos: None,
+			thinking: None,
+			id: None,
+		};
+		let transcript = build_transcript(&[msg(
+			"user",
+			format!("{}no, use custom error types", "x".repeat(5000)),
+		)]);
+		assert!(transcript.contains("no, use custom error types"));
+	}
+
+	#[test]
+	fn test_reconcile_candidates_caps_and_reserves_global() {
+		let scoped: Vec<Lesson> = (0..50)
+			.map(|i| lesson(&format!("scoped {}", i), "scoped", 0.9))
+			.collect();
+		let global: Vec<Lesson> = (0..10)
+			.map(|i| lesson(&format!("global {}", i), "global", 0.5))
+			.collect();
+		let out = reconcile_candidates(&scoped, &global);
+		assert_eq!(out.len(), RECONCILE_CANDIDATES);
+		// Global keeps its floor even though every scoped entry outranks it.
+		assert_eq!(
+			out.iter().filter(|l| l.scope == "global").count(),
+			RECONCILE_GLOBAL_MIN
+		);
+	}
+
+	#[test]
+	fn test_reconcile_candidates_excludes_orientation() {
+		let orientation = Lesson {
+			memory_type: "orientation".into(),
+			..lesson("auth is delegated to octolib", "scoped", 0.9)
+		};
+		let out = reconcile_candidates(&[orientation, lesson("a rule", "scoped", 0.5)], &[]);
+		assert_eq!(out.len(), 1);
+		assert_eq!(out[0].content, "a rule");
+	}
+
+	#[test]
+	fn test_format_existing_emits_ids_and_scope() {
+		assert_eq!(format_existing(&[]), "(none)");
+		let out = format_existing(&[
+			lesson("scoped rule", "scoped", 0.9),
+			lesson("global rule", "global", 0.9),
+		]);
+		assert!(out.contains("[L1] (this project/role, medium) scoped rule"));
+		assert!(out.contains("[L2] (global, medium) global rule"));
 	}
 }

--- a/src/supervisor/resolve.rs
+++ b/src/supervisor/resolve.rs
@@ -168,10 +168,11 @@ impl TaskContext {
 		session_context: &str,
 		active_plan: Option<&str>,
 	) -> Option<Self> {
-		let current_index = messages
-			.iter()
-			.rposition(crate::session::is_real_user_task_message)?;
-		let current_request = messages[current_index].content.clone();
+		// Index and content resolve through the same helper pair, so after a
+		// compaction both land on the continuation wrapper instead of the
+		// resolution silently switching off.
+		let current_index = crate::session::latest_task_turn_index(messages)?;
+		let current_request = crate::session::latest_real_user_task_content(messages)?.to_string();
 		Some(Self {
 			current_request,
 			recent_history: render_recent_history(&messages[..current_index]),


### PR DESCRIPTION
- Replace similarity-based deletion with explicit ID referencing
- Introduce Candidate struct to track lessons and superseded targets
- Add supersedes attribute and parse_supersedes to extraction logic
- Implement reconcile_candidates to rank and cap extracted lessons
- Use head-tail truncation for transcripts to preserve context
- Update verify_lessons to be fail-closed on errors or invalid output
- Prevent scoped lessons from deleting global preferences
- Add formatted IDs and scopes to extraction prompts
- Improve JSON parsing for unsupported filters
- Add tests for truncation and lesson parsing